### PR TITLE
feat: implement custom Paragraph widget with safe tab rendering

### DIFF
--- a/crates/coco-tui/Cargo.toml
+++ b/crates/coco-tui/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.3.31"
 ratatui = { version = "0.29.0", features = [
   "serde",
   "unstable-rendered-line-info",
+  "unstable-widget-ref",
 ] }
 code-highlight = { path = "../code-highlight" }
 throbber-widgets-tui = "0.9.0"

--- a/crates/coco-tui/src/components/code_highlight.rs
+++ b/crates/coco-tui/src/components/code_highlight.rs
@@ -5,7 +5,7 @@ use ratatui::{
     prelude::Rect,
     style::Style,
     text::{Line, Span, Text},
-    widgets::{Paragraph, Wrap},
+    widgets::Wrap,
 };
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
@@ -17,6 +17,7 @@ use crate::{
     error::Result,
     global,
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -78,10 +79,10 @@ impl<'a> CodeHighlight<'a> {
             }
         }
         lines.push(line);
-        let widget = Paragraph::new(Text::from(
-            lines.into_iter().map(Line::from).collect::<Vec<_>>(),
-        ))
-        .wrap(Wrap { trim: false });
+        let widget = Paragraph::new_wrap(
+            Text::from(lines.into_iter().map(Line::from).collect::<Vec<_>>()),
+            Wrap { trim: false },
+        );
         Ok(Self {
             state: State {
                 source: source.to_string(),

--- a/crates/coco-tui/src/components/command_palette.rs
+++ b/crates/coco-tui/src/components/command_palette.rs
@@ -8,7 +8,7 @@ use ratatui::{
     prelude::Rect,
     symbols::border,
     text::Text,
-    widgets::{Block, Borders, Clear, Paragraph, Widget},
+    widgets::{Block, Borders, Clear, Widget},
 };
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +18,7 @@ use crate::{
     error::Result,
     global::{self, State},
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -113,8 +114,11 @@ impl CommandPalette {
                     Layout::horizontal([Percentage(50), Percentage(50)]).areas(area);
 
                 frame.render_widget(
-                    Paragraph::new(Text::from(shortcut.to_owned()).style(theme.ui.shortcut))
-                        .right_aligned(),
+                    Paragraph::new(
+                        Text::from(shortcut.to_owned())
+                            .style(theme.ui.shortcut)
+                            .right_aligned(),
+                    ),
                     right,
                 );
 

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -7,7 +7,7 @@ use ratatui::{
     prelude::Rect,
     style::Stylize,
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders},
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -19,6 +19,7 @@ use crate::{
     events::{ComboEvent, Event},
     global::{self, State},
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(Serialize, Deserialize)]

--- a/crates/coco-tui/src/components/messages/plain.rs
+++ b/crates/coco-tui/src/components/messages/plain.rs
@@ -35,10 +35,6 @@ impl Plain {
     pub fn new(text: String) -> Self {
         let cfg = global::config_sync();
 
-        // '\t' rendering doesn't work well in ratatui.
-        // It causes the screen to retain the previous render result in the area of `\t` during scrolling.
-        let text = text.replace("\t", "  ");
-
         let rx = match cfg.ui.markdown_render_engine {
             MarkdownRenderEngine::ExternalCommand { executable, args } => {
                 let (tx, rx) = oneshot::channel();

--- a/crates/coco-tui/src/components/messages/plain/external_viewer.rs
+++ b/crates/coco-tui/src/components/messages/plain/external_viewer.rs
@@ -2,11 +2,7 @@ use std::process::Stdio;
 
 use ansi_to_tui::IntoText;
 use coco_macro::{ComponentExt, ContentComponentExt};
-use ratatui::{
-    Frame,
-    layout::Rect,
-    widgets::{Paragraph, Wrap},
-};
+use ratatui::{Frame, layout::Rect, widgets::Wrap};
 use snafu::prelude::*;
 use tokio::io::AsyncWriteExt;
 
@@ -14,6 +10,7 @@ use crate::{
     components::{Component, Content, ContentComponent, Persistable},
     error::*,
     session::Session,
+    widgets::Paragraph,
 };
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -49,7 +46,7 @@ impl<'a> ExternalMarkdownViewer<'a> {
             .stdout
             .into_text()
             .whatever_context("failed to convert the external markdown viewer result")?;
-        let widget = Paragraph::new(text).wrap(Wrap { trim: false });
+        let widget = Paragraph::new_wrap(text, Wrap { trim: false });
         Ok(Self { widget })
     }
 }

--- a/crates/coco-tui/src/components/messages/plain/raw.rs
+++ b/crates/coco-tui/src/components/messages/plain/raw.rs
@@ -1,14 +1,11 @@
 use coco_macro::{ComponentExt, ContentComponentExt};
-use ratatui::{
-    Frame,
-    prelude::Rect,
-    widgets::{Paragraph, Wrap},
-};
+use ratatui::{Frame, prelude::Rect, widgets::Wrap};
 
 use crate::{
     components::{Component, Content, ContentComponent, Persistable},
     error::*,
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -23,7 +20,7 @@ impl<'a> RawTextViewer<'a> {
     pub fn new(text: String) -> Self {
         Self {
             text: text.clone(),
-            widget: Paragraph::new(text).wrap(Wrap { trim: false }),
+            widget: Paragraph::new_wrap(text, Wrap { trim: false }),
         }
     }
 }

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -12,7 +12,7 @@ use ratatui::{
     prelude::Rect,
     style::Stylize,
     text::{Line, Span},
-    widgets::{Block, Paragraph, Wrap},
+    widgets::{Block, Wrap},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -27,6 +27,7 @@ use crate::{
     events::{AnswerEvent, AskEvent, Event},
     global::{self, State},
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -51,12 +52,7 @@ fn generate_output<'a>(output: Option<BashOutput>) -> Paragraph<'a> {
         .map(|output| (output.stderr, output.stdout))
         .unwrap_or_default();
 
-    // '\t' rendering doesn't work well in ratatui.
-    // It causes the screen to retain the previous render result in the area of `\t` during scrolling.
-    for (prompt, output) in [
-        ("2> ".red(), &stderr.replace("\t", "  ")),
-        ("1> ".blue(), &stdout.replace("\t", "  ")),
-    ] {
+    for (prompt, output) in [("2> ".red(), &stderr), ("1> ".blue(), &stdout)] {
         if output.is_empty() {
             continue;
         }
@@ -66,7 +62,7 @@ fn generate_output<'a>(output: Option<BashOutput>) -> Paragraph<'a> {
             lines.push(Line::from(line));
         }
     }
-    Paragraph::new(lines).wrap(Wrap { trim: false })
+    Paragraph::new_wrap(lines, Wrap { trim: false })
 }
 
 fn generate_input<'b>(tool_use: &ToolUse) -> CodeHighlight<'b> {

--- a/crates/coco-tui/src/components/messages/tool/raw.rs
+++ b/crates/coco-tui/src/components/messages/tool/raw.rs
@@ -1,11 +1,7 @@
 use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{ToolUse, tools::Final};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use ratatui::{
-    Frame,
-    prelude::Rect,
-    widgets::{Paragraph, Wrap},
-};
+use ratatui::{Frame, prelude::Rect, widgets::Wrap};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -15,6 +11,7 @@ use crate::{
     events::{AnswerEvent, Event},
     global::{self, State},
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -47,7 +44,7 @@ fn generate_widget<'b>(tool_use: &ToolUse, output: &Option<Final>) -> Paragraph<
         text.push('\n');
         text.push_str(&output);
     }
-    Paragraph::new(text).wrap(Wrap { trim: false })
+    Paragraph::new_wrap(text, Wrap { trim: false })
 }
 
 impl<'a> Raw<'a> {

--- a/crates/coco-tui/src/components/messages/tool/read.rs
+++ b/crates/coco-tui/src/components/messages/tool/read.rs
@@ -10,7 +10,7 @@ use ratatui::{
     prelude::Rect,
     style::Stylize,
     text::{Line, Span, Text},
-    widgets::{Block, Paragraph, Wrap},
+    widgets::{Block, Wrap},
 };
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +20,7 @@ use crate::{
     events::{AnswerEvent, Event},
     global::State,
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -67,11 +68,11 @@ fn generate_input_widget<'a>(input: ReadInput) -> Paragraph<'a> {
         ]));
     }
 
-    Paragraph::new(lines).wrap(Wrap { trim: false })
+    Paragraph::new_wrap(lines, Wrap { trim: false })
 }
 
 fn generate_output_widget<'a>(output: String) -> Paragraph<'a> {
-    Paragraph::new(Text::from(output)).wrap(Wrap { trim: false })
+    Paragraph::new_wrap(Text::from(output), Wrap { trim: false })
 }
 
 impl Read<'_> {

--- a/crates/coco-tui/src/components/messages/tool/str_replace.rs
+++ b/crates/coco-tui/src/components/messages/tool/str_replace.rs
@@ -4,13 +4,7 @@ use code_combo::{
     tools::{Final, STR_REPLACE_TOOL_NAME},
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use ratatui::{
-    Frame,
-    prelude::Rect,
-    style::Stylize,
-    text::Text,
-    widgets::{Block, Paragraph},
-};
+use ratatui::{Frame, prelude::Rect, style::Stylize, text::Text, widgets::Block};
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use tracing::warn;
@@ -23,6 +17,7 @@ use crate::{
     events::{AnswerEvent, AskEvent, Event},
     global::{self, State},
     session::{self, Session},
+    widgets::Paragraph,
 };
 
 #[derive(Serialize, Deserialize)]

--- a/crates/coco-tui/src/lib.rs
+++ b/crates/coco-tui/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app;
 pub mod error;
 pub mod global;
 pub mod session;
+pub mod widgets;
 #[macro_use]
 pub mod components;
 pub mod events;

--- a/crates/coco-tui/src/theme.rs
+++ b/crates/coco-tui/src/theme.rs
@@ -75,6 +75,7 @@ build_theme_type!(FinalizedUiTheme {
     bot_role,
     shortcut,
     shortcut_desc,
+    tab_spaces,
 });
 
 impl Theme {
@@ -100,6 +101,7 @@ impl Theme {
                     bot_role,
                     shortcut,
                     shortcut_desc,
+                    tab_spaces,
                 }
             )?,
             tree_sitter,

--- a/crates/coco-tui/src/widgets.rs
+++ b/crates/coco-tui/src/widgets.rs
@@ -1,0 +1,3 @@
+mod paragraph;
+
+pub use paragraph::*;

--- a/crates/coco-tui/src/widgets/paragraph.rs
+++ b/crates/coco-tui/src/widgets/paragraph.rs
@@ -1,0 +1,230 @@
+use ratatui::{
+    prelude::{Buffer, Rect},
+    text::{Line, Span, Text},
+    widgets::{Widget, WidgetRef, Wrap},
+};
+
+use crate::global;
+
+/// Customized Paragraph to safely render characters.
+///
+/// The standard ratatui Paragraph widget has issues with tab character (`\t`) rendering.
+/// When scrolling, the area occupied by a tab character may retain previous render content,
+/// causing visual artifacts. This wrapper ensures safe rendering by handling such edge cases.
+pub struct Paragraph<'a> {
+    inner: ratatui::widgets::Paragraph<'a>,
+}
+
+impl<'a> Paragraph<'a> {
+    pub fn new<T>(text: T) -> Self
+    where
+        T: Into<Text<'a>>,
+    {
+        let mut text: Text = text.into();
+        for line in &mut text.lines {
+            safe_line(line);
+        }
+        Self {
+            inner: ratatui::widgets::Paragraph::new(text),
+        }
+    }
+
+    pub fn new_wrap<T>(text: T, wrap: Wrap) -> Self
+    where
+        T: Into<Text<'a>>,
+    {
+        let mut text: Text = text.into();
+        for line in &mut text.lines {
+            safe_line(line);
+        }
+        Self {
+            inner: ratatui::widgets::Paragraph::new(text).wrap(wrap),
+        }
+    }
+
+    pub fn line_count(&self, width: u16) -> usize {
+        self.inner.line_count(width)
+    }
+}
+
+impl WidgetRef for Paragraph<'static> {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        self.inner.render_ref(area, buf);
+    }
+}
+
+impl Widget for Paragraph<'static> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        self.inner.render(area, buf);
+    }
+}
+
+const TAB_STOP: usize = 4;
+
+/// Replace specific characters like `\t` to avoid rendering issues or provide stylized looking in ratatui.
+///
+/// This function processes a line of text and replaces problematic characters:
+/// - Tab characters (`\t`) are replaced with a visible tab indicator ("▸" followed by spaces)
+/// - Space characters at tab stop boundaries are replaced with "│" (a visible space indicator)
+///
+/// These replacements prevent visual artifacts that can occur when ratatui renders
+/// these characters, particularly during scrolling operations.
+///
+/// # Tab Stop Alignment
+///
+/// The function maintains proper tab stop alignment with a tab stop size of 4 columns.
+/// The tab indicator ("▸") is positioned based on the current column position:
+/// - At column 0 (mod 4): "▸   " (4 columns)
+/// - At column 1 (mod 4): "▸  " (3 columns)
+/// - At column 2 (mod 4): "▸ " (2 columns)
+/// - At column 3 (mod 4): "▸" (1 column)
+///
+/// This ensures that the next character after a tab starts at the next tab stop boundary.
+///
+/// # Space Handling
+///
+/// Space characters at tab stop boundaries (every 4 columns) are replaced with "│"
+/// when they are at the start of a line or adjacent to another space character.
+/// This makes indentation levels visible while maintaining proper column alignment.
+/// Single isolated spaces at tab boundaries that are not part of an indentation
+/// sequence are preserved as-is.
+///
+/// # Styling
+///
+/// The visual markers ("▸" for tabs and "│" for spaces) inherit the `tab_spaces`
+/// style from the current theme, allowing consistent theming across the application.
+/// Regular text preserves its original style.
+fn safe_line(line: &mut Line) {
+    let theme = global::theme();
+    let tab_spaces_style = theme.ui.tab_spaces;
+
+    let mut new_spans = Vec::with_capacity(line.spans.len());
+    let mut col = 0;
+    for span in &line.spans {
+        let content = &span.content;
+        let chars = content.chars().collect::<Vec<_>>();
+        let mut i = 0;
+        let mut width = 0;
+
+        while i < chars.len() {
+            if chars[i] == '\t' {
+                let (sep, sep_width) = match (col + width) % TAB_STOP {
+                    0 => ("▸   ", 4),
+                    1 => ("▸  ", 3),
+                    2 => ("▸ ", 2),
+                    3 => ("▸", 1),
+                    _ => unreachable!(),
+                };
+                new_spans.push(Span::styled(sep, tab_spaces_style));
+                i += 1;
+                width += sep_width;
+            } else if chars[i] == ' '
+                && (col + width) % TAB_STOP == 0
+                && (i == 0 || chars[i - 1] == ' ' || (i + 1 < chars.len() && chars[i + 1] == ' '))
+            {
+                new_spans.push(Span::styled("│", tab_spaces_style));
+                i += 1;
+                width += 1;
+            } else {
+                // Collect regular characters
+                let start = i;
+                while i < chars.len()
+                    && chars[i] != '\t'
+                    && !(chars[i] == ' '
+                        && (col + width) % TAB_STOP == 0
+                        && (i == 0
+                            || chars[i - 1] == ' '
+                            || (i + 1 < chars.len() && chars[i + 1] == ' ')))
+                {
+                    i += 1;
+                    width += 1;
+                }
+
+                let regular_content = chars[start..i].iter().collect::<String>();
+                if !regular_content.is_empty() {
+                    new_spans.push(Span::styled(regular_content, span.style));
+                }
+            }
+        }
+        col += width
+    }
+    line.spans = new_spans;
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn simple() {
+        let widget = Paragraph::new("\t\tHello\n\tWorld\n    Hello\n    World");
+
+        let mut terminal = Terminal::new(TestBackend::new(17, 4)).unwrap();
+        terminal
+            .draw(|frame| widget.render(frame.area(), frame.buffer_mut()))
+            .unwrap();
+
+        let mut expected = Buffer::with_lines(vec![
+            "▸   ▸   Hello    ",
+            "▸   World        ",
+            "│   Hello        ",
+            "│   World        ",
+        ]);
+
+        // Apply the tab_spaces style to the special symbols
+        let tab_spaces_style = global::theme().ui.tab_spaces;
+
+        // Style the first tab symbol on line 0 (positions 0-3)
+        expected.set_style(Rect::new(0, 0, 4, 1), tab_spaces_style);
+        // Style the second tab symbol on line 0 (positions 4-7)
+        expected.set_style(Rect::new(4, 0, 4, 1), tab_spaces_style);
+
+        // Style the tab symbol on line 1
+        expected.set_style(Rect::new(0, 1, 4, 1), tab_spaces_style);
+
+        // Style the space symbol on line 2
+        expected.set_style(Rect::new(0, 2, 1, 1), tab_spaces_style);
+
+        // Style the space symbol on line 3
+        expected.set_style(Rect::new(0, 3, 1, 1), tab_spaces_style);
+
+        assert_eq!(terminal.backend().buffer(), &expected);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tab_stop() {
+        let widget = Paragraph::new("ab\t\tHello\n\tWorld\n     Hello\n+      World");
+
+        let mut terminal = Terminal::new(TestBackend::new(17, 4)).unwrap();
+        terminal
+            .draw(|frame| widget.render(frame.area(), frame.buffer_mut()))
+            .unwrap();
+
+        let mut expected = Buffer::with_lines(vec![
+            "ab▸ ▸   Hello    ",
+            "▸   World        ",
+            "│   │Hello       ",
+            "+   │  World     ",
+        ]);
+
+        // Apply the tab_spaces style to the special symbols
+        let tab_spaces_style = global::theme().ui.tab_spaces;
+
+        // Style the first tab symbol on line 0
+        expected.set_style(Rect::new(2, 0, 6, 1), tab_spaces_style);
+
+        // Style the tab symbol on line 1
+        expected.set_style(Rect::new(0, 1, 4, 1), tab_spaces_style);
+
+        // Style the space symbol on line 2
+        expected.set_style(Rect::new(0, 2, 1, 1), tab_spaces_style);
+        expected.set_style(Rect::new(4, 2, 1, 1), tab_spaces_style);
+
+        // Style the space symbol on line 3
+        expected.set_style(Rect::new(4, 3, 1, 1), tab_spaces_style);
+
+        assert_eq!(terminal.backend().buffer(), &expected);
+    }
+}

--- a/crates/coco-tui/theme/catppuccin_scheme.json
+++ b/crates/coco-tui/theme/catppuccin_scheme.json
@@ -12,7 +12,8 @@
             "fg": "blue",
             "add_modifier": "BOLD|ITALIC"
         },
-        "shortcut_desc": "overlay0"
+        "shortcut_desc": "overlay0",
+        "tab_spaces": "overlay0"
     },
     "tree_sitter": {
         "string": "green",


### PR DESCRIPTION
- Add custom Paragraph widget wrapper to fix ratatui tab character rendering issues
- Replace problematic tab characters with visible indicators ('▸' + spaces) to prevent visual artifacts during scrolling
- Add space character handling at tab stop boundaries with '│' indicators for visible indentation
- Implement tab stop alignment with 4-column tab stops and proper column positioning
- Add theme support with new 'tab_spaces' style for customizing visual indicators
- Update all message components to use the new Paragraph widget instead of ratatui's Paragraph
- Enable 'unstable-widget-ref' feature in ratatui dependency for widget reference support
- Add comprehensive unit tests for tab stop alignment and rendering behavior
- Remove manual tab replacement logic from plain text and bash output components