### PR TITLE
refactor: improve version display formatting

### DIFF
--- a/crates/coco-tui/src/version.rs
+++ b/crates/coco-tui/src/version.rs
@@ -25,14 +25,19 @@ fn long_version() -> &'static str {
 pub fn long_versions() -> &'static str {
     LONG_VERSIONS
         .get_or_init(|| {
-            let platform = format!("{}; {}", std::env::consts::OS, std::env::consts::ARCH);
             let coco_tui = long_version();
             let code_combo = code_combo::version::long_version();
-            if coco_tui == code_combo {
-                coco_tui.to_string()
-            } else {
-                format!("{coco_tui}\n- code_combo {code_combo}\n- platform: {platform}")
-            }
+
+            let mut lines = vec![coco_tui.to_string()];
+
+            if coco_tui != code_combo {
+                lines.push(format!("- code_combo: {code_combo}"));
+            };
+
+            let platform = format!("{}; {}", std::env::consts::OS, std::env::consts::ARCH);
+            lines.push(format!("- platform: {platform}"));
+
+            lines.join("\n")
         })
         .as_str()
 }


### PR DESCRIPTION
- Restructure long_versions() output for better readability
- Use vector-based line construction instead of conditional formatting
- Ensure consistent formatting with proper indentation
- Maintain platform information display in all cases