### PR TITLE
feat: implement session resuming system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "coco-macro"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "coco-tui"
 version = "0.1.0"
 dependencies = [
@@ -299,6 +307,7 @@ dependencies = [
  "bitflags",
  "bon",
  "clap",
+ "coco-macro",
  "code-combo",
  "code-highlight",
  "crossterm",
@@ -1410,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -1884,9 +1893,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "throbber-widgets-tui",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",
@@ -518,6 +519,16 @@ dependencies = [
  "darling_core 0.21.3",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1263,12 +1274,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1397,6 +1423,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -2012,6 +2044,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e58887883fb0a259717b16d68d251983e40850b4b2f45c2da410f46d4333dc"
 dependencies = [
  "ratatui",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.143"
 serde_yaml = "0.9.34"
 snafu = "0.8.9"

--- a/crates/coco-macro/Cargo.toml
+++ b/crates/coco-macro/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coco-macro"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.42"
+syn = "2.0.111"

--- a/crates/coco-macro/src/lib.rs
+++ b/crates/coco-macro/src/lib.rs
@@ -1,0 +1,153 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, LitStr, parse_macro_input};
+
+/// Derive macro for implementing the `Identity` trait and registering a component.
+///
+/// This macro generates:
+/// - An implementation of the `Identity` trait that returns the specified type ID
+/// - A registration module that automatically registers the component with the session system
+///
+/// # Attributes
+///
+/// The macro requires a `#[component]` attribute with a `type_id` parameter:
+/// ```ignore
+/// #[derive(ComponentExt)]
+/// #[component(type_id = "my_component")]
+/// struct MyComponent;
+/// ```
+///
+/// # Generated Code
+///
+/// The macro generates:
+/// - `impl Identity for MyComponent` with the `id()` method returning the type ID
+/// - A hidden module that registers the component during static initialization
+#[proc_macro_derive(ComponentExt, attributes(component))]
+pub fn component(input: TokenStream) -> TokenStream {
+    let mut type_id: Option<LitStr> = None;
+
+    let DeriveInput {
+        ident,
+        attrs,
+        generics,
+        ..
+    } = parse_macro_input!(input);
+    let attr = attrs
+        .iter()
+        .find(|a| a.path().is_ident("component"))
+        .expect("`component` attribute is required");
+    attr.parse_nested_meta(|m| {
+        if m.path.is_ident("type_id") {
+            let value = m.value().expect("`type_id` assignment is required");
+            let value = value
+                .parse::<LitStr>()
+                .expect("`type_id` value must be a literal string");
+            type_id.replace(value);
+        }
+        Ok(())
+    })
+    .ok();
+
+    let type_id = type_id.expect("`type_id` assignment not found");
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let handler_mod = quote::format_ident!("__COMPONENT_REGISTER_{}", ident);
+    let expanded = quote! {
+        impl #impl_generics crate::components::Identity for #ident #ty_generics #where_clause {
+            fn id(&self) -> &'static str {
+                #type_id
+            }
+        }
+
+        #[allow(non_snake_case)]
+        mod #handler_mod {
+            extern crate ctor;
+
+            use super::*;
+
+            #[ctor::ctor]
+            fn init() {
+                use crate::{
+                    components::Component,
+                    session::{Session, register_component},
+                };
+
+                register_component(
+                    #type_id,
+                    |s: Session| -> Result<Box<dyn Component>> {
+                        #ident::load(s).map(|x|x.into())
+                    },
+                );
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Derive macro for registering a content component.
+///
+/// This macro generates a registration module that automatically registers
+/// a content component with the session system during static initialization.
+///
+/// # Attributes
+///
+/// The macro requires a `#[component]` attribute with a `type_id` parameter:
+/// ```ignore
+/// #[derive(ComponentExt, ContentComponentExt)]
+/// #[component(type_id = "my_content_component")]
+/// struct MyContentComponent;
+/// ```
+///
+/// # Generated Code
+///
+/// The macro generates a hidden module that registers the content component
+/// during static initialization using the `ctor` crate.
+#[proc_macro_derive(ContentComponentExt)]
+pub fn content_component(input: TokenStream) -> TokenStream {
+    let mut type_id: Option<LitStr> = None;
+
+    let DeriveInput { ident, attrs, .. } = parse_macro_input!(input);
+    let attr = attrs
+        .iter()
+        .find(|a| a.path().is_ident("component"))
+        .expect("`component` attribute is required");
+    attr.parse_nested_meta(|m| {
+        if m.path.is_ident("type_id") {
+            let value = m.value().expect("`type_id` assignment is required");
+            let value = value
+                .parse::<LitStr>()
+                .expect("`type_id` value must be a literal string");
+            type_id.replace(value);
+        }
+        Ok(())
+    })
+    .ok();
+
+    let type_id = type_id.expect("`type_id` assignment not found");
+    let handler_mod = quote::format_ident!("__CONTENT_COMPONENT_REGISTER_{}", ident);
+    let expanded = quote! {
+        #[allow(non_snake_case)]
+        mod #handler_mod {
+            extern crate ctor;
+
+            use super::*;
+
+            #[ctor::ctor]
+            fn init() {
+                use crate::{
+                    components::ContentComponent,
+                    session::{Session, register_content_component},
+                };
+
+                register_content_component(
+                    #type_id,
+                    |s: Session| -> Result<Box<dyn ContentComponent>> {
+                        #ident::load(s).map(|x|x.into())
+                    },
+                );
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/coco-tui/Cargo.toml
+++ b/crates/coco-tui/Cargo.toml
@@ -54,5 +54,12 @@ ctor.workspace = true
 lazy_static.workspace = true
 bitflags = "2.10.0"
 indoc.workspace = true
+time = { version = "0.3.44", features = [
+  "macros",
+  "serde",
+  "local-offset",
+  "formatting",
+  "parsing",
+] }
 
 [dev-dependencies]

--- a/crates/coco-tui/Cargo.toml
+++ b/crates/coco-tui/Cargo.toml
@@ -43,7 +43,7 @@ tracing-error.workspace = true
 tracing-subscriber.workspace = true
 
 # Serialization and data handling
-serde = { workspace = true, features = ["rc"] }
+serde.workspace = true
 serde_json.workspace = true
 
 # Builder

--- a/crates/coco-tui/Cargo.toml
+++ b/crates/coco-tui/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 # Core
 code-combo = { path = "../.." }
+coco-macro = { path = "../coco-macro/" }
 
 # CLI
 clap = "4.5.49"
@@ -42,16 +43,16 @@ tracing-error.workspace = true
 tracing-subscriber.workspace = true
 
 # Serialization and data handling
-serde.workspace = true
+serde = { workspace = true, features = ["rc"] }
 serde_json.workspace = true
 
 # Builder
 bon.workspace = true
 
 # Others
+ctor.workspace = true
 lazy_static.workspace = true
 bitflags = "2.10.0"
 indoc.workspace = true
 
 [dev-dependencies]
-ctor.workspace = true

--- a/crates/coco-tui/examples/draw_components.rs
+++ b/crates/coco-tui/examples/draw_components.rs
@@ -1,21 +1,15 @@
-use std::{io::stderr, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use coco_tui::{
+    app,
     components::{Chat, CodeHighlight, Component},
     error::Result,
     global,
     session::{self, Session},
 };
 use code_combo::{Config, default_config_dir};
-use crossterm::{
-    cursor,
-    event::{EventStream, KeyCode, KeyModifiers},
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen},
-};
-use futures::{FutureExt, StreamExt};
 use indoc::indoc;
-use ratatui::{Terminal, prelude::CrosstermBackend};
 use snafu::prelude::*;
 
 /// Code Combo
@@ -58,13 +52,8 @@ async fn main() -> Result<()> {
     config.config_dir = config_dir;
     global::set_config(config.clone()).await;
 
-    // Initialize dummy channels for testing.
-    use tokio::sync::mpsc;
-    let (event_tx, _) = mpsc::unbounded_channel();
-    let (action_tx, _) = mpsc::unbounded_channel();
-    global::initialize(event_tx, action_tx);
-
-    let mut component: Box<dyn Component> = match args.command {
+    let mut app = app::App::new(config.clone())?;
+    let component: Box<dyn Component> = match args.command {
         Some(Commands::CodeHighlight) => {
             let app = CodeHighlight::try_new(
                 indoc! {"
@@ -92,41 +81,11 @@ async fn main() -> Result<()> {
         }
         None => Box::new(Chat::new(config)),
     };
+    app.set_root(component);
 
-    let backend = CrosstermBackend::new(stderr());
-    let mut terminal = Terminal::new(backend).whatever_context("failed to new terminal")?;
-    let mut event_stream = EventStream::new();
+    let result = app.run().await;
 
-    crossterm::terminal::enable_raw_mode().whatever_context("failed to enable raw mode")?;
-    crossterm::execute!(stderr(), EnterAlternateScreen, cursor::Hide)
-        .whatever_context("failed to enter alter screen")?;
+    ratatui::restore();
 
-    terminal
-        .draw(|frame| {
-            component.draw(frame, frame.area()).expect("failed to draw");
-        })
-        .whatever_context("failed to draw")?;
-
-    loop {
-        let crossterm_event = event_stream.next().fuse().await;
-        if let Some(Ok(crossterm::event::Event::Key(key))) = crossterm_event
-            && key.code == KeyCode::Char('c')
-            && key.modifiers == KeyModifiers::CONTROL
-        {
-            break;
-        }
-    }
-
-    if crossterm::terminal::is_raw_mode_enabled()
-        .whatever_context("failed to check raw mode enabled")?
-    {
-        terminal
-            .flush()
-            .whatever_context("failed to flush terminal")?;
-        crossterm::execute!(stderr(), LeaveAlternateScreen, cursor::Show)
-            .whatever_context("faile to leave alter screen")?;
-        crossterm::terminal::disable_raw_mode().whatever_context("failed to disable raw mode")?;
-    }
-
-    Ok(())
+    result
 }

--- a/crates/coco-tui/examples/draw_components.rs
+++ b/crates/coco-tui/examples/draw_components.rs
@@ -5,6 +5,7 @@ use coco_tui::{
     components::{Chat, CodeHighlight, Component},
     error::Result,
     global,
+    session::{self, Session},
 };
 use code_combo::{Config, default_config_dir};
 use crossterm::{
@@ -36,6 +37,8 @@ struct Args {
 #[derive(Subcommand)]
 enum Commands {
     CodeHighlight,
+
+    Session { path: String },
 }
 
 #[snafu::report]
@@ -55,7 +58,13 @@ async fn main() -> Result<()> {
     config.config_dir = config_dir;
     global::set_config(config.clone()).await;
 
-    let mut app: Box<dyn Component> = match args.command {
+    // Initialize dummy channels for testing.
+    use tokio::sync::mpsc;
+    let (event_tx, _) = mpsc::unbounded_channel();
+    let (action_tx, _) = mpsc::unbounded_channel();
+    global::initialize(event_tx, action_tx);
+
+    let mut component: Box<dyn Component> = match args.command {
         Some(Commands::CodeHighlight) => {
             let app = CodeHighlight::try_new(
                 indoc! {"
@@ -72,8 +81,18 @@ async fn main() -> Result<()> {
             .whatever_context("failed to new CodeHighlight")?;
             Box::new(app)
         }
+        Some(Commands::Session { path }) => {
+            let content = tokio::fs::read_to_string(path)
+                .await
+                .whatever_context("failed to read text file")?;
+            let s: Session =
+                serde_json::from_str(&content).whatever_context("failed to deserialize json")?;
+            let (type_id, s): (String, Session) = session::load_related(s)?;
+            session::load_component(&type_id, s)?
+        }
         None => Box::new(Chat::new(config)),
     };
+
     let backend = CrosstermBackend::new(stderr());
     let mut terminal = Terminal::new(backend).whatever_context("failed to new terminal")?;
     let mut event_stream = EventStream::new();
@@ -84,7 +103,7 @@ async fn main() -> Result<()> {
 
     terminal
         .draw(|frame| {
-            app.draw(frame, frame.area()).expect("failed to draw");
+            component.draw(frame, frame.area()).expect("failed to draw");
         })
         .whatever_context("failed to draw")?;
 

--- a/crates/coco-tui/examples/session_code_highlight_bash.json
+++ b/crates/coco-tui/examples/session_code_highlight_bash.json
@@ -1,0 +1,7 @@
+{
+    "t": "code_highlight",
+    "y": {
+        "source": "echo \"hello world\"",
+        "lang": "Bash"
+    }
+}

--- a/crates/coco-tui/examples/session_command_palette.json
+++ b/crates/coco-tui/examples/session_command_palette.json
@@ -1,0 +1,16 @@
+{
+    "t": "command_palette",
+    "y": {
+        "commands": [
+            {
+                "name": "New Session",
+                "shortcut": "<C-n>"
+            },
+            {
+                "name": "Switch Session",
+                "shortcut": "<C-s>"
+            }
+        ],
+        "focus": 0
+    }
+}

--- a/crates/coco-tui/examples/session_str_replace.json
+++ b/crates/coco-tui/examples/session_str_replace.json
@@ -1,0 +1,17 @@
+{
+    "t": "str_replace",
+    "y": {
+        "tool_use": {
+            "id": "xxxxxxx",
+            "name": "str_replace",
+            "input": null
+        },
+        "edit": {
+            "path": "README.md",
+            "origin": "# Hello jack",
+            "text": "# Hello jack",
+            "new_text": "# Hello world"
+        },
+        "appliable": true
+    }
+}

--- a/crates/coco-tui/src/actions.rs
+++ b/crates/coco-tui/src/actions.rs
@@ -11,6 +11,7 @@ pub enum Action {
     Combo(ComboAction),
     Tool(ToolAction),
     Session(SessionAction),
+    Command(String),
 
     Blur,
     Focus,

--- a/crates/coco-tui/src/actions.rs
+++ b/crates/coco-tui/src/actions.rs
@@ -1,6 +1,8 @@
 use code_combo::{TextEdit, ToolUse};
 use tokio::time::Instant;
 
+use crate::session::Session;
+
 #[derive(Debug, Clone)]
 pub enum Action {
     Quit,
@@ -28,6 +30,16 @@ impl Action {
     /// Create a Session action with immediate save
     pub fn save_session_now() -> Self {
         SessionAction::SaveNow.into()
+    }
+
+    /// Restore last Session
+    pub fn restore_last_session() -> Self {
+        SessionAction::RestoreLastSession.into()
+    }
+
+    /// Restore a Session
+    pub fn restore_session(s: Session) -> Self {
+        SessionAction::RestoreSession(s).into()
     }
 }
 
@@ -67,6 +79,8 @@ impl From<ToolAction> for Action {
 pub enum SessionAction {
     ScheduleSave { save_at: Instant },
     SaveNow,
+    RestoreLastSession,
+    RestoreSession(Session),
 }
 
 impl From<SessionAction> for Action {

--- a/crates/coco-tui/src/actions.rs
+++ b/crates/coco-tui/src/actions.rs
@@ -1,4 +1,5 @@
 use code_combo::{TextEdit, ToolUse};
+use tokio::time::Instant;
 
 #[derive(Debug, Clone)]
 pub enum Action {
@@ -7,9 +8,27 @@ pub enum Action {
 
     Combo(ComboAction),
     Tool(ToolAction),
+    Session(SessionAction),
 
     Blur,
     Focus,
+}
+
+const SAVE_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
+impl Action {
+    /// Create a Session action with schedule save
+    pub fn schedule_session_save() -> Self {
+        SessionAction::ScheduleSave {
+            save_at: Instant::now() + SAVE_DELAY,
+        }
+        .into()
+    }
+
+    /// Create a Session action with immediate save
+    pub fn save_session_now() -> Self {
+        SessionAction::SaveNow.into()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -41,5 +60,17 @@ pub enum ToolAction {
 impl From<ToolAction> for Action {
     fn from(value: ToolAction) -> Self {
         Self::Tool(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SessionAction {
+    ScheduleSave { save_at: Instant },
+    SaveNow,
+}
+
+impl From<SessionAction> for Action {
+    fn from(value: SessionAction) -> Self {
+        Self::Session(value)
     }
 }

--- a/crates/coco-tui/src/app.rs
+++ b/crates/coco-tui/src/app.rs
@@ -72,6 +72,10 @@ impl App {
         })
     }
 
+    pub fn set_root(&mut self, component: Box<dyn Component>) {
+        self.root = component
+    }
+
     pub fn send_action(&self, action: Action) {
         self.action_tx.send(action).unwrap()
     }

--- a/crates/coco-tui/src/components.rs
+++ b/crates/coco-tui/src/components.rs
@@ -1,7 +1,9 @@
+use std::any::Any;
+
 use crossterm::event::{KeyEvent, MouseEvent};
 use ratatui::{Frame, layout::Rect};
 
-use crate::{actions::*, error::*, events::*};
+use crate::{actions::*, error::*, events::*, session::Session};
 
 /// A macro to handle component events in a standardized way.
 ///
@@ -48,16 +50,65 @@ macro_rules! handle_component_event {
 mod chat;
 mod code_highlight;
 mod input;
+mod message;
 mod messages;
 
 pub use chat::Chat;
 pub use code_highlight::CodeHighlight;
 pub use input::Input;
+pub use message::*;
 pub use messages::*;
 
+/// Provides a unique identifier string for struct registry.
+///
+/// This trait allows components to be uniquely identified, which is useful for
+/// registration systems, session management, and component lookup operations.
+/// Each implementing struct should return a constant string that uniquely
+/// identifies its type.
+///
+/// The `coco-macro` crate provides a derive macro `ComponentExt` that will fill the implementation.
+pub trait Identity {
+    /// Get the unique identifier string for this struct.
+    ///
+    /// # Returns
+    ///
+    /// * `&'static str` - A static string slice that uniquely identifies this type
+    fn id(&self) -> &'static str;
+}
+
+/// Provides persistence capabilities for components.
+///
+/// This trait defines the interface for components that can save their state to persistent storage
+/// and restore their state from previously saved data. This enables persistence
+/// of component state across application restarts.
+pub trait Persistable: Identity {
+    /// Save the current state of the component to persistent storage.
+    ///
+    /// # Returns
+    ///
+    /// * `Session` - A session object containing the serialized state of the component.
+    fn save(&self) -> Session;
+
+    /// Load the component state from previously saved data.
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - The session state to restore from
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self>` - The restored component instance or an error if loading fails
+    ///
+    /// # Type Parameters
+    ///
+    /// * `Self` - The implementing component type
+    fn load(state: Session) -> Result<Self>
+    where
+        Self: Sized;
+}
+
 /// `Component` is a trait that represents a visual and interactive element of the user interface.
-#[allow(dead_code)]
-pub trait Component {
+pub trait Component: Persistable + Any + Send {
     /// Get the children components of this component.
     ///
     /// This method returns an iterator over mutable references to the child components.
@@ -134,4 +185,22 @@ pub trait Component {
     ///
     /// * `Result<()>` - An Ok result or an error.
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()>;
+}
+
+impl<T: Component> From<T> for Box<dyn Component> {
+    fn from(value: T) -> Self {
+        Box::new(value)
+    }
+}
+
+impl dyn Component {
+    /// Allow downcasting the trait object to its concrete type at runtime
+    pub fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Allow downcasting the trait object to its concrete type at runtime
+    pub fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
 }

--- a/crates/coco-tui/src/components.rs
+++ b/crates/coco-tui/src/components.rs
@@ -49,12 +49,14 @@ macro_rules! handle_component_event {
 
 mod chat;
 mod code_highlight;
+mod command_palette;
 mod input;
 mod message;
 mod messages;
 
 pub use chat::Chat;
 pub use code_highlight::CodeHighlight;
+pub use command_palette::*;
 pub use input::Input;
 pub use message::*;
 pub use messages::*;

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -15,11 +15,14 @@ use ratatui::{
 
 use serde::{Deserialize, Serialize};
 use throbber_widgets_tui::{Throbber, ThrobberState};
+use time::OffsetDateTime;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use super::{
     Action, AnswerEvent, AskEvent, BotMessage, Combo, ComboAction, ComboEvent, Component, Content,
-    Event, Input, Message, Messages, Plain, Tool, ToolAction, shortcuts_desc,
+    Event, Input, Message, Messages, Plain, SessionAction, Tool, ToolAction, shortcuts_desc,
 };
 use crate::{
     components::{Command, CommandPalette, Persistable},
@@ -39,13 +42,38 @@ pub struct Chat<'a> {
     input: Input<'a>,
     messages: Messages,
     indicator: ThrobberState,
+
+    token_schedule_session_save: Option<CancellationToken>,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct Inner {
     state: ChatState,
     focus: Focus,
     pending_chats: Vec<ChatBlock>,
+    #[serde(with = "time::serde::rfc3339")]
+    created_at: time::OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    updated_at: time::OffsetDateTime,
+    name: String,
+}
+
+impl Default for Inner {
+    fn default() -> Self {
+        let now = time::OffsetDateTime::now_utc();
+        Self {
+            state: ChatState::Ready,
+            focus: Focus::Input,
+            pending_chats: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            name: format!(
+                "Session {}",
+                now.format(&time::format_description::well_known::Rfc3339)
+                    .expect("failed to format current time")
+            ),
+        }
+    }
 }
 
 #[derive(Default, Clone, Serialize, Deserialize)]
@@ -93,7 +121,54 @@ impl Chat<'static> {
             input: Input::default(),
             messages: Messages::default(),
             indicator: ThrobberState::default(),
+            token_schedule_session_save: None,
         }
+    }
+
+    fn trigger_save(&mut self, save_at: Instant) {
+        // Cancel existing timer if any
+        if let Some(token) = self.token_schedule_session_save.take() {
+            token.cancel();
+        }
+
+        let token = CancellationToken::new();
+        self.token_schedule_session_save = Some(token.clone());
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = token.cancelled() => (),
+                _ = tokio::time::sleep_until(save_at) => {
+                    global::action_tx().send(Action::save_session_now()).unwrap();
+                }
+            }
+        });
+    }
+
+    fn save_now(&self) {
+        let session_dir = std::path::Path::new(".coco/sessions");
+        let session = self.save();
+        let name = self.state.name.clone();
+        let created_at = self.state.created_at;
+
+        tokio::spawn(async move {
+            if let Err(e) = tokio::fs::create_dir_all(session_dir).await {
+                warn!(?e, "failed to create session directory");
+                return;
+            }
+
+            let now = time::OffsetDateTime::now_utc();
+            let persistent_session = crate::session::PersistentSession {
+                name,
+                inner: session,
+                created_at,
+                updated_at: now,
+            };
+
+            if let Err(e) = crate::session::save_session(session_dir, persistent_session).await {
+                warn!(?e, "failed to save session");
+            } else {
+                debug!("Session saved successfully");
+            }
+        });
     }
 
     fn handle_combo_event(&mut self, event: &ComboEvent) {
@@ -294,6 +369,8 @@ impl Component for Chat<'static> {
                         BotMessage::ToolUse(tool_use) => Tool::new(tool_use.to_owned()).into(),
                     })
                 }));
+                // Trigger session save after receiving bot response
+                global::trigger_schedule_session_save();
             }
             Event::Ask(AskEvent::ToolUsePermission(_) | AskEvent::TextEdit { .. }) => {
                 if let Some(idx) = self.messages.on_tool_event(event) {
@@ -301,6 +378,8 @@ impl Component for Chat<'static> {
                     self.update_focus(Focus::Messages);
                     self.messages.focus(idx);
                 }
+                // Trigger session save after ask event
+                global::trigger_schedule_session_save();
             }
             Event::Answer(AnswerEvent::ToolResult {
                 id,
@@ -324,6 +403,8 @@ impl Component for Chat<'static> {
                 }]);
                 let content = self.build_user_content(content);
                 tokio::task::spawn(task_chat(self.agent.clone(), content));
+                // Trigger session save after tool result
+                global::trigger_schedule_session_save();
             }
             _ => {
                 // Handle other kinds of events by default
@@ -426,6 +507,8 @@ impl Component for Chat<'static> {
                             is_error: Some(true),
                             content: code_combo::Content::Text("User cancelled".to_string()),
                         });
+                    // Trigger session save after tool cancellation
+                    global::trigger_schedule_session_save();
                 }
                 ToolAction::ApplyTextEdit {
                     id,
@@ -452,8 +535,19 @@ impl Component for Chat<'static> {
                             *hunk_idx,
                         ));
                     }
+                    // Trigger session save after text edit operation
+                    global::trigger_schedule_session_save();
                 }
             },
+            Action::Session(SessionAction::SaveNow) => {
+                // Immediate save
+                self.save_now();
+            }
+            Action::Session(SessionAction::ScheduleSave { save_at }) => {
+                // Schedule a debounced save
+                self.state.write_untracked().updated_at = OffsetDateTime::now_utc();
+                self.trigger_save(save_at.to_owned());
+            }
             _ => (),
         }
     }

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -22,7 +22,7 @@ use super::{
     Event, Input, Message, Messages, Plain, Tool, ToolAction, shortcuts_desc,
 };
 use crate::{
-    components::Persistable,
+    components::{Command, CommandPalette, Persistable},
     error::*,
     global::{self, State},
     session::{self, Session},
@@ -35,6 +35,7 @@ pub struct Chat<'a> {
 
     agent: Agent,
 
+    command_palette: CommandPalette,
     input: Input<'a>,
     messages: Messages,
     indicator: ThrobberState,
@@ -71,6 +72,7 @@ enum Focus {
     Input,
     InputBlur,
     Messages,
+    CommandPalette,
 }
 
 impl Chat<'static> {
@@ -78,6 +80,16 @@ impl Chat<'static> {
         Self {
             state: State::default(),
             agent: Agent::new(config),
+            command_palette: CommandPalette::new(&[
+                Command {
+                    name: "New Session".to_string(),
+                    shortcut: Some("<C-n>".to_string()),
+                },
+                Command {
+                    name: "Switch Session".to_string(),
+                    shortcut: Some("<C-s>".to_string()),
+                },
+            ]),
             input: Input::default(),
             messages: Messages::default(),
             indicator: ThrobberState::default(),
@@ -162,6 +174,7 @@ impl Chat<'static> {
                 .title_bottom(shortcuts_desc(&[("Submit", "CR")])),
             Focus::InputBlur => block
                 .title_bottom(shortcuts_desc(&[("Focus", "CR")]))
+                .title_bottom(shortcuts_desc(&[("Commands", "C-p")]))
                 .title_bottom(shortcuts_desc(&[("Up", "k"), ("Down", "j")])),
             Focus::Messages => {
                 block = self.messages.block_with_shortcuts_desc(block);
@@ -170,6 +183,7 @@ impl Chat<'static> {
                     .title_bottom(shortcuts_desc(&[("Scroll Up", "C-y"), ("Down", "C-e")]))
                     .title_bottom(shortcuts_desc(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]))
             }
+            Focus::CommandPalette => block,
         }
     }
 
@@ -326,8 +340,9 @@ impl Component for Chat<'static> {
         let focus = &self.state.focus;
         match (focus, key.modifiers, key.code) {
             // Focus switching
-            (Input, KM::NONE, Esc) => self.update_focus(Focus::InputBlur),
-            (InputBlur, KM::NONE, Enter) => self.update_focus(Focus::Input),
+            (Input, KM::NONE, Esc) => self.update_focus(InputBlur),
+            (InputBlur, KM::NONE, Enter) => self.update_focus(Input),
+            (InputBlur, KM::CONTROL, Char('p')) => self.update_focus(CommandPalette),
             (Messages, KM::NONE, Esc) if !self.messages.is_actionable() => {
                 self.messages.blur();
                 self.update_focus(Focus::InputBlur);
@@ -370,6 +385,8 @@ impl Component for Chat<'static> {
 
             // Handle actionable messages
             (Messages, _, _) => self.messages.handle_key_event(key),
+            (CommandPalette, KM::NONE, Esc) => self.update_focus(InputBlur),
+            (CommandPalette, _, _) => self.command_palette.handle_key_event(key),
 
             (InputBlur, _, _) => {
                 warn!(?key, ?focus, "unknown key event");
@@ -468,7 +485,14 @@ impl Component for Chat<'static> {
                 .title_bottom(self.widget_state_indicator()),
             bottom,
         );
-        self.input.draw(frame, area_input)
+        self.input.draw(frame, area_input)?;
+
+        if self.state.focus == Focus::CommandPalette {
+            // popup floating window
+            self.command_palette.draw(frame, area)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -268,7 +268,7 @@ impl Component for Chat<'static> {
             ChatState::Procesing | ChatState::ComboDiscovering
         ) {
             self.indicator.calc_next();
-            global::signal_ditry();
+            global::signal_dirty();
         }
     }
 

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,3 +1,4 @@
+use coco_macro::ComponentExt;
 use code_combo::{
     Agent, Block as ChatBlock, Config, Content as ChatContent, Message as ChatMessage, Output,
     TextEdit, ToolUse,
@@ -12,31 +13,41 @@ use ratatui::{
     widgets::{Block, Borders},
 };
 
+use serde::{Deserialize, Serialize};
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tracing::{debug, warn};
 
 use super::{
     Action, AnswerEvent, AskEvent, BotMessage, Combo, ComboAction, ComboEvent, Component, Content,
-    ContentComponent, Event, Input, Message, Messages, Plain, Role, Tool, ToolAction,
-    shortcuts_desc,
+    Event, Input, Message, Messages, Plain, Tool, ToolAction, shortcuts_desc,
 };
 use crate::{
+    components::Persistable,
     error::*,
     global::{self, State},
+    session::{self, Session},
 };
 
+#[derive(ComponentExt)]
+#[component(type_id = "chat")]
 pub struct Chat<'a> {
-    state: State<ChatState>,
-    focus: State<Focus>,
+    state: State<Inner>,
+
     agent: Agent,
 
     input: Input<'a>,
     messages: Messages,
-    pending_chats: Vec<ChatBlock>,
     indicator: ThrobberState,
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Serialize, Deserialize)]
+struct Inner {
+    state: ChatState,
+    focus: Focus,
+    pending_chats: Vec<ChatBlock>,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize)]
 enum ChatState {
     #[default]
     Ready,
@@ -54,7 +65,7 @@ impl std::fmt::Display for ChatState {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 enum Focus {
     #[default]
     Input,
@@ -62,15 +73,13 @@ enum Focus {
     Messages,
 }
 
-impl Chat<'_> {
+impl Chat<'static> {
     pub fn new(config: Config) -> Self {
         Self {
             state: State::default(),
-            focus: State::default(),
             agent: Agent::new(config),
             input: Input::default(),
             messages: Messages::default(),
-            pending_chats: vec![],
             indicator: ThrobberState::default(),
         }
     }
@@ -79,10 +88,10 @@ impl Chat<'_> {
         debug!(?event, "receive combo event");
         match event {
             ComboEvent::Discovering => {
-                *self.state.write() = ChatState::ComboDiscovering;
+                self.state.write().state = ChatState::ComboDiscovering;
             }
             ComboEvent::Executing { .. } | ComboEvent::Output { .. } => {
-                *self.state.write() = ChatState::Procesing;
+                self.state.write().state = ChatState::Procesing;
             }
             ComboEvent::Executed { starter, .. } => {
                 let combo = starter.combo.as_ref().unwrap();
@@ -90,13 +99,13 @@ impl Chat<'_> {
                 tokio::task::spawn(task_chat(self.agent.clone(), content));
             }
             ComboEvent::Discovered { .. } | ComboEvent::NotFound { .. } => {
-                *self.state.write() = ChatState::Ready;
+                self.state.write().state = ChatState::Ready;
             }
         }
     }
 
     fn update_focus(&mut self, new_focus: Focus) {
-        let focus = self.focus.read();
+        let focus = &self.state.focus;
         if focus == &new_focus {
             return;
         }
@@ -107,7 +116,7 @@ impl Chat<'_> {
         if new_focus == Focus::Input {
             self.input.update(&Action::Focus);
         }
-        *self.focus.write() = new_focus
+        self.state.write().focus = new_focus
     }
 
     /// Combines pending ToolResults (e.g., User Cancelled) with user instructions.
@@ -115,10 +124,10 @@ impl Chat<'_> {
     /// This ensures the LLM doesn't react to tool results without explicit user instructions.
     /// Tool results are queued and combined with the next user message to provide context.
     fn build_user_content(&mut self, content: ChatContent) -> ChatContent {
-        if self.pending_chats.is_empty() {
+        if self.state.pending_chats.is_empty() {
             content
         } else {
-            let mut blocks = std::mem::take(&mut self.pending_chats);
+            let mut blocks = std::mem::take(&mut self.state.write().pending_chats);
             ChatContent::Multiple(match content {
                 ChatContent::Text(text) => {
                     blocks.push(ChatBlock::Text { text });
@@ -133,11 +142,11 @@ impl Chat<'_> {
     }
 
     fn on_submit(&mut self) {
-        if matches!(self.state.read(), ChatState::Ready) {
+        if matches!(self.state.state, ChatState::Ready) {
             let value = self.input.clear();
             debug!(?value, "submiting");
             self.messages
-                .push(Message::user(Plain::new(value.clone()).boxed()));
+                .push(Message::user(Plain::new(value.clone()).into()));
             let content = self.build_user_content(ChatContent::Text(value));
             tokio::task::spawn(task_chat(self.agent.clone(), content));
         } else {
@@ -147,7 +156,7 @@ impl Chat<'_> {
 
     fn block_bottom_with_shortcuts_desc<'a>(&self, mut block: Block<'a>) -> Block<'a> {
         block = block.title_bottom(Line::from(""));
-        match self.focus.read() {
+        match self.state.focus {
             Focus::Input => block
                 .title_bottom(shortcuts_desc(&[("Blur", "Esc")]))
                 .title_bottom(shortcuts_desc(&[("Submit", "CR")])),
@@ -165,7 +174,7 @@ impl Chat<'_> {
     }
 
     fn widget_state_indicator(&self) -> Line<'_> {
-        let state = self.state.read();
+        let state = &self.state.state;
         (match state {
             ChatState::Ready => Line::from(format!(" {state} ").green()),
             ChatState::Procesing | ChatState::ComboDiscovering => Line::from(vec![
@@ -202,21 +211,38 @@ impl Chat<'_> {
             }
             // Await the next user message to avoid the LLM reacting without further user
             // instructions
-            self.pending_chats.push(code_combo::Block::ToolResult {
-                tool_use_id: id,
-                is_error: Some(!edit.changed()),
-                content: if edit.changed() {
-                    "User rejects some changes"
-                } else {
-                    "User rejects all changes"
-                }
-                .into(),
-            });
+            self.state
+                .write()
+                .pending_chats
+                .push(code_combo::Block::ToolResult {
+                    tool_use_id: id,
+                    is_error: Some(!edit.changed()),
+                    content: if edit.changed() {
+                        "User rejects some changes"
+                    } else {
+                        "User rejects all changes"
+                    }
+                    .into(),
+                });
         }
     }
 }
 
-impl Component for Chat<'_> {
+impl Persistable for Chat<'static> {
+    fn save(&self) -> Session {
+        session::save_related(&self.state, self.messages.save())
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let (state, session): (Inner, Session) = session::load_related(session)?;
+        let mut inst = Self::new(global::config_sync());
+        inst.state = State::new(state);
+        inst.messages = Messages::load(session)?;
+        Ok(inst)
+    }
+}
+
+impl Component for Chat<'static> {
     fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
         let children: Vec<&mut dyn Component> = vec![&mut self.input, &mut self.messages];
         Box::new(children.into_iter())
@@ -224,7 +250,7 @@ impl Component for Chat<'_> {
 
     fn on_tick(&mut self) {
         if matches!(
-            self.state.get(),
+            self.state.state,
             ChatState::Procesing | ChatState::ComboDiscovering
         ) {
             self.indicator.calc_next();
@@ -244,14 +270,14 @@ impl Component for Chat<'_> {
                 handle_component_event!(self, event);
             }
             Event::Ask(AskEvent::Bot) => {
-                *self.state.write() = ChatState::Procesing;
+                self.state.write().state = ChatState::Procesing;
             }
             Event::Answer(AnswerEvent::Bot(msgs)) => {
-                *self.state.write() = ChatState::Ready;
+                self.state.write().state = ChatState::Ready;
                 self.messages.extend(msgs.iter().cloned().map(|msg| {
                     Message::bot(match msg {
-                        BotMessage::Plain(text) => Plain::new(text).boxed(),
-                        BotMessage::ToolUse(tool_use) => Tool::new(tool_use.to_owned()).boxed(),
+                        BotMessage::Plain(text) => Plain::new(text).into(),
+                        BotMessage::ToolUse(tool_use) => Tool::new(tool_use.to_owned()).into(),
                     })
                 }));
             }
@@ -297,7 +323,8 @@ impl Component for Chat<'_> {
         use KeyCode::*;
         use KeyModifiers as KM;
 
-        match (self.focus.read(), key.modifiers, key.code) {
+        let focus = &self.state.focus;
+        match (focus, key.modifiers, key.code) {
             // Focus switching
             (Input, KM::NONE, Esc) => self.update_focus(Focus::InputBlur),
             (InputBlur, KM::NONE, Enter) => self.update_focus(Focus::Input),
@@ -345,7 +372,7 @@ impl Component for Chat<'_> {
             (Messages, _, _) => self.messages.handle_key_event(key),
 
             (InputBlur, _, _) => {
-                warn!(?key, ?self.focus, "unknown key event");
+                warn!(?key, ?focus, "unknown key event");
             }
         }
     }
@@ -354,12 +381,9 @@ impl Component for Chat<'_> {
         debug!(?action, "updating");
 
         match action {
-            Action::Combo(ComboAction::Discover | ComboAction::Execute { .. }) => {
-                let combo = Combo::default();
-                self.messages.push(Message {
-                    role: Role::User,
-                    content: Box::new(combo),
-                });
+            Action::Combo(ComboAction::Execute { name }) => {
+                let combo = Combo::new(name);
+                self.messages.push(Message::user(combo.into()));
                 debug!("Combo message pushed");
             }
             Action::Tool(action) => match action {
@@ -377,11 +401,14 @@ impl Component for Chat<'_> {
                     }
                     // Await the next user message to avoid the LLM reacting without further user
                     // instructions
-                    self.pending_chats.push(code_combo::Block::ToolResult {
-                        tool_use_id: tool_use.id.clone(),
-                        is_error: Some(true),
-                        content: code_combo::Content::Text("User cancelled".to_string()),
-                    });
+                    self.state
+                        .write()
+                        .pending_chats
+                        .push(code_combo::Block::ToolResult {
+                            tool_use_id: tool_use.id.clone(),
+                            is_error: Some(true),
+                            content: code_combo::Content::Text("User cancelled".to_string()),
+                        });
                 }
                 ToolAction::ApplyTextEdit {
                     id,
@@ -428,7 +455,7 @@ impl Component for Chat<'_> {
         frame.render_widget(self.block_bottom_with_shortcuts_desc(block), divider);
 
         let mut block = Block::new().borders(Borders::BOTTOM);
-        block = if !matches!(self.focus.read(), Focus::Messages) {
+        block = if !matches!(self.state.focus, Focus::Messages) {
             block.border_set(border::THICK).border_style(Style::reset())
         } else {
             block

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -103,6 +103,8 @@ enum Focus {
     CommandPalette,
 }
 
+const COMMAND_NEW_SESSION: &str = "New Session";
+
 impl Chat<'static> {
     pub fn new(config: Config) -> Self {
         Self {
@@ -110,13 +112,10 @@ impl Chat<'static> {
             agent: Agent::new(config),
             command_palette: CommandPalette::new(&[
                 Command {
-                    name: "New Session".to_string(),
+                    name: COMMAND_NEW_SESSION.to_string(),
                     shortcut: Some("<C-n>".to_string()),
                 },
-                Command {
-                    name: "Switch Session".to_string(),
-                    shortcut: Some("<C-s>".to_string()),
-                },
+                // TODO: Switch Session
             ]),
             input: Input::default(),
             messages: Messages::default(),
@@ -351,10 +350,41 @@ impl Chat<'static> {
                 });
         }
     }
+
+    /// Handle the "New Session" command
+    /// Optionally saves the current session before clearing
+    fn new_session(&mut self) {
+        // 1. Save current session if there are messages
+        if !self.messages.is_empty() {
+            // TODO: maybe don't save if being in processing state
+            self.save_now();
+        }
+
+        // 2. Clear messages
+        self.messages.clear();
+
+        // 3. Reset state
+        *self.state.write() = Inner {
+            focus: Focus::InputBlur,
+            ..Default::default()
+        };
+
+        // 4. Reset focus to Input from InputBlur to trigger the input component
+        self.update_focus(Focus::Input);
+
+        // 5. Cancel any pending save timer
+        if let Some(token) = self.token_schedule_session_save.take() {
+            token.cancel();
+        }
+
+        debug!("New session started");
+        global::signal_dirty();
+    }
 }
 
 impl Persistable for Chat<'static> {
     fn save(&self) -> Session {
+        // FIXME: Save LLM messages from self.agent
         session::save_related(&self.state, self.messages.save())
     }
 
@@ -597,6 +627,20 @@ impl Component for Chat<'static> {
                     }
                     Err(e) => {
                         warn!(?e, "failed to restore session");
+                    }
+                }
+            }
+            Action::Command(name) => {
+                // Close command palette
+                self.update_focus(Focus::InputBlur);
+
+                // Handle command
+                match name.as_str() {
+                    COMMAND_NEW_SESSION => {
+                        self.new_session();
+                    }
+                    unknown => {
+                        warn!(?unknown, "unknown command");
                     }
                 }
             }

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -171,6 +171,42 @@ impl Chat<'static> {
         });
     }
 
+    fn restore_last_session(&mut self) {
+        let session_dir = std::path::Path::new(".coco/sessions").to_path_buf();
+
+        tokio::spawn(async move {
+            match crate::session::list_session(&session_dir).await {
+                Ok(mut sessions) => {
+                    if sessions.is_empty() {
+                        debug!("No sessions to restore");
+                        return;
+                    }
+
+                    // Sort by updated_at descending to get the most recent session
+                    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+
+                    let last_session = &sessions[0];
+                    let filename = last_session.filename();
+
+                    match crate::session::load_session(&session_dir, &filename).await {
+                        Ok(persistent_session) => {
+                            global::action_tx()
+                                .send(Action::restore_session(persistent_session.inner))
+                                .unwrap();
+                            debug!(name = %persistent_session.name, "Session restore requested");
+                        }
+                        Err(e) => {
+                            warn!(?e, "failed to load session");
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(?e, "failed to list sessions");
+                }
+            }
+        });
+    }
+
     fn handle_combo_event(&mut self, event: &ComboEvent) {
         debug!(?event, "receive combo event");
         match event {
@@ -547,6 +583,22 @@ impl Component for Chat<'static> {
                 // Schedule a debounced save
                 self.state.write_untracked().updated_at = OffsetDateTime::now_utc();
                 self.trigger_save(save_at.to_owned());
+            }
+            Action::Session(SessionAction::RestoreLastSession) => {
+                self.restore_last_session();
+            }
+            Action::Session(SessionAction::RestoreSession(session)) => {
+                match Self::load(session.clone()) {
+                    Ok(restored) => {
+                        self.state = restored.state;
+                        self.messages = restored.messages;
+                        debug!(name = %self.state.name, "Session restored");
+                        global::signal_dirty();
+                    }
+                    Err(e) => {
+                        warn!(?e, "failed to restore session");
+                    }
+                }
             }
             _ => (),
         }

--- a/crates/coco-tui/src/components/code_highlight.rs
+++ b/crates/coco-tui/src/components/code_highlight.rs
@@ -1,3 +1,4 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
 use code_highlight::{Event, Lang, highlight};
 use ratatui::{
     Frame,
@@ -6,13 +7,28 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Paragraph, Wrap},
 };
+use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tracing::trace;
 
 use super::{Component, Content, ContentComponent};
-use crate::{error::*, global};
+use crate::{
+    components::Persistable,
+    error::Result,
+    global,
+    session::{self, Session},
+};
 
+#[derive(Debug, Serialize, Deserialize)]
+struct State {
+    source: String,
+    lang: Lang,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "code_highlight")]
 pub struct CodeHighlight<'a> {
+    state: State,
     widget: Paragraph<'a>,
 }
 
@@ -66,11 +82,28 @@ impl<'a> CodeHighlight<'a> {
             lines.into_iter().map(Line::from).collect::<Vec<_>>(),
         ))
         .wrap(Wrap { trim: false });
-        Ok(Self { widget })
+        Ok(Self {
+            state: State {
+                source: source.to_string(),
+                lang,
+            },
+            widget,
+        })
     }
 }
 
-impl<'a> Component for CodeHighlight<'a> {
+impl Persistable for CodeHighlight<'static> {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: State = session::load(session)?;
+        Self::try_new(&state.source, state.lang)
+    }
+}
+
+impl Component for CodeHighlight<'static> {
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         frame.render_widget(&self.widget, area);
         Ok(())

--- a/crates/coco-tui/src/components/command_palette.rs
+++ b/crates/coco-tui/src/components/command_palette.rs
@@ -154,7 +154,7 @@ impl Component for CommandPalette {
                 unimplemented!()
             }
             (KM::NONE, Esc) => {
-                unimplemented!()
+                unreachable!("Esc key should be handled by the parent component")
             }
             _ => (),
         }

--- a/crates/coco-tui/src/components/command_palette.rs
+++ b/crates/coco-tui/src/components/command_palette.rs
@@ -1,0 +1,184 @@
+use std::iter;
+
+use coco_macro::ComponentExt;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    prelude::Rect,
+    symbols::border,
+    text::Text,
+    widgets::{Block, Borders, Paragraph},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    components::{Component, Persistable, shortcuts_desc},
+    error::Result,
+    global::{self, State},
+    session::{self, Session},
+};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Command {
+    pub name: String,
+    pub shortcut: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Inner {
+    pub commands: Vec<Command>,
+    pub focus: Option<usize>,
+}
+
+/// Command Palette is a popup floating window that allows users to quickly execute commands.
+///
+/// This component provides a floating interface that can be triggered to access various
+/// application commands and actions. It typically appears as an overlay on top of other
+/// UI elements and disappears after a command is executed or when dismissed.
+#[derive(ComponentExt)]
+#[component(type_id = "command_palette")]
+pub struct CommandPalette {
+    state: State<Inner>,
+}
+
+impl CommandPalette {
+    pub fn new(commands: &[Command]) -> Self {
+        let focus = if commands.is_empty() { None } else { Some(0) };
+        Self {
+            state: State::new(Inner {
+                commands: Vec::from(commands),
+                focus,
+            }),
+        }
+    }
+
+    fn select_prev(&mut self) -> bool {
+        if let Some(idx) = self.state.focus
+            && idx > 0
+        {
+            self.state.write().focus = Some(idx - 1);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn select_next(&mut self) -> bool {
+        if let Some(idx) = self.state.focus
+            && idx < self.state.commands.len() - 1
+        {
+            self.state.write().focus = Some(idx + 1);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn draw_commands(&self, frame: &mut Frame, area: Rect) -> Result<()> {
+        use Constraint::*;
+
+        let height = self.state.commands.len();
+        let constraints = iter::repeat_n(Constraint::Length(1), height);
+        let chunks = Layout::vertical(constraints).split(area);
+
+        let theme = global::theme();
+        for (idx, command) in self.state.commands.iter().enumerate() {
+            let area = chunks[idx];
+
+            // Command focus highlight
+            let mut block = Block::new().borders(Borders::LEFT);
+            let is_focus = Some(idx) == self.state.focus;
+            block = if is_focus {
+                block.border_set(border::THICK)
+            } else {
+                block
+                    .border_set(border::PLAIN)
+                    .border_style(theme.ui.shortcut_desc)
+            };
+            frame.render_widget(&block, area);
+            let area = block.inner(area);
+
+            // Command shortcut
+            let area = if let Some(shortcut) = &command.shortcut {
+                let [left, right] =
+                    Layout::horizontal([Percentage(50), Percentage(50)]).areas(area);
+
+                frame.render_widget(
+                    Paragraph::new(Text::from(shortcut.to_owned()).style(theme.ui.shortcut))
+                        .right_aligned(),
+                    right,
+                );
+
+                left
+            } else {
+                area
+            };
+
+            // Command name
+            let mut name = Text::from(command.name.clone()).left_aligned();
+            if !is_focus {
+                name = name.style(theme.ui.shortcut_desc)
+            }
+            frame.render_widget(Paragraph::new(name), area);
+        }
+        Ok(())
+    }
+}
+
+impl Persistable for CommandPalette {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+    fn load(state: Session) -> Result<Self> {
+        let state: Inner = session::load(state)?;
+        Ok(Self {
+            state: State::new(state),
+        })
+    }
+}
+
+impl Component for CommandPalette {
+    fn handle_key_event(&mut self, key: &KeyEvent) {
+        use KeyCode::*;
+        use KeyModifiers as KM;
+
+        match (key.modifiers, key.code) {
+            (KM::NONE, Char('k')) => {
+                self.select_prev();
+            }
+            (KM::NONE, Char('j')) => {
+                self.select_next();
+            }
+            (KM::NONE, Enter) => {
+                unimplemented!()
+            }
+            (KM::NONE, Esc) => {
+                unimplemented!()
+            }
+            _ => (),
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        use Constraint::*;
+
+        let area = {
+            let [_, area_h_center, _] =
+                Layout::horizontal([Fill(1), Max(120), Fill(1)]).areas(area);
+            let [_, area_floating, _] =
+                Layout::vertical([Fill(1), Max(20), Fill(1)]).areas(area_h_center);
+            area_floating
+        };
+
+        let block = Block::new().borders(Borders::BOTTOM);
+        let block = block
+            .title_bottom("")
+            .title_bottom(shortcuts_desc(&[("Up", "k"), ("Down", "j")]))
+            .title_bottom(shortcuts_desc(&[("Confirm", "CR")]))
+            .title_bottom(shortcuts_desc(&[("Cancel", "Esc")]));
+
+        frame.render_widget(&block, area);
+        self.draw_commands(frame, block.inner(area))
+    }
+}

--- a/crates/coco-tui/src/components/command_palette.rs
+++ b/crates/coco-tui/src/components/command_palette.rs
@@ -8,7 +8,7 @@ use ratatui::{
     prelude::Rect,
     symbols::border,
     text::Text,
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph, Widget},
 };
 use serde::{Deserialize, Serialize};
 
@@ -170,6 +170,8 @@ impl Component for CommandPalette {
                 Layout::vertical([Fill(1), Max(20), Fill(1)]).areas(area_h_center);
             area_floating
         };
+        // ensure that all cells under the popup are cleared to avoid leaking content
+        Clear.render(area, frame.buffer_mut());
 
         let block = Block::new().borders(Borders::BOTTOM);
         let block = block

--- a/crates/coco-tui/src/components/command_palette.rs
+++ b/crates/coco-tui/src/components/command_palette.rs
@@ -13,6 +13,7 @@ use ratatui::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    actions::Action,
     components::{Component, Persistable, shortcuts_desc},
     error::Result,
     global::{self, State},
@@ -73,6 +74,13 @@ impl CommandPalette {
         } else {
             false
         }
+    }
+
+    /// Returns the currently focused command, if any
+    fn selected_command(&self) -> Option<&Command> {
+        self.state
+            .focus
+            .and_then(|idx| self.state.commands.get(idx))
     }
 
     pub fn draw_commands(&self, frame: &mut Frame, area: Rect) -> Result<()> {
@@ -151,7 +159,11 @@ impl Component for CommandPalette {
                 self.select_next();
             }
             (KM::NONE, Enter) => {
-                unimplemented!()
+                if let Some(command) = self.selected_command() {
+                    global::action_tx()
+                        .send(Action::Command(command.name.clone()))
+                        .unwrap();
+                }
             }
             (KM::NONE, Esc) => {
                 unreachable!("Esc key should be handled by the parent component")

--- a/crates/coco-tui/src/components/input.rs
+++ b/crates/coco-tui/src/components/input.rs
@@ -73,7 +73,7 @@ impl Component for Input<'static> {
         let cursor = self.textarea.cursor();
         // Signal dirty if text changed or cursor position changed
         if self.textarea.input(key.to_owned()) || self.textarea.cursor() != cursor {
-            global::signal_ditry();
+            global::signal_dirty();
         }
     }
 

--- a/crates/coco-tui/src/components/input.rs
+++ b/crates/coco-tui/src/components/input.rs
@@ -1,9 +1,17 @@
+use coco_macro::ComponentExt;
 use crossterm::event::KeyEvent;
 use ratatui::{Frame, prelude::*};
 
 use super::{Action, Component};
-use crate::{error::*, global};
+use crate::{
+    components::Persistable,
+    error::*,
+    global,
+    session::{self, Session},
+};
 
+#[derive(ComponentExt)]
+#[component(type_id = "input")]
 pub struct Input<'a> {
     pub textarea: tui_textarea::TextArea<'a>,
     pub cursor_style: Style,
@@ -33,7 +41,22 @@ impl Input<'_> {
     }
 }
 
-impl Component for Input<'_> {
+impl Persistable for Input<'static> {
+    fn save(&self) -> Session {
+        session::save(self.textarea.lines().join("\n"))
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let text: String = session::load(session)?;
+        let mut inst = Self::default();
+        inst.textarea.set_yank_text(text);
+        inst.textarea.paste();
+        inst.textarea.set_yank_text("");
+        Ok(inst)
+    }
+}
+
+impl Component for Input<'static> {
     fn update(&mut self, action: &Action) {
         match action {
             Action::Blur => {

--- a/crates/coco-tui/src/components/message.rs
+++ b/crates/coco-tui/src/components/message.rs
@@ -1,0 +1,164 @@
+use std::any::Any;
+
+use coco_macro::ComponentExt;
+use crossterm::event::KeyEvent;
+use ratatui::{
+    Frame,
+    prelude::*,
+    widgets::{Block, Paragraph},
+};
+use serde::{Deserialize, Serialize};
+
+use super::Component;
+use crate::{
+    components::{Persistable, Tool},
+    error::*,
+    global::{self},
+    session::{self, Session},
+};
+
+#[derive(Serialize, Deserialize)]
+pub enum Role {
+    User,
+    Bot,
+}
+
+/// The content of `Message`;
+pub trait Content {
+    /// the height of content rect.
+    fn height(&self, width: u16) -> usize;
+
+    /// Check if the content is actionable.
+    fn is_actionable(&self) -> bool {
+        false
+    }
+
+    /// Display shortcuts description on the block bottom of the chat window.
+    fn block_with_shortcuts_desc<'a>(&self, block: Block<'a>) -> Block<'a> {
+        block
+    }
+}
+
+pub trait ContentComponent: Component + Content {}
+
+impl<T: ContentComponent> From<T> for Box<dyn ContentComponent> {
+    fn from(value: T) -> Self {
+        Box::new(value)
+    }
+}
+
+impl dyn ContentComponent {
+    /// Allow downcasting the trait object to its concrete type at runtime
+    pub fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Allow downcasting the trait object to its concrete type at runtime
+    pub fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// A message component in the Chat component
+#[derive(ComponentExt)]
+#[component(type_id = "message")]
+pub struct Message {
+    state: Inner,
+    content: Box<dyn ContentComponent>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Inner {
+    pub role: Role,
+    pub content_type_id: String,
+}
+
+impl Message {
+    pub fn bot(content: Box<dyn ContentComponent>) -> Self {
+        Self {
+            state: Inner {
+                role: Role::Bot,
+                content_type_id: content.id().to_string(),
+            },
+            content,
+        }
+    }
+
+    pub fn user(content: Box<dyn ContentComponent>) -> Self {
+        Self {
+            state: Inner {
+                role: Role::User,
+                content_type_id: content.id().to_string(),
+            },
+            content,
+        }
+    }
+
+    pub fn is_same_tool_id(&self, id: &str) -> bool {
+        self.content
+            .as_any()
+            .downcast_ref::<Tool>()
+            .map(|tool| tool.tool_use_id() == id)
+            .unwrap_or_default()
+    }
+}
+
+// Delegate Content trait to its inner content.
+impl Content for Message {
+    fn height(&self, width: u16) -> usize {
+        let role_width = match self.state.role {
+            Role::User => 7,
+            Role::Bot => 6,
+        };
+        self.content.height(width.saturating_sub(role_width))
+    }
+
+    fn is_actionable(&self) -> bool {
+        self.content.is_actionable()
+    }
+
+    fn block_with_shortcuts_desc<'a>(&self, block: Block<'a>) -> Block<'a> {
+        self.content.block_with_shortcuts_desc(block)
+    }
+}
+
+impl Persistable for Message {
+    fn save(&self) -> Session {
+        session::save_related(&self.state, self.content.save())
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let (state, child): (Inner, Session) = session::load_related(session)?;
+        let content = session::load_content_component(&state.content_type_id, child)?;
+        Ok(Self { state, content })
+    }
+}
+
+impl Component for Message {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(vec![self.content.as_mut() as &mut dyn Component].into_iter())
+    }
+
+    fn handle_key_event(&mut self, event: &KeyEvent) {
+        // Delegate the handle_key_event to its inner content.
+        self.content.handle_key_event(event);
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        use Constraint::*;
+
+        let [area_role, area_content] = Layout::horizontal([Length(8), Min(1)]).areas(area);
+        self.content.draw(frame, area_content)?;
+
+        let theme = global::theme();
+        let paragraph = Paragraph::new(Line::from(match self.state.role {
+            Role::User => Span::styled(" User: ", theme.ui.user_role),
+            Role::Bot => Span::styled(" Bot: ", theme.ui.bot_role),
+        }));
+        frame.render_widget(paragraph, area_role);
+
+        Ok(())
+    }
+}
+
+impl ContentComponent for Message {}

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -1,5 +1,6 @@
-use std::{any::Any, cmp::min};
+use std::cmp::min;
 
+use coco_macro::ComponentExt;
 use crossterm::event::KeyEvent;
 use ratatui::{
     Frame,
@@ -7,17 +8,19 @@ use ratatui::{
     layout::Flex,
     prelude::*,
     symbols::{border, line},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{Block, Borders, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
 use snafu::ResultExt;
 use tracing::{trace, warn};
 
 use crate::{
+    components::Persistable,
     error::*,
     global::{self, State},
+    session::{self, Session},
 };
 
-use super::{AnswerEvent, AskEvent, Component, Event};
+use super::{AnswerEvent, AskEvent, Component, Content, Event, Message};
 
 mod combo;
 mod plain;
@@ -26,7 +29,8 @@ pub use combo::Combo;
 pub use plain::Plain;
 pub use tool::Tool;
 
-#[derive(Default)]
+#[derive(Default, ComponentExt)]
+#[component(type_id = "messages")]
 pub struct Messages {
     messages: State<Vec<Message>>,
     focus: State<Option<usize>>,
@@ -130,13 +134,12 @@ impl Messages {
     }
 
     pub fn locate_tool_message(&mut self, id: &str) -> Option<usize> {
-        if let Some((idx, _)) = self.messages.iter().enumerate().find(|(_, m)| {
-            m.content
-                .as_any()
-                .downcast_ref::<Tool>()
-                .map(|tool| tool.id() == id)
-                .unwrap_or_default()
-        }) {
+        if let Some((idx, _)) = self
+            .messages
+            .iter()
+            .enumerate()
+            .find(|(_, m)| m.is_same_tool_id(id))
+        {
             Some(idx)
         } else {
             None
@@ -253,6 +256,22 @@ impl Content for Messages {
     }
 }
 
+impl Persistable for Messages {
+    fn save(&self) -> Session {
+        let messages = self.messages.iter().map(|m| (m.save())).collect::<Vec<_>>();
+        session::save(messages)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let messages: Vec<Session> = session::load(session)?;
+        let mut inst = Self::default();
+        for message in messages {
+            inst.push(Message::load(message)?);
+        }
+        Ok(inst)
+    }
+}
+
 impl Component for Messages {
     fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
         Box::new(
@@ -303,117 +322,6 @@ impl Component for Messages {
     }
 }
 
-pub enum Role {
-    User,
-    Bot,
-}
-
-/// The content of `Message`;
-pub trait Content {
-    /// the height of content rect.
-    fn height(&self, width: u16) -> usize;
-
-    /// Check if the content is actionable.
-    fn is_actionable(&self) -> bool {
-        false
-    }
-
-    /// Display shortcuts description on the block bottom of the chat window.
-    fn block_with_shortcuts_desc<'a>(&self, block: Block<'a>) -> Block<'a> {
-        block
-    }
-}
-
-pub trait ContentComponent: Component + Content + Any + Send {
-    fn boxed(self) -> Box<dyn ContentComponent>
-    where
-        Self: Sized + Send + 'static,
-    {
-        Box::new(self)
-    }
-}
-
-impl dyn ContentComponent {
-    /// Allow downcasting the trait object to its concrete type at runtime
-    pub fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    pub fn as_mut_any(&mut self) -> &mut dyn Any {
-        self
-    }
-}
-
-/// A message component in the Chat component
-pub struct Message {
-    pub role: Role,
-    pub content: Box<dyn ContentComponent>,
-}
-
-impl Message {
-    pub fn bot(content: Box<dyn ContentComponent>) -> Self {
-        Self {
-            role: Role::Bot,
-            content,
-        }
-    }
-
-    pub fn user(content: Box<dyn ContentComponent>) -> Self {
-        Self {
-            role: Role::User,
-            content,
-        }
-    }
-}
-
-// Delegate Content trait to its inner content.
-impl Content for Message {
-    fn height(&self, width: u16) -> usize {
-        let role_width = match self.role {
-            Role::User => 7,
-            Role::Bot => 6,
-        };
-        self.content.height(width.saturating_sub(role_width))
-    }
-
-    fn is_actionable(&self) -> bool {
-        self.content.is_actionable()
-    }
-
-    fn block_with_shortcuts_desc<'a>(&self, block: Block<'a>) -> Block<'a> {
-        self.content.block_with_shortcuts_desc(block)
-    }
-}
-
-impl Component for Message {
-    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
-        Box::new(vec![self.content.as_mut() as &mut dyn Component].into_iter())
-    }
-
-    fn handle_key_event(&mut self, event: &KeyEvent) {
-        // Delegate the handle_key_event to its inner content.
-        self.content.handle_key_event(event);
-    }
-
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        use Constraint::*;
-
-        let [area_role, area_content] = Layout::horizontal([Length(8), Min(1)]).areas(area);
-        self.content.draw(frame, area_content)?;
-
-        let theme = global::theme();
-        let paragraph = Paragraph::new(Line::from(match self.role {
-            Role::User => Span::styled(" User: ", theme.ui.user_role),
-            Role::Bot => Span::styled(" Bot: ", theme.ui.bot_role),
-        }));
-        frame.render_widget(paragraph, area_role);
-
-        Ok(())
-    }
-}
-
-impl ContentComponent for Message {}
-
 pub(super) fn shortcuts_desc<'a>(pairs: &[(&str, &str)]) -> Line<'a> {
     let theme = global::theme();
     let descs: Vec<&str> = pairs.iter().map(|(desc, _)| desc.to_owned()).collect();
@@ -445,8 +353,8 @@ mod tests {
         let mut app = Messages::default();
         app.extend(
             [
-                Message::user(Plain::new("Hello".to_string()).boxed()),
-                Message::user(Plain::new("Hello world".to_string()).boxed()),
+                Message::user(Plain::new("Hello".to_string()).into()),
+                Message::user(Plain::new("Hello world".to_string()).into()),
             ]
             .into_iter(),
         );
@@ -477,8 +385,8 @@ mod tests {
         let mut app = Messages::default();
         app.extend(
             [
-                Message::user(Plain::new("Hello".to_string()).boxed()),
-                Message::user(Plain::new("Lorem ipsum dolor sit amet".to_string()).boxed()),
+                Message::user(Plain::new("Hello".to_string()).into()),
+                Message::user(Plain::new("Lorem ipsum dolor sit amet".to_string()).into()),
             ]
             .into_iter(),
         );
@@ -534,8 +442,8 @@ mod tests {
         let mut app = Messages::default();
         app.extend(
             [
-                Message::user(Plain::new("Hello".to_string()).boxed()),
-                Message::user(Plain::new("Lorem ipsum dolor sit amet".to_string()).boxed()),
+                Message::user(Plain::new("Hello".to_string()).into()),
+                Message::user(Plain::new("Lorem ipsum dolor sit amet".to_string()).into()),
             ]
             .into_iter(),
         );

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -51,6 +51,19 @@ impl Messages {
         self.messages.write().push(message);
     }
 
+    /// Clear all messages
+    pub fn clear(&mut self) {
+        self.messages.write().clear();
+        *self.focus.write() = None;
+        *self.offset.write() = 0;
+        self.total_height = 0;
+    }
+
+    /// Check if there are no messages
+    pub fn is_empty(&self) -> bool {
+        self.messages.is_empty()
+    }
+
     fn new_scrollstate(&self) -> ScrollbarState {
         // N is the viewport sliding range on the whole content.
         // It has double end, so we need to add 1 to fit with position design.

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 
+use coco_macro::{ComponentExt, ContentComponentExt};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout},
@@ -8,130 +9,146 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
+use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use super::{Component, Content, ContentComponent, Plain};
 use crate::{
     actions::{Action, ComboAction},
+    components::{Component, Content, ContentComponent, Persistable, Plain},
     error::*,
     events::{ComboEvent, Event},
     global::{self, State},
+    session::{self, Session},
 };
 
-#[derive(Default)]
-pub struct Combo {
-    // executing
-    event: State<Option<ComboEvent>>,
-    output: State<VecDeque<code_combo::Line>>,
+#[derive(Serialize, Deserialize)]
+enum StarterState {
+    Discovering,
+    NotFound,
+    Executing { output: VecDeque<code_combo::Line> },
+    Finalized { output: String },
+}
 
-    // finalized
+#[derive(Default, Serialize, Deserialize)]
+struct Inner {
+    name: String,
+    is_error: bool,
+    starter_state: StarterState,
+}
+
+impl Default for StarterState {
+    fn default() -> Self {
+        Self::Discovering
+    }
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "combo")]
+pub struct Combo {
+    state: State<Inner>,
+
     widget: Option<Plain>,
 }
 
 const LIMIT: usize = 10;
 
 impl Combo {
-    fn update_event_state(&mut self, new_event: &ComboEvent) {
-        let event = self.event.read();
-        // Skip updating if in final state.
-        if matches!(
-            event,
-            Some(ComboEvent::NotFound { .. } | ComboEvent::Executed { .. })
-        ) {
-            return;
+    pub fn new(name: &str) -> Self {
+        Self {
+            state: State::new(Inner {
+                name: name.to_string(),
+                ..Default::default()
+            }),
+            widget: None,
         }
-        let new_event = Some(new_event.to_owned());
-        debug!(?event, ?new_event, "update event state");
-        *self.event.write() = new_event;
     }
 
     fn on_combo_event(&mut self, event: &ComboEvent) {
         match event {
-            ComboEvent::Output { name, lines } => self.on_output_event(name, lines),
-            ComboEvent::Discovering
-            | ComboEvent::Executing { .. }
-            | ComboEvent::Discovered { .. }
-            | ComboEvent::NotFound { .. } => {
-                self.update_event_state(event);
+            ComboEvent::NotFound { name } => {
+                if &self.state.name == name {
+                    self.state.write().starter_state = StarterState::NotFound
+                }
             }
-            ComboEvent::Executed { starter, .. } => {
-                let combo = starter.combo.as_ref().unwrap();
-                self.update_plain_msg(combo);
-                self.update_event_state(event);
+            ComboEvent::Output { name, lines } => self.on_ouput_event(name, lines),
+            ComboEvent::Executing { name } => {
+                if &self.state.name == name {
+                    self.state.write().starter_state = StarterState::Executing {
+                        output: VecDeque::new(),
+                    };
+                }
             }
+            ComboEvent::Executed { name, starter, .. } => {
+                if &self.state.name == name {
+                    let mut state = self.state.write();
+                    let output = match &starter.combo {
+                        Ok(combo) => combo.to_markdown(),
+                        Err(err) => {
+                            state.is_error = true;
+                            format!("Failed to execute starter: {err}")
+                        }
+                    };
+                    self.widget = Some(Plain::new(output.clone()));
+                    state.starter_state = StarterState::Finalized { output };
+                }
+            }
+            _ => (),
         }
     }
 
-    fn on_output_event(&mut self, target: &String, batch: &Vec<code_combo::Line>) {
-        match self.event.read() {
-            Some(ComboEvent::Executing { name } | ComboEvent::Executed { name, .. })
-                if name == target =>
-            {
-                let mut lines = self.output.write();
-                let batch_size = batch.len();
-                let line_count = lines.len();
-                if batch_size > LIMIT {
-                    debug!(?LIMIT, ?batch_size, "Batch size exceeds limit, truncating");
-                    lines.clear();
-                    lines.extend(batch[batch_size - LIMIT..batch_size].to_vec());
-                } else if line_count + batch_size > LIMIT {
-                    debug!(
-                        ?line_count,
-                        ?batch_size,
-                        ?LIMIT,
-                        "Line count exceeds limit, removing oldest lines"
-                    );
-                    lines.drain(0..(line_count + batch_size - LIMIT));
-                    lines.extend(batch.to_owned());
-                } else {
-                    debug!(?line_count, ?batch_size, ?LIMIT, "Adding new lines");
-                    lines.extend(batch.to_owned());
-                }
-            }
-            _ => {
-                // ignore
-            }
+    fn on_ouput_event(&mut self, name: &str, batch: &Vec<code_combo::Line>) {
+        if self.state.name != name {
+            return;
+        }
+        let StarterState::Executing { output: lines } = &mut self.state.write().starter_state
+        else {
+            return;
+        };
+        let batch_size = batch.len();
+        let line_count = lines.len();
+        if batch_size > LIMIT {
+            debug!(?LIMIT, ?batch_size, "Batch size exceeds limit, truncating");
+            lines.clear();
+            lines.extend(batch[batch_size - LIMIT..batch_size].to_vec());
+        } else if line_count + batch_size > LIMIT {
+            debug!(
+                ?line_count,
+                ?batch_size,
+                ?LIMIT,
+                "Line count exceeds limit, removing oldest lines"
+            );
+            lines.drain(0..(line_count + batch_size - LIMIT));
+            lines.extend(batch.to_owned());
+        } else {
+            debug!(?line_count, ?batch_size, ?LIMIT, "Adding new lines");
+            lines.extend(batch.to_owned());
         }
     }
 
     fn get_title_spans(&self) -> Vec<Span<'_>> {
         // Use block title to show progress message and indicator with simple loading character
         let mut spans = vec![" 󱐋 ".yellow(), " Combo:".into()];
-        match self.event.read() {
-            Some(ComboEvent::Discovering) => {
-                spans.push("   Discovering combo starters...".yellow())
-            }
-            Some(ComboEvent::Discovered { starters }) => {
-                spans.push(format!("   Discovered {} combo starters", starters.len()).green())
-            }
-            Some(ComboEvent::Executing { name }) => {
-                spans.push(name.as_str().cyan());
-                spans.push("   Executing...".yellow());
-            }
-            Some(ComboEvent::Executed { name, starter }) => {
-                spans.push(name.as_str().cyan());
-                spans.push(if starter.combo.is_ok() {
-                    "   Completed".green()
-                } else {
-                    "   Failed".red()
-                });
-            }
-            Some(ComboEvent::NotFound { name }) => {
-                spans.push(name.as_str().cyan());
+        match self.state.starter_state {
+            StarterState::Discovering => spans.push("   Discovering combo starters...".yellow()),
+            StarterState::NotFound => {
+                spans.push(self.state.name.clone().cyan());
                 spans.push("   Not found".red())
             }
-            None => spans.push("   Null".into()),
-            Some(ComboEvent::Output { .. }) => {
-                unreachable!()
+            StarterState::Executing { .. } => {
+                spans.push(self.state.name.clone().cyan());
+                spans.push("   Executing...".yellow());
+            }
+            StarterState::Finalized { .. } => {
+                spans.push(self.state.name.clone().cyan());
+                spans.push(if self.state.is_error {
+                    "   Failed".red()
+                } else {
+                    "   Completed".green()
+                });
             }
         }
         spans.push(" ".into());
         spans
-    }
-
-    fn update_plain_msg(&mut self, combo: &code_combo::Combo) {
-        let text = combo.to_markdown();
-        self.widget = Some(Plain::new(text))
     }
 }
 
@@ -141,13 +158,30 @@ impl Content for Combo {
         if let Some(plain) = &self.widget {
             plain.height(width) + border_height
         } else {
-            match self.event.read() {
-                Some(ComboEvent::Executing { .. } | ComboEvent::Executed { .. }) => {
-                    self.output.len() + border_height
-                }
-                _ => border_height,
-            }
+            (match &self.state.starter_state {
+                StarterState::Executing { output } => output.len(),
+                _ => 0,
+            }) + border_height
         }
+    }
+}
+
+impl Persistable for Combo {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: Inner = session::load(session)?;
+        let widget = if let StarterState::Finalized { output } = &state.starter_state {
+            Some(Plain::new(output.clone()))
+        } else {
+            None
+        };
+        Ok(Self {
+            state: State::new(state),
+            widget,
+        })
     }
 }
 
@@ -177,7 +211,7 @@ impl Component for Combo {
                     tokio::task::spawn(discover());
                 }
                 ComboAction::Execute { name } => {
-                    tokio::task::spawn(execute(name.to_owned(), self.event.get()));
+                    tokio::task::spawn(execute(name.to_owned()));
                 }
             }
         }
@@ -197,11 +231,9 @@ impl Component for Combo {
 
         if let Some(plain) = &mut self.widget {
             plain.draw(frame, output_area)?;
-        } else if let Some(ComboEvent::Executing { .. } | ComboEvent::Executed { .. }) =
-            self.event.read()
-        {
-            let chunks = Layout::vertical(self.output.iter().map(|_| Length(1))).split(output_area);
-            for (idx, line) in self.output.iter().enumerate() {
+        } else if let StarterState::Executing { output } = &self.state.starter_state {
+            let chunks = Layout::vertical(output.iter().map(|_| Length(1))).split(output_area);
+            for (idx, line) in output.iter().enumerate() {
                 let p = Paragraph::new(line.content.to_string());
                 frame.render_widget(&p, chunks[idx]);
             }
@@ -223,24 +255,21 @@ async fn discover() {
     tx.send(ComboEvent::Discovered { starters }.into()).unwrap();
 }
 
-async fn execute(name: String, event: Option<ComboEvent>) {
+async fn execute(name: String) {
     let tx = global::event_tx();
     let config = global::config().await;
     let combo_dir = config.combo_dir();
-    let starters = match event {
-        Some(ComboEvent::Discovered { starters }) => starters,
-        _ => {
-            tx.send(ComboEvent::Discovering.into()).unwrap();
-            let starters = code_combo::discover_combo_starters(&combo_dir.to_string_lossy()).await;
-            tx.send(
-                ComboEvent::Discovered {
-                    starters: starters.clone(),
-                }
-                .into(),
-            )
-            .unwrap();
-            starters
-        }
+    let starters = {
+        tx.send(ComboEvent::Discovering.into()).unwrap();
+        let starters = code_combo::discover_combo_starters(&combo_dir.to_string_lossy()).await;
+        tx.send(
+            ComboEvent::Discovered {
+                starters: starters.clone(),
+            }
+            .into(),
+        )
+        .unwrap();
+        starters
     };
     if let Some(starter) = starters.into_iter().find(|starter| match &starter.combo {
         Ok(combo) => combo.metadata.name == name,

--- a/crates/coco-tui/src/components/messages/plain.rs
+++ b/crates/coco-tui/src/components/messages/plain.rs
@@ -91,7 +91,7 @@ impl Component for Plain {
             };
             self.widget = widget;
             self.rx = None;
-            global::signal_ditry();
+            global::signal_dirty();
             trace!("replaced inner widget of Plain Message");
         }
     }

--- a/crates/coco-tui/src/components/messages/plain.rs
+++ b/crates/coco-tui/src/components/messages/plain.rs
@@ -1,3 +1,4 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::MarkdownRenderEngine;
 use ratatui::{Frame, prelude::Rect};
 use tokio::sync::oneshot;
@@ -5,9 +6,10 @@ use tracing::{trace, warn};
 
 use super::{Component, Content};
 use crate::{
-    components::{CodeHighlight, ContentComponent},
+    components::{CodeHighlight, ContentComponent, Persistable},
     error::*,
     global,
+    session::{self, Session},
 };
 
 mod external_viewer;
@@ -21,7 +23,10 @@ use raw::RawTextViewer;
 /// - Use a built-in Markdown parser and renderer. (Streaming)
 /// - Use an external CLI tool to render Markdown
 /// - Save content to a temporary file and open with external viewer
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "plain")]
 pub struct Plain {
+    text: String,
     widget: Box<dyn ContentComponent>,
     rx: Option<oneshot::Receiver<Box<dyn ContentComponent>>>,
 }
@@ -44,7 +49,7 @@ impl Plain {
                         match ExternalMarkdownViewer::try_new(&text, &executable, &args).await {
                             Ok(widget) => {
                                 trace!("using an external CLI tool to render Markdown success");
-                                tx.send(widget.boxed()).ok();
+                                tx.send(widget.into()).ok();
                             }
                             Err(err) => {
                                 warn!(?err, "failed using an external CLI tool to render Markdown");
@@ -59,12 +64,22 @@ impl Plain {
         };
 
         let widget = CodeHighlight::try_new(&text, code_highlight::Lang::Markdown)
-            .map(|x| x.boxed())
+            .map(|x| x.into())
             .unwrap_or_else(|err| {
                 warn!(?err, "failed to new CodeHighlight Component");
-                RawTextViewer::new(text).boxed()
+                RawTextViewer::new(text.clone()).into()
             });
-        Self { widget, rx }
+        Self { text, widget, rx }
+    }
+}
+
+impl Persistable for Plain {
+    fn save(&self) -> Session {
+        session::save(&self.text)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        Ok(Self::new(session::load(session)?))
     }
 }
 

--- a/crates/coco-tui/src/components/messages/plain/external_viewer.rs
+++ b/crates/coco-tui/src/components/messages/plain/external_viewer.rs
@@ -1,6 +1,7 @@
 use std::process::Stdio;
 
 use ansi_to_tui::IntoText;
+use coco_macro::{ComponentExt, ContentComponentExt};
 use ratatui::{
     Frame,
     layout::Rect,
@@ -10,10 +11,13 @@ use snafu::prelude::*;
 use tokio::io::AsyncWriteExt;
 
 use crate::{
-    components::{Component, Content, ContentComponent},
+    components::{Component, Content, ContentComponent, Persistable},
     error::*,
+    session::Session,
 };
 
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "external_markdown_viewer")]
 pub struct ExternalMarkdownViewer<'a> {
     widget: Paragraph<'a>,
 }
@@ -50,7 +54,17 @@ impl<'a> ExternalMarkdownViewer<'a> {
     }
 }
 
-impl<'a> Component for ExternalMarkdownViewer<'a> {
+impl Persistable for ExternalMarkdownViewer<'static> {
+    fn save(&self) -> Session {
+        unreachable!("External markdown viewer doesn't support saving session")
+    }
+
+    fn load(_session: Session) -> Result<Self> {
+        unreachable!("External markdown viewer doesn't support loading session")
+    }
+}
+
+impl Component for ExternalMarkdownViewer<'static> {
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         frame.render_widget(&self.widget, area);
         Ok(())

--- a/crates/coco-tui/src/components/messages/plain/raw.rs
+++ b/crates/coco-tui/src/components/messages/plain/raw.rs
@@ -1,3 +1,4 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
 use ratatui::{
     Frame,
     prelude::Rect,
@@ -5,23 +6,39 @@ use ratatui::{
 };
 
 use crate::{
-    components::{Component, Content, ContentComponent},
+    components::{Component, Content, ContentComponent, Persistable},
     error::*,
+    session::{self, Session},
 };
 
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "raw_text_viewer")]
 pub struct RawTextViewer<'a> {
+    text: String,
+
     widget: Paragraph<'a>,
 }
 
 impl<'a> RawTextViewer<'a> {
     pub fn new(text: String) -> Self {
         Self {
+            text: text.clone(),
             widget: Paragraph::new(text).wrap(Wrap { trim: false }),
         }
     }
 }
 
-impl<'a> Component for RawTextViewer<'a> {
+impl Persistable for RawTextViewer<'static> {
+    fn save(&self) -> Session {
+        session::save(&self.text)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        Ok(Self::new(session::load(session)?))
+    }
+}
+
+impl Component for RawTextViewer<'static> {
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         frame.render_widget(&self.widget, area);
         Ok(())

--- a/crates/coco-tui/src/components/messages/tool.rs
+++ b/crates/coco-tui/src/components/messages/tool.rs
@@ -1,3 +1,4 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{
     ToolUse,
     tools::{BASH_TOOL_NAME, READ_TOOL_NAME, STR_REPLACE_TOOL_NAME},
@@ -12,14 +13,18 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders},
 };
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use snafu::whatever;
 use tracing::{debug, warn};
 
-use super::{Component, Content, ContentComponent};
 use crate::{
     actions::{Action, ToolAction},
+    components::{Component, Content, ContentComponent, Persistable},
     error::*,
     events::{AnswerEvent, AskEvent, Event},
     global::State,
+    session::{self, Session},
 };
 
 mod bash;
@@ -31,7 +36,7 @@ use raw::Raw;
 use read::Read;
 use str_replace::StrReplace;
 
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum ToolState {
     #[default]
     Initing,
@@ -44,11 +49,16 @@ pub enum ToolState {
     Failed,
 }
 
-pub struct Tool {
-    id: String,
-    name: String,
-    state: State<ToolState>,
+#[derive(Serialize, Deserialize)]
+struct Inner {
+    tool_use: ToolUse,
+    state: ToolState,
+}
 
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "tool")]
+pub struct Tool {
+    inner: State<Inner>,
     widget: Box<dyn ContentComponent>,
 }
 
@@ -56,13 +66,10 @@ pub struct Tool {
 
 impl Tool {
     pub fn new(tool_use: ToolUse) -> Self {
-        let id = tool_use.id.clone();
-        let name = tool_use.name.clone();
-
-        let widget = match name.as_str() {
-            READ_TOOL_NAME => Some(Read::new(&tool_use).boxed()),
+        let widget = match tool_use.name.as_str() {
+            READ_TOOL_NAME => Some(Read::new(&tool_use).into()),
             BASH_TOOL_NAME => match Bash::try_new().tool_use(&tool_use).call() {
-                Ok(widget) => Some(widget.boxed()),
+                Ok(widget) => Some(widget.into()),
                 Err(err) => {
                     warn!(
                         ?err,
@@ -71,35 +78,40 @@ impl Tool {
                     None
                 }
             },
-            STR_REPLACE_TOOL_NAME => Some(StrReplace::new(&tool_use).boxed()),
+            STR_REPLACE_TOOL_NAME => Some(StrReplace::new(&tool_use).into()),
             _ => None,
         }
-        .unwrap_or_else(|| Raw::new(tool_use).boxed());
+        .unwrap_or_else(|| Raw::new(tool_use.clone()).into());
 
         Self {
-            id,
-            name,
-            state: State::default(),
+            inner: State::new(Inner {
+                tool_use,
+                state: ToolState::default(),
+            }),
             widget,
         }
     }
 
-    pub fn id(&self) -> &str {
-        &self.id
+    pub fn tool_use_id(&self) -> &str {
+        &self.inner.tool_use.id
     }
 
     pub fn update_state(&mut self, new_state: ToolState) {
-        let state = self.state.read();
+        let state = &self.inner.state;
         if state == &new_state {
             return;
         }
         debug!(?state, ?new_state, "update state");
-        *self.state.write() = new_state
+        self.inner.write().state = new_state
     }
 
     fn get_title_spans(&self) -> Vec<Span<'_>> {
-        let mut spans = vec![" 󱁤  ".blue(), "Tool: ".into(), self.name.as_str().cyan()];
-        match self.state.read() {
+        let mut spans = vec![
+            " 󱁤  ".blue(),
+            "Tool: ".into(),
+            self.inner.tool_use.name.clone().cyan(),
+        ];
+        match self.inner.state {
             ToolState::Initing => spans.push("   Initing...".yellow()),
             ToolState::PendingConfirmation => {
                 spans.push("   Awaiting confirmation".blue());
@@ -122,6 +134,27 @@ impl Tool {
     }
 }
 
+impl Persistable for Tool {
+    fn save(&self) -> Session {
+        session::save_related(&self.inner, self.widget.save())
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let (inner, child): (Inner, Value) = session::load_related(session)?;
+        let name = &inner.tool_use.name;
+        let widget = match name.as_str() {
+            BASH_TOOL_NAME => Bash::load(child)?.into(),
+            READ_TOOL_NAME => Read::load(child)?.into(),
+            STR_REPLACE_TOOL_NAME => StrReplace::load(child)?.into(),
+            _ => whatever!("Unknown tool {name:?}"),
+        };
+        Ok(Self {
+            inner: State::new(inner),
+            widget,
+        })
+    }
+}
+
 impl Component for Tool {
     fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
         Box::new(vec![self.widget.as_mut() as &mut dyn Component].into_iter())
@@ -130,14 +163,14 @@ impl Component for Tool {
     fn handle_event(&mut self, event: &Event) {
         match event {
             Event::Ask(AskEvent::ToolUsePermission(id) | AskEvent::TextEdit { id, .. }) => {
-                if &self.id == id {
+                if self.tool_use_id() == id {
                     debug!(?event, "state change to pending confirmation");
                     self.update_state(ToolState::PendingConfirmation);
                     handle_component_event!(self, event);
                 }
             }
             Event::Answer(AnswerEvent::ToolResult { id, is_error, .. }) => {
-                if &self.id == id {
+                if self.tool_use_id() == id {
                     self.update_state(if *is_error {
                         ToolState::Failed
                     } else {
@@ -157,14 +190,14 @@ impl Component for Tool {
     fn update(&mut self, action: &Action) {
         match action {
             Action::Tool(ToolAction::Grant(ToolUse { id, .. })) => {
-                if &self.id == id {
+                if self.tool_use_id() == id {
                     self.update_state(ToolState::Executing);
                 }
             }
             Action::Tool(ToolAction::ApplyTextEdit {
                 id, is_rejecting, ..
             }) => {
-                if &self.id == id {
+                if self.tool_use_id() == id {
                     if *is_rejecting {
                         self.update_state(ToolState::Cancelled);
                     } else {
@@ -173,7 +206,7 @@ impl Component for Tool {
                 }
             }
             Action::Tool(ToolAction::Cancel(ToolUse { id, .. })) => {
-                if &self.id == id {
+                if self.tool_use_id() == id {
                     self.update_state(ToolState::Cancelled);
                 }
             }

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -1,4 +1,5 @@
 use bon::bon;
+use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{
     ToolUse,
     tools::{BashInput, BashOutput, Final},
@@ -13,6 +14,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Paragraph, Wrap},
 };
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::prelude::*;
 use tracing::warn;
@@ -20,16 +22,26 @@ use tracing::warn;
 use super::{Component, Content, ContentComponent};
 use crate::{
     actions::ToolAction,
-    components::{CodeHighlight, shortcuts_desc},
+    components::{CodeHighlight, Persistable, shortcuts_desc},
     error::*,
     events::{AnswerEvent, AskEvent, Event},
-    global,
+    global::{self, State},
+    session::{self, Session},
 };
 
-pub struct Bash<'a> {
+#[derive(Serialize, Deserialize)]
+struct Inner {
     tool_use: ToolUse,
-    input: CodeHighlight<'a>,
     requiring_confirmation: bool,
+    output: Option<BashOutput>,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "bash")]
+pub struct Bash<'a> {
+    state: State<Inner>,
+
+    input: CodeHighlight<'a>,
     output: Paragraph<'a>,
 }
 
@@ -57,26 +69,31 @@ fn generate_output<'a>(output: Option<BashOutput>) -> Paragraph<'a> {
     Paragraph::new(lines).wrap(Wrap { trim: false })
 }
 
+fn generate_input<'b>(tool_use: &ToolUse) -> CodeHighlight<'b> {
+    let input: BashInput =
+        serde_json::from_value(tool_use.input.clone()).expect("failed to parse BashInput");
+    CodeHighlight::try_new(&input.command, Lang::Bash).expect("failed to new CodeHighlight")
+}
+
 #[bon]
 impl<'a> Bash<'a> {
     #[builder]
     pub fn try_new(tool_use: &ToolUse, output: Option<Value>) -> Result<Self> {
-        let input: BashInput = serde_json::from_value(tool_use.input.clone())
-            .whatever_context("failed to parse BashInput")?;
-
-        let input = CodeHighlight::try_new(&input.command, Lang::Bash)?;
-
+        let input = generate_input(tool_use);
         let output = output
             .map(serde_json::from_value)
             .transpose()
             .whatever_context("failed to parse BashOutput")?;
-        let output = generate_output(output);
+        let output_widget = generate_output(output.clone());
 
         Ok(Self {
-            tool_use: tool_use.to_owned(),
+            state: State::new(Inner {
+                tool_use: tool_use.to_owned(),
+                requiring_confirmation: false,
+                output,
+            }),
             input,
-            requiring_confirmation: false,
-            output,
+            output: output_widget,
         })
     }
 
@@ -96,7 +113,7 @@ impl<'a> Content for Bash<'a> {
     }
 
     fn is_actionable(&self) -> bool {
-        self.requiring_confirmation
+        self.state.requiring_confirmation
     }
 
     fn block_with_shortcuts_desc<'b>(&self, block: Block<'b>) -> Block<'b> {
@@ -106,10 +123,27 @@ impl<'a> Content for Bash<'a> {
     }
 }
 
-impl Component for Bash<'_> {
+impl Persistable for Bash<'static> {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: Inner = session::load(session)?;
+        Ok(Self {
+            input: generate_input(&state.tool_use),
+            output: generate_output(state.output.clone()),
+            state: global::State::new(state),
+        })
+    }
+}
+
+impl Component for Bash<'static> {
     fn handle_event(&mut self, event: &Event) {
         match event {
-            Event::Ask(AskEvent::ToolUsePermission(_)) => self.requiring_confirmation = true,
+            Event::Ask(AskEvent::ToolUsePermission(_)) => {
+                self.state.write().requiring_confirmation = true
+            }
             Event::Answer(AnswerEvent::ToolResult { output, .. }) => {
                 if let Err(err) = self.update_output(Some(output.to_owned())) {
                     warn!(?err, "failed to update tool output");
@@ -123,15 +157,15 @@ impl Component for Bash<'_> {
         match (key.modifiers, key.code) {
             (KeyModifiers::NONE, KeyCode::Enter) => {
                 global::action_tx()
-                    .send(ToolAction::Grant(self.tool_use.to_owned()).into())
+                    .send(ToolAction::Grant(self.state.tool_use.to_owned()).into())
                     .unwrap();
-                self.requiring_confirmation = false;
+                self.state.write().requiring_confirmation = false;
             }
             (KeyModifiers::NONE, KeyCode::Esc) => {
                 global::action_tx()
-                    .send(ToolAction::Cancel(self.tool_use.to_owned()).into())
+                    .send(ToolAction::Cancel(self.state.tool_use.to_owned()).into())
                     .unwrap();
-                self.requiring_confirmation = false;
+                self.state.write().requiring_confirmation = false;
             }
             _ => (), // ignore
         }

--- a/crates/coco-tui/src/components/messages/tool/raw.rs
+++ b/crates/coco-tui/src/components/messages/tool/raw.rs
@@ -1,3 +1,4 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{ToolUse, tools::Final};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
@@ -5,54 +6,85 @@ use ratatui::{
     prelude::Rect,
     widgets::{Paragraph, Wrap},
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     actions::ToolAction,
-    components::{Component, Content, ContentComponent},
-    error,
+    components::{Component, Content, ContentComponent, Persistable},
+    error::Result,
     events::{AnswerEvent, Event},
     global::{self, State},
+    session::{self, Session},
 };
 
-pub struct Raw {
+#[derive(Serialize, Deserialize)]
+struct Inner {
     tool_use: ToolUse,
-    is_actionable: State<bool>,
-    output: State<Option<Final>>,
+    is_actionable: bool,
+    output: Option<Final>,
 }
 
-impl Raw {
-    pub fn new(tool_use: ToolUse) -> Self {
-        Self {
-            tool_use,
-            is_actionable: State::new(true),
-            output: State::default(),
-        }
-    }
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "raw")]
+pub struct Raw<'a> {
+    state: State<Inner>,
+    widget: Paragraph<'a>,
+}
 
-    fn generate_default(&self) -> Paragraph<'_> {
-        let mut text = match serde_json::to_string_pretty(&self.tool_use.input) {
-            Ok(json_str) => format!("Input: {}", json_str),
-            Err(_) => "Input: [Invalid JSON]".to_string(),
+fn generate_widget<'b>(tool_use: &ToolUse, output: &Option<Final>) -> Paragraph<'b> {
+    let mut text = match serde_json::to_string_pretty(&tool_use.input) {
+        Ok(json_str) => format!("Input: {}", json_str),
+        Err(_) => "Input: [Invalid JSON]".to_string(),
+    };
+    if let Some(output) = output {
+        let output = match output {
+            Final::Json(output) => match serde_json::to_string_pretty(output) {
+                Ok(json_str) => format!("Output: {}", json_str),
+                Err(_) => "Output: [Invalid JSON]".to_string(),
+            },
+            Final::Message(text) => text.to_owned(),
         };
-        if let Some(output) = self.output.read() {
-            let output = match output {
-                Final::Json(output) => match serde_json::to_string_pretty(output) {
-                    Ok(json_str) => format!("Output: {}", json_str),
-                    Err(_) => "Output: [Invalid JSON]".to_string(),
-                },
-                Final::Message(text) => text.to_owned(),
-            };
-            text.push('\n');
-            text.push_str(&output);
+        text.push('\n');
+        text.push_str(&output);
+    }
+    Paragraph::new(text).wrap(Wrap { trim: false })
+}
+
+impl<'a> Raw<'a> {
+    pub fn new(tool_use: ToolUse) -> Self {
+        let widget = generate_widget(&tool_use, &None);
+        Self {
+            state: State::new(Inner {
+                tool_use,
+                is_actionable: true,
+                output: None,
+            }),
+            widget,
         }
-        Paragraph::new(text).wrap(Wrap { trim: false })
     }
 }
 
-impl Component for Raw {
+impl Persistable for Raw<'static> {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: Inner = session::load(session)?;
+        let widget = generate_widget(&state.tool_use, &state.output);
+        Ok(Self {
+            state: State::new(state),
+            widget,
+        })
+    }
+}
+
+impl Component for Raw<'static> {
     fn handle_event(&mut self, event: &Event) {
         if let Event::Answer(AnswerEvent::ToolResult { output, .. }) = event {
-            *self.output.write() = Some(output.to_owned());
+            let output = Some(output.to_owned());
+            self.widget = generate_widget(&self.state.tool_use, &output);
+            self.state.write().output = output;
         } else {
             handle_component_event!(self, event);
         }
@@ -60,32 +92,35 @@ impl Component for Raw {
 
     fn handle_key_event(&mut self, key: &KeyEvent) {
         let action = match (key.modifiers, key.code) {
-            (KeyModifiers::NONE, KeyCode::Enter) => ToolAction::Grant(self.tool_use.to_owned()),
-            (KeyModifiers::NONE, KeyCode::Esc) => ToolAction::Cancel(self.tool_use.to_owned()),
+            (KeyModifiers::NONE, KeyCode::Enter) => {
+                ToolAction::Grant(self.state.tool_use.to_owned())
+            }
+            (KeyModifiers::NONE, KeyCode::Esc) => {
+                ToolAction::Cancel(self.state.tool_use.to_owned())
+            }
             _ => {
                 // ignore
                 return;
             }
         };
-        *self.is_actionable.write() = false;
+        self.state.write().is_actionable = false;
         global::action_tx().send(action.into()).unwrap();
     }
 
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> error::Result<()> {
-        let content = self.generate_default();
-        frame.render_widget(content, area);
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        frame.render_widget(&self.widget, area);
         Ok(())
     }
 }
 
-impl Content for Raw {
+impl<'a> Content for Raw<'a> {
     fn is_actionable(&self) -> bool {
-        self.is_actionable.get()
+        self.state.is_actionable
     }
 
     fn height(&self, width: u16) -> usize {
-        self.generate_default().line_count(width)
+        self.widget.line_count(width)
     }
 }
 
-impl ContentComponent for Raw {}
+impl ContentComponent for Raw<'static> {}

--- a/crates/coco-tui/src/components/messages/tool/read.rs
+++ b/crates/coco-tui/src/components/messages/tool/read.rs
@@ -1,3 +1,4 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{
     ToolUse,
     tools::{DEFAULT_LINE_LIMIT, DEFAULT_LINE_OFFSET, Final, ReadInput},
@@ -11,19 +12,31 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Paragraph, Wrap},
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    components::{Component, Content, ContentComponent},
-    error,
+    components::{Component, Content, ContentComponent, Persistable},
+    error::Result,
     events::{AnswerEvent, Event},
     global::State,
+    session::{self, Session},
 };
 
+#[derive(Serialize, Deserialize)]
+struct Inner {
+    input: ReadInput,
+    output: Option<String>,
+    collapsed: bool,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "read")]
 pub struct Read<'a> {
+    state: State<Inner>,
+
     input_widget: Paragraph<'a>,
+    output_widget: Option<Paragraph<'a>>,
     output_line_cnt: usize,
-    output_widget: State<Option<Paragraph<'a>>>,
-    collapsed: State<bool>,
 }
 
 const COLLAPSED_PREVIEW_LINES: usize = 5;
@@ -57,17 +70,25 @@ fn generate_input_widget<'a>(input: ReadInput) -> Paragraph<'a> {
     Paragraph::new(lines).wrap(Wrap { trim: false })
 }
 
+fn generate_output_widget<'a>(output: String) -> Paragraph<'a> {
+    Paragraph::new(Text::from(output)).wrap(Wrap { trim: false })
+}
+
 impl Read<'_> {
     pub fn new(tool_use: &ToolUse) -> Self {
         let input: ReadInput = serde_json::from_value(tool_use.input.to_owned())
             .expect("Should be a valid ReadInput.");
-        let input_widget = generate_input_widget(input);
+        let input_widget = generate_input_widget(input.clone());
 
         Self {
             input_widget,
-            output_widget: State::default(),
+            output_widget: None,
             output_line_cnt: 0,
-            collapsed: State::new(true),
+            state: State::new(Inner {
+                input,
+                output: None,
+                collapsed: true,
+            }),
         }
     }
 
@@ -76,14 +97,14 @@ impl Read<'_> {
             unreachable!("Read tool should only return Final::Message");
         };
 
+        self.state.write().output = Some(text.clone());
+
         self.output_line_cnt = text.lines().count();
-        let widget = Paragraph::new(Text::from(text)).wrap(Wrap { trim: false });
-        *self.output_widget.write() = Some(widget);
+        self.output_widget = Some(generate_output_widget(text));
     }
 
     fn toggle_collapsed(&mut self) {
-        let is_collapsed = *self.collapsed.read();
-        *self.collapsed.write() = !is_collapsed;
+        self.state.write().collapsed = !self.state.collapsed;
     }
 }
 
@@ -95,7 +116,7 @@ impl Content for Read<'_> {
             .as_ref()
             .map(|x| {
                 let mut height = x.line_count(width);
-                if self.collapsed.get() && height > COLLAPSED_PREVIEW_LINES {
+                if self.state.collapsed && height > COLLAPSED_PREVIEW_LINES {
                     // Add 1 for the collapsed indicator at the bottom.
                     height = COLLAPSED_PREVIEW_LINES + 1
                 };
@@ -106,12 +127,12 @@ impl Content for Read<'_> {
     }
 
     fn is_actionable(&self) -> bool {
-        self.output_widget.read().is_some()
+        self.output_widget.is_some()
     }
 
     fn block_with_shortcuts_desc<'b>(&self, block: Block<'b>) -> Block<'b> {
-        if self.output_widget.read().is_some() {
-            let toggle_text = if *self.collapsed.read() {
+        if self.output_widget.is_some() {
+            let toggle_text = if self.state.collapsed {
                 ("Unfold", "z")
             } else {
                 ("Fold", "z")
@@ -123,7 +144,27 @@ impl Content for Read<'_> {
     }
 }
 
-impl Component for Read<'_> {
+impl Persistable for Read<'static> {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: Inner = session::load(session)?;
+        Ok(Self {
+            input_widget: generate_input_widget(state.input.clone()),
+            output_widget: state.output.clone().map(generate_output_widget),
+            output_line_cnt: state
+                .output
+                .as_ref()
+                .map(|x| x.lines().count())
+                .unwrap_or_default(),
+            state: State::new(state),
+        })
+    }
+}
+
+impl Component for Read<'static> {
     fn handle_event(&mut self, event: &Event) {
         match event {
             Event::Answer(AnswerEvent::ToolResult { output, .. }) => {
@@ -137,18 +178,18 @@ impl Component for Read<'_> {
 
     fn handle_key_event(&mut self, key: &KeyEvent) {
         if let (KeyModifiers::NONE, KeyCode::Char('z')) = (key.modifiers, key.code)
-            && self.output_widget.read().is_some()
+            && self.output_widget.is_some()
         {
             self.toggle_collapsed();
         }
     }
 
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> error::Result<()> {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         use Constraint::{Length, Min};
         let width = area.width;
         let height_input = self.input_widget.line_count(width);
 
-        if let Some(output_widget) = self.output_widget.read() {
+        if let Some(output_widget) = &self.output_widget {
             let width = area.width;
             let [area_input, area_output] =
                 Layout::vertical([Length(height_input as u16), Min(1)]).areas(area);
@@ -162,7 +203,7 @@ impl Component for Read<'_> {
                 format!("... (showing first part of {} lines)", self.output_line_cnt).dark_gray(),
             );
             let indicator_height = indicator.line_count(width);
-            if self.collapsed.get() && height > COLLAPSED_PREVIEW_LINES + indicator_height {
+            if self.state.collapsed && height > COLLAPSED_PREVIEW_LINES + indicator_height {
                 let [area_output, area_indicator] =
                     Layout::vertical([Min(1), Length(indicator_height as u16)]).areas(area_output);
                 frame.render_widget(indicator, area_indicator);

--- a/crates/coco-tui/src/components/messages/tool/str_replace.rs
+++ b/crates/coco-tui/src/components/messages/tool/str_replace.rs
@@ -1,3 +1,4 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{
     TextEdit, ToolUse,
     tools::{Final, STR_REPLACE_TOOL_NAME},
@@ -10,21 +11,31 @@ use ratatui::{
     text::Text,
     widgets::{Block, Paragraph},
 };
+use serde::{Deserialize, Serialize};
+use snafu::prelude::*;
 use tracing::warn;
 
 use super::{Component, Content, ContentComponent};
 use crate::{
     actions::{Action, ToolAction},
-    components::{code_highlight::CodeHighlight, shortcuts_desc},
-    error,
+    components::{Persistable, code_highlight::CodeHighlight, shortcuts_desc},
+    error::Result,
     events::{AnswerEvent, AskEvent, Event},
     global::{self, State},
+    session::{self, Session},
 };
 
-pub struct StrReplace<'a> {
+#[derive(Serialize, Deserialize)]
+struct Inner {
     tool_use: ToolUse,
     edit: Option<TextEdit>,
-    appliable: State<bool>,
+    appliable: bool,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "str_replace")]
+pub struct StrReplace<'a> {
+    state: State<Inner>,
     widget: StrReplaceWidget<'a>,
 }
 
@@ -38,9 +49,11 @@ const CONTEXT_RADIUS: usize = 3;
 impl<'a> StrReplace<'a> {
     pub fn new(tool_use: &ToolUse) -> Self {
         Self {
-            tool_use: tool_use.to_owned(),
-            edit: None,
-            appliable: State::default(),
+            state: State::new(Inner {
+                tool_use: tool_use.to_owned(),
+                edit: None,
+                appliable: false,
+            }),
             widget: StrReplaceWidget::Paragraph(Paragraph::new("")),
         }
     }
@@ -70,7 +83,9 @@ impl<'a> StrReplace<'a> {
             Err(_) => StrReplaceWidget::Paragraph(Paragraph::new(diff_text)),
         };
 
-        self.edit = Some(edit);
+        let mut state = self.state.write();
+        state.edit = Some(edit);
+        state.appliable = true;
         self.widget = widget;
     }
 }
@@ -84,11 +99,11 @@ impl Content for StrReplace<'_> {
     }
 
     fn is_actionable(&self) -> bool {
-        self.appliable.get()
+        self.state.appliable
     }
 
     fn block_with_shortcuts_desc<'b>(&self, block: Block<'b>) -> Block<'b> {
-        if self.appliable.get() {
+        if self.state.appliable {
             block
                 .title_bottom(shortcuts_desc(&[("Apply", "CR")]))
                 .title_bottom(shortcuts_desc(&[("Reject", "Esc")]))
@@ -98,15 +113,24 @@ impl Content for StrReplace<'_> {
     }
 }
 
-impl Component for StrReplace<'_> {
+impl Persistable for StrReplace<'static> {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: Inner = session::load(session)?;
+        let mut inst = Self::new(&state.tool_use);
+        inst.update_text_edit(state.edit.whatever_context("text edit should exist")?);
+        Ok(inst)
+    }
+}
+
+impl Component for StrReplace<'static> {
     fn handle_key_event(&mut self, key: &KeyEvent) {
-        if !self.appliable.read() {
+        if self.state.appliable && self.state.edit.is_some() {
             return;
         }
-
-        let Some(edit) = &mut self.edit else {
-            return;
-        };
 
         let is_rejecting = match (key.modifiers, key.code) {
             (KeyModifiers::NONE, KeyCode::Enter) => false,
@@ -116,13 +140,16 @@ impl Component for StrReplace<'_> {
             } // ignore
         };
 
-        *self.appliable.write() = false;
+        let Some(edit) = self.state.edit.clone() else {
+            return;
+        };
+        self.state.write().appliable = false;
 
         global::action_tx()
             .send(Action::Tool(ToolAction::ApplyTextEdit {
-                id: self.tool_use.id.clone(),
+                id: self.state.tool_use.id.clone(),
                 name: STR_REPLACE_TOOL_NAME.to_string(),
-                edit: edit.clone(),
+                edit,
                 context_radius: CONTEXT_RADIUS,
                 hunk_idx: 0,
                 is_rejecting,
@@ -134,7 +161,6 @@ impl Component for StrReplace<'_> {
         match event {
             Event::Ask(AskEvent::TextEdit { edit, .. }) => {
                 self.update_text_edit(edit.clone());
-                *self.appliable.write() = true;
             }
             Event::Answer(AnswerEvent::ToolResult {
                 is_error, output, ..
@@ -160,7 +186,7 @@ impl Component for StrReplace<'_> {
         }
     }
 
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> error::Result<()> {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         match &mut self.widget {
             StrReplaceWidget::CodeHighlight(highlight) => {
                 highlight.draw(frame, area)?;

--- a/crates/coco-tui/src/global.rs
+++ b/crates/coco-tui/src/global.rs
@@ -112,7 +112,7 @@ pub fn workspace_dir() -> &'static Path {
 /// This function sends a `Dirty` event to trigger a re-render of the UI.
 /// It's typically called automatically when state is modified through a `WriteGuard`.
 #[inline]
-pub fn signal_ditry() {
+pub fn signal_dirty() {
     event_tx().send(Event::Dirty).ok();
 }
 
@@ -184,7 +184,7 @@ pub struct WriteGuard<T> {
 
 impl<T> Drop for WriteGuard<T> {
     fn drop(&mut self) {
-        signal_ditry();
+        signal_dirty();
     }
 }
 

--- a/crates/coco-tui/src/global.rs
+++ b/crates/coco-tui/src/global.rs
@@ -107,6 +107,11 @@ pub fn workspace_dir() -> &'static Path {
     })
 }
 
+#[inline]
+pub fn trigger_schedule_session_save() {
+    action_tx().send(Action::schedule_session_save()).ok();
+}
+
 /// Signal dirty for re-rendering.
 ///
 /// This function sends a `Dirty` event to trigger a re-render of the UI.

--- a/crates/coco-tui/src/global.rs
+++ b/crates/coco-tui/src/global.rs
@@ -1,5 +1,7 @@
 use std::{
+    env,
     ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
 
@@ -14,6 +16,7 @@ use crate::{
 
 static EVENT_TX: OnceLock<UnboundedSender<Event>> = OnceLock::new();
 static ACTION_TX: OnceLock<UnboundedSender<Action>> = OnceLock::new();
+static WORKSPACE_DIR: OnceLock<PathBuf> = OnceLock::new();
 
 /// Initialize the global event and action senders.
 ///
@@ -70,6 +73,38 @@ pub async fn set_config(config: code_combo::Config) {
 pub fn theme() -> &'static FinalizedTheme {
     let config = config_sync();
     use_builtin_theme(&config.ui.theme)
+}
+
+/// Returns the workspace directory by walking up from the current directory
+/// until a `.git` directory is found. If no `.git` directory is found,
+/// falls back to the current directory.
+///
+/// The result is cached globally after the first call.
+pub fn workspace_dir() -> &'static Path {
+    WORKSPACE_DIR.get_or_init(|| {
+        // Start from current directory
+        let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        // Walk up the directory tree to find a .git directory
+        let mut dir = current_dir.clone();
+        loop {
+            let git_dir = dir.join(".git");
+            if git_dir.exists() && git_dir.is_dir() {
+                return dir;
+            }
+
+            // Move to parent directory
+            if let Some(parent) = dir.parent() {
+                dir = parent.to_path_buf();
+            } else {
+                // Reached root, use current directory
+                break;
+            }
+        }
+
+        // Fallback to current directory
+        current_dir
+    })
 }
 
 /// Signal dirty for re-rendering.

--- a/crates/coco-tui/src/global.rs
+++ b/crates/coco-tui/src/global.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc::UnboundedSender};
 
 use crate::{
@@ -90,8 +91,9 @@ pub fn signal_ditry() {
 /// mutable access to the inner value. When the `WriteGuard` is dropped, it
 /// automatically sends a `Dirty` event to notify the system that the state
 /// has been modified.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct State<T> {
+    #[serde(flatten)]
     inner: T,
 }
 

--- a/crates/coco-tui/src/lib.rs
+++ b/crates/coco-tui/src/lib.rs
@@ -2,6 +2,7 @@ pub mod actions;
 pub mod app;
 pub mod error;
 pub mod global;
+pub mod session;
 #[macro_use]
 pub mod components;
 pub mod events;

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -4,7 +4,13 @@ use clap::{Parser, Subcommand};
 use code_combo::{Config, default_config_dir};
 use snafu::prelude::*;
 
-use coco_tui::{actions::ComboAction, app, error::Result, global};
+use coco_tui::{
+    actions::{Action, ComboAction},
+    app,
+    error::Result,
+    global,
+};
+use tracing::info;
 
 /// Code Combo
 #[derive(Parser)]
@@ -17,6 +23,10 @@ struct Args {
     /// Config file dir
     #[arg(long, default_value_t = default_config_dir().to_string_lossy().to_string())]
     config_dir: String,
+
+    /// Restore the last session
+    #[arg(short = 'r', long)]
+    restore: bool,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -57,7 +67,12 @@ async fn main() -> Result<()> {
                 app.send_action(ComboAction::Execute { name }.into());
             }
         },
-        None => {}
+        None => {
+            if args.restore {
+                info!("restoring last session");
+                app.send_action(Action::restore_last_session());
+            }
+        }
     }
 
     let result = app.run().await;

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -30,7 +30,6 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum ComboCommands {
-    List,
     Run { name: String },
 }
 
@@ -54,9 +53,6 @@ async fn main() -> Result<()> {
     let mut app = app::App::new(config)?;
     match args.command {
         Some(Commands::Combo(combo_cmd)) => match combo_cmd {
-            ComboCommands::List => {
-                app.send_action(ComboAction::Discover.into());
-            }
             ComboCommands::Run { name } => {
                 app.send_action(ComboAction::Execute { name }.into());
             }

--- a/crates/coco-tui/src/session.rs
+++ b/crates/coco-tui/src/session.rs
@@ -4,7 +4,9 @@ use snafu::prelude::*;
 
 use crate::error::Result;
 
+mod fs;
 mod registries;
+pub use fs::*;
 pub use registries::*;
 
 /// A serialized session state that can be saved and restored.

--- a/crates/coco-tui/src/session.rs
+++ b/crates/coco-tui/src/session.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::Value;
+use snafu::prelude::*;
+
+use crate::error::Result;
+
+mod registries;
+pub use registries::*;
+
+/// A serialized session state that can be saved and restored.
+///
+/// This type alias represents session data that has been serialized to JSON format,
+/// allowing components to persist their state across application sessions.
+pub type Session = Value;
+
+/// Serializes a value into a session-compatible JSON value.
+///
+/// # Arguments
+/// * `session` - The value to serialize
+///
+/// # Panics
+/// Panics if serialization fails
+pub fn save<T>(session: T) -> Session
+where
+    T: Serialize,
+{
+    serde_json::to_value(session).expect("failed to save session")
+}
+
+/// Deserializes a session JSON value back into its original type.
+///
+/// # Arguments
+/// * `session` - The session value to deserialize
+///
+/// # Returns
+/// Returns the deserialized value or an error if deserialization fails
+pub fn load<T>(session: Session) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(session).whatever_context("failed to load session")
+}
+
+#[derive(Serialize, Deserialize)]
+struct Relate<T, Y> {
+    pub t: T,
+    pub y: Y,
+}
+
+impl<T, Y> Relate<T, Y> {
+    pub fn new(t: T, y: Y) -> Self {
+        Self { t, y }
+    }
+}
+
+/// Serializes two related values into a session-compatible JSON value.
+///
+/// This function creates a relationship between two values of potentially different types
+/// and serializes them together into a single session value.
+///
+/// # Arguments
+/// * `t` - The first value to serialize
+/// * `y` - The second value to serialize
+///
+/// # Panics
+/// Panics if serialization fails
+pub fn save_related<T, Y>(t: T, y: Y) -> Session
+where
+    T: Serialize,
+    Y: Serialize,
+{
+    let inst = Relate::new(t, y);
+    serde_json::to_value(inst).expect("faild to save session")
+}
+
+/// Deserializes a session JSON value containing two related values back into their original types.
+///
+/// This function reverses the `relate` operation, extracting the two related values
+/// that were previously stored together in a session.
+///
+/// # Arguments
+/// * `value` - The session value containing the related values
+///
+/// # Returns
+/// Returns a tuple of the two deserialized values or an error if deserialization fails
+pub fn load_related<T, Y>(value: Session) -> Result<(T, Y)>
+where
+    T: DeserializeOwned,
+    Y: DeserializeOwned,
+{
+    let inst: Relate<T, Y> =
+        serde_json::from_value(value).whatever_context("failed to load session")?;
+    Ok((inst.t, inst.y))
+}

--- a/crates/coco-tui/src/session/fs.rs
+++ b/crates/coco-tui/src/session/fs.rs
@@ -84,14 +84,18 @@ pub async fn list_session(session_dir: &Path) -> Result<Vec<PersistentSessionMet
         }
 
         if let Some(extension) = file_path.extension().and_then(|e| e.to_str()) {
-            if extension != "metadata" {
+            if extension != "json" {
                 continue;
             }
+
             let file_name = file_path
                 .file_name()
                 .and_then(|name| name.to_str())
                 .unwrap_or_default()
                 .to_string();
+            if !file_name.contains("metadata") {
+                continue;
+            }
 
             if let Some(file_path_str) = file_path.to_str() {
                 match load_session_metadata(session_dir, &file_name).await {

--- a/crates/coco-tui/src/session/fs.rs
+++ b/crates/coco-tui/src/session/fs.rs
@@ -1,0 +1,149 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use snafu::prelude::*;
+use tracing::warn;
+
+use super::Session;
+use crate::error::Result;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistentSessionMetadata {
+    pub name: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: time::OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: time::OffsetDateTime,
+}
+
+impl PersistentSessionMetadata {
+    pub fn filename(&self) -> String {
+        format!("{}.json", self.created_at.unix_timestamp_nanos())
+    }
+
+    pub fn metadata_filename(&self) -> String {
+        format!("{}.metadata.json", self.created_at.unix_timestamp_nanos())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PersistentSession {
+    pub name: String,
+    pub inner: Session,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: time::OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: time::OffsetDateTime,
+}
+
+impl PersistentSession {
+    pub fn filename(&self) -> String {
+        format!("{}.json", self.created_at.unix_timestamp_nanos())
+    }
+
+    pub fn to_metadata(&self) -> PersistentSessionMetadata {
+        PersistentSessionMetadata {
+            name: self.name.clone(),
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+}
+
+async fn load_session_metadata(
+    session_dir: &Path,
+    filename: &str,
+) -> Result<PersistentSessionMetadata> {
+    let file_path = session_dir.join(filename);
+    let json = tokio::fs::read_to_string(&file_path)
+        .await
+        .whatever_context("failed to read session metadata from file")?;
+
+    let metadata: PersistentSessionMetadata =
+        serde_json::from_str(&json).whatever_context("failed to deserialize session metadata")?;
+
+    Ok(metadata)
+}
+
+pub async fn list_session(session_dir: &Path) -> Result<Vec<PersistentSessionMetadata>> {
+    let mut sessions = Vec::new();
+
+    let mut entries = tokio::fs::read_dir(session_dir)
+        .await
+        .whatever_context("failed to read session directory")?;
+
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .whatever_context("failed to read directory entry")?
+    {
+        let file_path = entry.path();
+
+        if !file_path.is_file() {
+            continue;
+        }
+
+        if let Some(extension) = file_path.extension().and_then(|e| e.to_str()) {
+            if extension != "metadata" {
+                continue;
+            }
+            let file_name = file_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+
+            if let Some(file_path_str) = file_path.to_str() {
+                match load_session_metadata(session_dir, &file_name).await {
+                    Ok(metadata) => sessions.push(metadata),
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            path = file_path_str,
+                            "failed to load session metadata"
+                        );
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(sessions)
+}
+
+pub async fn save_session(session_dir: &Path, session: PersistentSession) -> Result<()> {
+    // Save full session
+    let json =
+        serde_json::to_string_pretty(&session).whatever_context("failed to serialize session")?;
+
+    let session_path = session_dir.join(session.filename());
+    tokio::fs::write(&session_path, json)
+        .await
+        .whatever_context("failed to write session to file")?;
+
+    // Save metadata
+    let metadata = session.to_metadata();
+    let metadata_json =
+        serde_json::to_string_pretty(&metadata).whatever_context("failed to serialize metadata")?;
+
+    let metadata_path = session_dir.join(metadata.metadata_filename());
+    tokio::fs::write(&metadata_path, metadata_json)
+        .await
+        .whatever_context("failed to write metadata to file")?;
+
+    Ok(())
+}
+
+pub async fn load_session(session_dir: &Path, filename: &str) -> Result<PersistentSession> {
+    let file_path = session_dir.join(filename);
+
+    let json = tokio::fs::read_to_string(&file_path)
+        .await
+        .whatever_context("failed to read session from file")?;
+
+    let session: PersistentSession =
+        serde_json::from_str(&json).whatever_context("failed to deserialize session")?;
+
+    Ok(session)
+}

--- a/crates/coco-tui/src/session/registries.rs
+++ b/crates/coco-tui/src/session/registries.rs
@@ -1,0 +1,93 @@
+use std::{collections::HashMap, sync::Mutex};
+
+use lazy_static::lazy_static;
+use snafu::prelude::*;
+
+use super::Session;
+use crate::{
+    components::{Component, ContentComponent},
+    error::Result,
+};
+
+type Registry = HashMap<&'static str, fn(Session) -> Result<Box<dyn Component>>>;
+type ContentRegistry = HashMap<&'static str, fn(Session) -> Result<Box<dyn ContentComponent>>>;
+
+lazy_static! {
+    static ref COMPONENT_REGISTRY: Mutex<Registry> = Mutex::new(Registry::new());
+    static ref CONTENT_COMPONENT_REGISTRY: Mutex<ContentRegistry> =
+        Mutex::new(ContentRegistry::new());
+}
+
+/// Registers a component factory function for the given type identifier.
+///
+/// # Arguments
+///
+/// * `type_id` - The unique identifier for the component type
+/// * `load` - The factory function that creates the component
+pub fn register_component(type_id: &'static str, load: fn(Session) -> Result<Box<dyn Component>>) {
+    let mut registry = COMPONENT_REGISTRY.lock().unwrap();
+    registry.insert(type_id, load);
+}
+
+/// Registers a content component factory function for the given type identifier.
+///
+/// # Arguments
+///
+/// * `type_id` - The unique identifier for the content component type
+/// * `load` - The factory function that creates the content component
+pub fn register_content_component(
+    type_id: &'static str,
+    load: fn(Session) -> Result<Box<dyn ContentComponent>>,
+) {
+    let mut registry = CONTENT_COMPONENT_REGISTRY.lock().unwrap();
+    registry.insert(type_id, load);
+}
+
+/// Loads a component by its type identifier using the provided session.
+///
+/// # Arguments
+///
+/// * `type_id` - The identifier of the component type to load
+/// * `session` - The session context for component creation
+///
+/// # Returns
+///
+/// Returns a boxed component if the type identifier is registered
+///
+/// # Errors
+///
+/// Returns an error if the type identifier is not found in the registry
+pub fn load_component(type_id: &str, session: Session) -> Result<Box<dyn Component>> {
+    let registry = COMPONENT_REGISTRY.lock().unwrap();
+    let load = registry
+        .get(type_id)
+        .whatever_context(format!("Unknown type_id: {type_id}"))?;
+
+    load(session)
+}
+
+/// Loads a content component by its type identifier using the provided session.
+///
+/// # Arguments
+///
+/// * `type_id` - The identifier of the content component type to load
+/// * `session` - The session context for component creation
+///
+/// # Returns
+///
+/// Returns a boxed content component if the type identifier is registered
+///
+/// # Errors
+///
+/// Returns an error if the type identifier is not found in the registry
+pub fn load_content_component(
+    type_id: &str,
+    session: Session,
+) -> Result<Box<dyn ContentComponent>> {
+    let registry = CONTENT_COMPONENT_REGISTRY.lock().unwrap();
+    let load = registry
+        .get(type_id)
+        .whatever_context(format!("Unknown type_id: {type_id}"))?;
+
+    load(session)
+}

--- a/crates/coco-tui/src/session/registries.rs
+++ b/crates/coco-tui/src/session/registries.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+};
 
 use lazy_static::lazy_static;
 use snafu::prelude::*;
@@ -18,13 +21,24 @@ lazy_static! {
         Mutex::new(ContentRegistry::new());
 }
 
+static FINALIZED_COMPONENT_REGISTRY: OnceLock<Registry> = OnceLock::new();
+static FINALIZED_CONTENT_COMPONENT_REGISTRY: OnceLock<ContentRegistry> = OnceLock::new();
+
 /// Registers a component factory function for the given type identifier.
 ///
 /// # Arguments
 ///
 /// * `type_id` - The unique identifier for the component type
 /// * `load` - The factory function that creates the component
+///
+/// # Panics
+///
+/// Panics if the component registry has already been finalized
 pub fn register_component(type_id: &'static str, load: fn(Session) -> Result<Box<dyn Component>>) {
+    if FINALIZED_COMPONENT_REGISTRY.get().is_some() {
+        panic!("component registry is already finalized!")
+    }
+
     let mut registry = COMPONENT_REGISTRY.lock().unwrap();
     registry.insert(type_id, load);
 }
@@ -35,10 +49,18 @@ pub fn register_component(type_id: &'static str, load: fn(Session) -> Result<Box
 ///
 /// * `type_id` - The unique identifier for the content component type
 /// * `load` - The factory function that creates the content component
+///
+/// # Panics
+///
+/// Panics if the content component registry has already been finalized
 pub fn register_content_component(
     type_id: &'static str,
     load: fn(Session) -> Result<Box<dyn ContentComponent>>,
 ) {
+    if FINALIZED_CONTENT_COMPONENT_REGISTRY.get().is_some() {
+        panic!("content component registry is already finalized!")
+    }
+
     let mut registry = CONTENT_COMPONENT_REGISTRY.lock().unwrap();
     registry.insert(type_id, load);
 }
@@ -58,7 +80,11 @@ pub fn register_content_component(
 ///
 /// Returns an error if the type identifier is not found in the registry
 pub fn load_component(type_id: &str, session: Session) -> Result<Box<dyn Component>> {
-    let registry = COMPONENT_REGISTRY.lock().unwrap();
+    let registry = FINALIZED_COMPONENT_REGISTRY.get_or_init(|| {
+        let registry = COMPONENT_REGISTRY.lock().unwrap();
+        registry.clone()
+    });
+
     let load = registry
         .get(type_id)
         .whatever_context(format!("Unknown type_id: {type_id}"))?;
@@ -84,7 +110,11 @@ pub fn load_content_component(
     type_id: &str,
     session: Session,
 ) -> Result<Box<dyn ContentComponent>> {
-    let registry = CONTENT_COMPONENT_REGISTRY.lock().unwrap();
+    let registry = FINALIZED_CONTENT_COMPONENT_REGISTRY.get_or_init(|| {
+        let registry = CONTENT_COMPONENT_REGISTRY.lock().unwrap();
+        registry.clone()
+    });
+
     let load = registry
         .get(type_id)
         .whatever_context(format!("Unknown type_id: {type_id}"))?;

--- a/crates/code-highlight/src/lang.rs
+++ b/crates/code-highlight/src/lang.rs
@@ -1,9 +1,10 @@
+use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use tree_sitter_highlight::HighlightConfiguration;
 
 use super::Result;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Lang {
     Bash,
     Diff,

--- a/src/combo/starter.rs
+++ b/src/combo/starter.rs
@@ -1,5 +1,6 @@
 use std::process::Stdio;
 
+use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use tokio::{
     fs,
@@ -46,7 +47,7 @@ pub async fn discover_combo_starters(path: &str) -> Vec<Starter> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LineContent {
     Stdout(String),
     Stderr(String),
@@ -61,7 +62,7 @@ impl std::fmt::Display for LineContent {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Line {
     pub timestamp: i64,
     pub content: LineContent,

--- a/src/text_edit.rs
+++ b/src/text_edit.rs
@@ -4,7 +4,9 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Default, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, Serialize, Deserialize)]
 pub struct TextEdit {
     pub path: PathBuf,
     pub origin: Arc<String>,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 macro_rules! err_msg {
@@ -61,7 +62,7 @@ impl From<TextEdit> for Output {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Final {
     Json(Value),
     Message(String),

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -17,7 +17,7 @@ pub struct BashInput {
     pub timeout: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BashOutput {
     pub exit_code: u8,
     pub stdout: String,

--- a/src/tools/read.rs
+++ b/src/tools/read.rs
@@ -9,7 +9,7 @@ use super::{ExecuteResult, Final, Input, Tool};
 #[derive(Default)]
 pub struct ReadTool {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadInput {
     pub path: String,
     #[serde(default = "default_line_offset")]


### PR DESCRIPTION
## Summary

   - Implements session resuming system with component persistence
   - Adds command palette with New Session command for session management
   - Integrates session restoration with CLI flag support
   - Implements automatic session persistence with debounced saving
   - Updates serde dependencies with rc feature for improved serialization
   - Adds draw_components example for testing component persistences
   - Adds a new crate "coco-macro"