### PR TITLE
refactor: replace external throbber dependency with custom implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "throbber-widgets-tui",
  "time",
  "tokio",
  "tokio-util",
@@ -1991,15 +1990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "throbber-widgets-tui"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e58887883fb0a259717b16d68d251983e40850b4b2f45c2da410f46d4333dc"
-dependencies = [
- "ratatui",
 ]
 
 [[package]]

--- a/crates/coco-tui/Cargo.toml
+++ b/crates/coco-tui/Cargo.toml
@@ -35,7 +35,6 @@ ratatui = { version = "0.29.0", features = [
   "unstable-widget-ref",
 ] }
 code-highlight = { path = "../code-highlight" }
-throbber-widgets-tui = "0.9.0"
 ansi-to-tui = "7.0.0"
 tui-textarea = "0.7.0"
 

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -14,7 +14,6 @@ use ratatui::{
 };
 
 use serde::{Deserialize, Serialize};
-use throbber_widgets_tui::{Throbber, ThrobberState};
 use time::OffsetDateTime;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -29,6 +28,7 @@ use crate::{
     error::*,
     global::{self, State},
     session::{self, Session},
+    widgets::{BRAILLE_EIGHT_DOUBLE, Throbber, ThrobberState},
 };
 
 #[derive(ComponentExt)]
@@ -314,9 +314,9 @@ impl Chat<'static> {
             ChatState::Procesing | ChatState::ComboDiscovering => Line::from(vec![
                 " ".into(),
                 Throbber::default()
-                    .throbber_set(throbber_widgets_tui::BRAILLE_EIGHT_DOUBLE)
+                    .throbber_set(BRAILLE_EIGHT_DOUBLE)
                     .to_symbol_span(&self.indicator),
-                format!("{state} ").yellow(),
+                format!(" {state} ").yellow(),
             ]),
         })
         .bold()

--- a/crates/coco-tui/src/widgets.rs
+++ b/crates/coco-tui/src/widgets.rs
@@ -1,3 +1,5 @@
 mod paragraph;
+mod throbber;
 
 pub use paragraph::*;
+pub use throbber::*;

--- a/crates/coco-tui/src/widgets/throbber.rs
+++ b/crates/coco-tui/src/widgets/throbber.rs
@@ -1,0 +1,116 @@
+use ratatui::{
+    prelude::{Buffer, Rect},
+    style::Style,
+    text::Span,
+    widgets::StatefulWidget,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Set {
+    pub full: &'static str,
+    pub empty: &'static str,
+    pub symbols: &'static [&'static str],
+}
+
+pub const BRAILLE_EIGHT_DOUBLE: Set = Set {
+    full: "⣿",
+    empty: "　",
+    symbols: &["⣧", "⣏", "⡟", "⠿", "⢻", "⣹", "⣼", "⣶"],
+};
+
+#[derive(Clone, Debug)]
+pub struct Throbber {
+    set: Set,
+    style: Style,
+}
+
+impl Default for Throbber {
+    fn default() -> Self {
+        Self {
+            set: BRAILLE_EIGHT_DOUBLE,
+            style: Style::default(),
+        }
+    }
+}
+
+impl Throbber {
+    pub fn throbber_set(mut self, set: Set) -> Self {
+        self.set = set;
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub fn to_symbol_span(&self, state: &ThrobberState) -> Span<'static> {
+        Span::styled(state.current_symbol(&self.set), self.style)
+    }
+}
+
+impl StatefulWidget for Throbber {
+    type State = ThrobberState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        if area.is_empty() {
+            return;
+        }
+
+        let symbol = state.current_symbol(&self.set);
+        buf[(area.x, area.y)]
+            .set_symbol(symbol)
+            .set_style(self.style);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ThrobberState {
+    frame: usize,
+}
+
+impl ThrobberState {
+    pub fn calc_next(&mut self) {
+        self.frame = self.frame.wrapping_add(1);
+    }
+
+    fn current_symbol(&self, set: &Set) -> &'static str {
+        if set.symbols.is_empty() {
+            return "";
+        }
+        let idx = self.frame % set.symbols.len();
+        set.symbols[idx]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cycles_symbols() {
+        let mut state = ThrobberState::default();
+        let throbber = Throbber::default().throbber_set(BRAILLE_EIGHT_DOUBLE);
+        let expected = BRAILLE_EIGHT_DOUBLE
+            .symbols
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect::<Vec<_>>();
+
+        let mut got = Vec::new();
+        for _ in 0..BRAILLE_EIGHT_DOUBLE.symbols.len() {
+            got.push(throbber.to_symbol_span(&state).content.to_string());
+            state.calc_next();
+        }
+
+        assert_eq!(got, expected);
+
+        // second cycle
+        got.clear();
+        for _ in 0..BRAILLE_EIGHT_DOUBLE.symbols.len() {
+            got.push(throbber.to_symbol_span(&state).content.to_string());
+            state.calc_next();
+        }
+        assert_eq!(got, expected);
+    }
+}


### PR DESCRIPTION

- Remove throbber-widgets-tui dependency from Cargo.toml and Cargo.lock
- Implement custom Throbber widget with BRAILLE_EIGHT_DOUBLE animation set
- Add ThrobberState for managing animation frames and symbol cycling
- Update chat component to use custom throbber implementation
- Export throbber module from widgets module
- Add unit tests for symbol cycling functionality