### PR TITLE
refactor: standardize logging environment variable to COCO_LOG

### DIFF
--- a/crates/coco-tui/src/lib.rs
+++ b/crates/coco-tui/src/lib.rs
@@ -25,7 +25,7 @@ fn init() {
 
     tracing_subscriber::registry()
         .with(vec![console_log])
-        .with(EnvFilter::from_default_env())
+        .with(EnvFilter::from_env("COCO_LOG"))
         .init();
 
     // Initialize dummy channels for testing.

--- a/crates/code-highlight/src/lib.rs
+++ b/crates/code-highlight/src/lib.rs
@@ -22,6 +22,6 @@ fn init() {
 
     tracing_subscriber::registry()
         .with(vec![console_log])
-        .with(EnvFilter::from_default_env())
+        .with(EnvFilter::from_env("COCO_LOG"))
         .init();
 }

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-export RUST_LOG=${RUST_LOG-debug}
+export COCO_LOG=${COCO_LOG-debug}
 
 cargo build --bin coco
 cargo nextest run "$@"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,6 @@ fn init() {
 
     tracing_subscriber::registry()
         .with(vec![console_log])
-        .with(EnvFilter::from_default_env())
+        .with(EnvFilter::from_env("COCO_LOG"))
         .init();
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -54,6 +54,7 @@ pub fn init_file_logging(log_name: &str) -> Result<PathBuf> {
 
     let env_filter = EnvFilter::builder()
         .with_default_directive(tracing::Level::INFO.into())
+        .with_env_var("COCO_LOG")
         .from_env()
         .whatever_context("failed to load filter from env")?;
 


### PR DESCRIPTION
- Update all logging configurations to use COCO_LOG instead of RUST_LOG
- Modify EnvFilter initialization to use from_env("COCO_LOG") consistently
- Update run-test.sh script to export COCO_LOG instead of RUST_LOG
- Add COCO_LOG environment variable support to file logging configuration
- Ensure consistent logging behavior across all components