### PR TITLE
feat: add Nix build support and build-time version information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,12 +346,14 @@ dependencies = [
  "similar",
  "snafu",
  "tempfile",
+ "time",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-md",
+ "which",
 ]
 
 [[package]]
@@ -789,6 +791,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.0",
+]
 
 [[package]]
 name = "http"
@@ -2585,6 +2596,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +2893,12 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ tree-sitter = { version = "0.25" }
 tree-sitter-md = { version = "0.3.2" }
 indoc = "2.0.6"
 lazy_static = "1.5.0"
+time = { version = "0.3.44" }
+chrono = { version = "0.4" }
 
 # Core dependencies for CLI and application functionality
 [dependencies]
@@ -33,7 +35,7 @@ lazy_static = "1.5.0"
 anthropic = { path = "./crates/anthropic" }
 
 # Datetime utilities
-chrono = "0.4.42"
+chrono.workspace = true
 
 # Command line argument parsing
 clap = { version = "4.5.47", features = ["derive"] }
@@ -66,7 +68,11 @@ similar = "2.7.0"
 
 [dev-dependencies]
 ctor.workspace = true
+which = "6.0"
 tempfile = "3.22.0"
+
+[build-dependencies]
+time = { workspace = true, features = ["formatting"] }
 
 [patch.crates-io]
 tree-sitter-diff = { git = "https://github.com/tree-sitter-grammars/tree-sitter-diff.git", tag = "v0.1.0" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,103 @@
+use std::env;
+use std::process::Command;
+
+use time::format_description::well_known::Rfc3339;
+
+fn main() {
+    emit_git_commit_sha();
+    emit_git_dirty_status();
+    emit_built_time_utc();
+
+    // Tell cargo to rerun this script if .git/HEAD changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    // Also watch the current branch ref file for new commits
+    if let Ok(head_content) = std::fs::read_to_string(".git/HEAD")
+        && let Some(branch_ref) = head_content.strip_prefix("ref: ").map(|s| s.trim())
+    {
+        println!("cargo:rerun-if-changed=.git/{branch_ref}");
+    }
+}
+
+fn get_git_commit_sha() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+fn get_git_commit_sha_from_packaged() -> Option<String> {
+    let mut packaged = std::path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    packaged.push(".packaged-commit");
+    std::fs::read_to_string(&packaged)
+        .ok()
+        .and_then(|contents| contents.trim().to_string().into())
+}
+
+fn get_git_dirty_status() -> Option<String> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let is_dirty = !output.stdout.is_empty();
+        Some(if is_dirty { "true" } else { "false" }.to_string())
+    } else {
+        None
+    }
+}
+
+fn emit_git_commit_sha() {
+    println!("cargo:rerun-if-env-changed=GIT_COMMIT_SHA");
+
+    // Get Git commit SHA
+    // - packaged commit SHA overrides env var
+    // - env var overrides .git
+    let git_commit_sha = get_git_commit_sha_from_packaged()
+        .or_else(|| env::var("GIT_COMMIT_SHA").ok())
+        .or_else(get_git_commit_sha)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_COMMIT_SHA={git_commit_sha}");
+}
+
+fn emit_git_dirty_status() {
+    println!("cargo:rerun-if-env-changed=GIT_DIRTY");
+
+    // Get Git dirty status - env var overrides .git
+    let git_dirty = env::var("GIT_DIRTY").unwrap_or_else(|_| {
+        // fallback to running git command if not set
+        get_git_dirty_status().unwrap_or_else(|| "unknown".to_string())
+    });
+
+    println!("cargo:rustc-env=GIT_DIRTY={git_dirty}");
+}
+
+fn emit_built_time_utc() {
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
+    // Get build time - SOURCE_DATE_EPOCH overrides current time
+    let build_time = env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|epoch| epoch.parse::<i64>().ok())
+        .map(|timestamp| {
+            time::UtcDateTime::from_unix_timestamp(timestamp)
+                .expect("failed to pase unix timestamp")
+                .format(&Rfc3339)
+                .expect("failed to format datetime")
+        })
+        .unwrap_or_else(|| {
+            // fallback to current time if SOURCE_DATE_EPOCH is not set
+            time::UtcDateTime::now()
+                .format(&Rfc3339)
+                .expect("failed to format datetime")
+        });
+
+    println!("cargo:rustc-env=BUILT_TIME_UTC={build_time}");
+}

--- a/crates/coco-tui/Cargo.toml
+++ b/crates/coco-tui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "coco-tui"
 version.workspace = true
 edition.workspace = true
+build = "../../build.rs"
 
 [[bin]]
 name = "coco"
@@ -55,7 +56,7 @@ ctor.workspace = true
 lazy_static.workspace = true
 bitflags = "2.10.0"
 indoc.workspace = true
-time = { version = "0.3.44", features = [
+time = { workspace = true, features = [
   "macros",
   "serde",
   "local-offset",
@@ -64,3 +65,6 @@ time = { version = "0.3.44", features = [
 ] }
 
 [dev-dependencies]
+
+[build-dependencies]
+time = { workspace = true, features = ["formatting"] }

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::OnceLock};
 
 use clap::{Parser, Subcommand};
 use code_combo::{Config, default_config_dir};
@@ -12,9 +12,31 @@ use coco_tui::{
 };
 use tracing::info;
 
+static LONG_VERSION: OnceLock<String> = OnceLock::new();
+
+fn long_version() -> &'static str {
+    LONG_VERSION
+        .get_or_init(|| {
+            // This closure is executed only once, on the first call to get_or_init
+            let dirty = if env!("GIT_DIRTY") == "true" {
+                "[dirty]"
+            } else {
+                ""
+            };
+            format!(
+                "{} (sha:{:?}, build_time:{:?}){}",
+                env!("CARGO_PKG_VERSION"),
+                env!("GIT_COMMIT_SHA"),
+                env!("BUILT_TIME_UTC"),
+                dirty
+            )
+        })
+        .as_str()
+}
+
 /// Code Combo
 #[derive(Parser)]
-#[command(version, about)]
+#[command(name="coco", version, long_version=long_version(), about)]
 struct Args {
     /// Config file path
     #[arg(long)]

--- a/flake.nix
+++ b/flake.nix
@@ -15,13 +15,82 @@
     utils.lib.eachDefaultSystem
     (
       system: let
+        description = "Agentic Code Combo";
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
             inputs.fenix.overlays.default
           ];
         };
+        lib = pkgs.lib;
+        git_dirty =
+          if (self.sourceInfo ? rev)
+          then "false"
+          else "true";
+        git_commit_sha =
+          self.sourceInfo.rev or (
+            if (self.sourceInfo ? dirtyRev)
+            then lib.strings.removeSuffix "-dirty" self.sourceInfo.dirtyRev
+            else "unknown"
+          );
+        git_last_modified = toString self.sourceInfo.lastModified or "unknown";
       in {
+        packages = rec {
+          default = code-combo;
+          code-combo = let
+            inherit (pkgs.fenix.stable) toolchain;
+            rustPlatform = pkgs.makeRustPlatform {
+              cargo = toolchain;
+              rustc = toolchain;
+            };
+            meta = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+            inherit (meta.package) name;
+            inherit (meta.workspace.package) version;
+          in
+            rustPlatform.buildRustPackage {
+              pname = name;
+              inherit version;
+              meta = {
+                inherit description;
+                mainProgram = "coco";
+              };
+              src = ./.;
+              logLevel = "trace";
+              env = {
+                GIT_COMMIT_SHA = git_commit_sha;
+                GIT_DIRTY = git_dirty;
+                SOURCE_DATE_EPOCH = git_last_modified;
+              };
+              nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux (with pkgs; [pkg-config]);
+              buildInputs = lib.optionals pkgs.stdenv.isLinux (with pkgs; [openssl]);
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+
+                outputHashes = {
+                  "tree-sitter-diff-0.1.0" = "sha256-8rYLNGgoZSvvfqO2++nAgFKmvbkKJ3m+9B8bTXp6Us4=";
+                };
+              };
+              cargoBuildFlags = ["-p" "coco-tui"];
+
+              nativeCheckInputs = with pkgs; [
+                bash
+              ];
+              cargoTestFlags = [
+                "--no-capture"
+              ];
+              useNextest = true;
+            };
+        };
+        apps = rec {
+          default = coco;
+          coco = {
+            type = "app";
+            meta = {
+              inherit description;
+            };
+            program = lib.getExe self.packages.${system}.code-combo;
+          };
+        };
         devShells = let
           components = [
             "cargo"
@@ -46,11 +115,19 @@
                 (fenix.stable.withComponents components)
               ]
               ++ lib.optionals stdenv.isLinux [pkg-config]);
+
             buildInputs = with pkgs; ([]
               ++ lib.optionals stdenv.isLinux [
                 openssl
               ]);
+
             inherit packages;
+
+            shellHook = ''
+              # Unset SOURCE_DATE_EPOCH to prevent reproducible build timestamps during development.
+              # This allows timestamps to reflect the current time, which is useful for development workflows.
+              unset SOURCE_DATE_EPOCH
+            '';
           };
         };
       }

--- a/src/combo/starter.rs
+++ b/src/combo/starter.rs
@@ -178,12 +178,20 @@ pub fn execute_starter(
 mod test {
     use std::os::unix::fs::PermissionsExt;
 
-    use indoc::indoc;
+    use indoc::formatdoc;
     use tempfile::TempDir;
 
     use crate::{ComboMode, Instruction};
 
     use super::*;
+
+    fn find_bash() -> String {
+        // why not `/usr/bin/env`? Because it is not working in the Nix build sandbox
+        which::which("bash")
+            .expect("failed to find bash")
+            .to_string_lossy()
+            .to_string()
+    }
 
     async fn create_temp_combo(
         name: &str,
@@ -213,10 +221,11 @@ mod test {
 
     #[tokio::test]
     async fn execute_starter_abort() -> Result<(), Box<dyn std::error::Error>> {
+        let bash = find_bash();
         let (_guard, file_path) = create_temp_combo(
             "commit.sh",
-            indoc! {r#"
-            #!/usr/bin/env bash
+            formatdoc! {r#"
+            #!{bash}
 
             cat <<EOF
             ---
@@ -232,7 +241,7 @@ mod test {
 
             # Enter to continue, Ctrl-D to abort
             read -rs || exit
-            "#},
+            "#}.as_str(),
         )
             .await?;
 
@@ -257,10 +266,11 @@ mod test {
 
     #[tokio::test]
     async fn execute_starter_continue() -> Result<(), Box<dyn std::error::Error>> {
+        let bash = find_bash();
         let (_guard, file_path) = create_temp_combo(
             "test.sh",
-            indoc! {r#"
-            #!/usr/bin/env bash
+            formatdoc! {r#"
+            #!{bash}
 
             cat <<-EOF
             ---
@@ -274,7 +284,8 @@ mod test {
             read -rs || exit
 
             echo "Hello world"
-            "#},
+            "#}
+            .as_str(),
         )
         .await?;
 


### PR DESCRIPTION
- Add build.rs for embedding Git metadata (commit SHA, dirty status, build time)
- Implement Nix flake with reproducible builds and package definition
- Add version information to CLI with Git commit SHA and build timestamp
- Update Cargo.toml dependencies to use workspace versions
- Fix test dependencies to work in Nix build sandbox
- Add shell hook to unset SOURCE_DATE_EPOCH for development builds
- Include build dependencies for time formatting in build script