### PR TITLE
feat: implement list tool for directory listing

### DIFF
--- a/crates/coco-tui/src/components/messages/tool.rs
+++ b/crates/coco-tui/src/components/messages/tool.rs
@@ -1,7 +1,7 @@
 use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{
     ToolUse,
-    tools::{BASH_TOOL_NAME, READ_TOOL_NAME, STR_REPLACE_TOOL_NAME},
+    tools::{BASH_TOOL_NAME, LIST_TOOL_NAME, READ_TOOL_NAME, STR_REPLACE_TOOL_NAME},
 };
 use crossterm::event::KeyEvent;
 use ratatui::{
@@ -28,10 +28,12 @@ use crate::{
 };
 
 mod bash;
+mod list;
 mod raw;
 mod read;
 mod str_replace;
 use bash::Bash;
+use list::List;
 use raw::Raw;
 use read::Read;
 use str_replace::StrReplace;
@@ -68,6 +70,7 @@ impl Tool {
     pub fn new(tool_use: ToolUse) -> Self {
         let widget = match tool_use.name.as_str() {
             READ_TOOL_NAME => Some(Read::new(&tool_use).into()),
+            LIST_TOOL_NAME => Some(List::new(&tool_use).into()),
             BASH_TOOL_NAME => match Bash::try_new().tool_use(&tool_use).call() {
                 Ok(widget) => Some(widget.into()),
                 Err(err) => {
@@ -145,6 +148,7 @@ impl Persistable for Tool {
         let widget = match name.as_str() {
             BASH_TOOL_NAME => Bash::load(child)?.into(),
             READ_TOOL_NAME => Read::load(child)?.into(),
+            LIST_TOOL_NAME => List::load(child)?.into(),
             STR_REPLACE_TOOL_NAME => StrReplace::load(child)?.into(),
             _ => whatever!("Unknown tool {name:?}"),
         };

--- a/crates/coco-tui/src/components/messages/tool/list.rs
+++ b/crates/coco-tui/src/components/messages/tool/list.rs
@@ -1,0 +1,268 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
+use code_combo::{
+    ToolUse,
+    tools::{DEFAULT_ENTRY_LIMIT, Final, ListInput},
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    prelude::Rect,
+    style::Stylize,
+    text::{Line, Span, Text},
+    widgets::{Block, Wrap},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    actions::Action,
+    components::{Component, Content, ContentComponent, Persistable},
+    error::Result,
+    events::{AnswerEvent, Event},
+    global::State,
+    session::{self, Session},
+    widgets::Paragraph,
+};
+
+#[derive(Serialize, Deserialize)]
+struct Inner {
+    input: ListInput,
+    output: Option<String>,
+    #[serde(default = "default_display_state")]
+    display_state: DisplayState,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+enum DisplayState {
+    Omitted,
+    Collapsed,
+    Expanded,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "list")]
+pub struct List<'a> {
+    state: State<Inner>,
+
+    input_widget: Paragraph<'a>,
+    output_widget: Option<Paragraph<'a>>,
+    output_line_cnt: usize,
+}
+
+const OMITTED_PREVIEW_LINES: usize = 5;
+
+fn default_display_state() -> DisplayState {
+    DisplayState::Omitted
+}
+
+fn generate_input_widget<'a>(input: ListInput) -> Paragraph<'a> {
+    let mut lines = vec![];
+
+    lines.push(Line::from(vec![" Path: ".blue(), Span::raw(input.path)]));
+
+    if input.entry_limit != DEFAULT_ENTRY_LIMIT {
+        lines.push(Line::from(vec![
+            " Entry Limit: ".blue(),
+            Span::raw(input.entry_limit.to_string()),
+        ]));
+    }
+
+    Paragraph::new_wrap(lines, Wrap { trim: false })
+}
+
+fn generate_output_widget<'a>(output: String) -> Paragraph<'a> {
+    Paragraph::new_wrap(Text::from(output), Wrap { trim: false })
+}
+
+impl List<'_> {
+    pub fn new(tool_use: &ToolUse) -> Self {
+        let input: ListInput = serde_json::from_value(tool_use.input.to_owned())
+            .expect("Should be a valid ListInput.");
+        let input_widget = generate_input_widget(input.clone());
+
+        Self {
+            input_widget,
+            output_widget: None,
+            output_line_cnt: 0,
+            state: State::new(Inner {
+                input,
+                output: None,
+                display_state: DisplayState::Omitted,
+            }),
+        }
+    }
+
+    fn update_output(&mut self, output: Final) {
+        let Final::Message(text) = output else {
+            unreachable!("List tool should only return Final::Message");
+        };
+
+        self.state.write().output = Some(text.clone());
+
+        self.output_line_cnt = text.lines().count();
+        self.output_widget = Some(generate_output_widget(text));
+    }
+
+    fn toggle_display_state(&mut self) {
+        let mut state = self.state.write();
+        state.display_state = match state.display_state {
+            DisplayState::Collapsed => DisplayState::Expanded,
+            DisplayState::Expanded => DisplayState::Collapsed,
+            DisplayState::Omitted => DisplayState::Omitted,
+        };
+    }
+
+    fn on_blur(&mut self) {
+        if self.state.display_state == DisplayState::Omitted {
+            self.state.write().display_state = DisplayState::Collapsed;
+        }
+    }
+
+    fn omitted_indicator(&self) -> Paragraph<'static> {
+        Paragraph::new(
+            format!(
+                "... (omitted, showing first part of {} lines)",
+                self.output_line_cnt
+            )
+            .dark_gray(),
+        )
+    }
+}
+
+impl Content for List<'_> {
+    fn height(&self, width: u16) -> usize {
+        let input_height = self.input_widget.line_count(width);
+        let output_height = self
+            .output_widget
+            .as_ref()
+            .map(|widget| match self.state.display_state {
+                DisplayState::Collapsed => 0,
+                DisplayState::Expanded => widget.line_count(width),
+                DisplayState::Omitted => {
+                    let height = widget.line_count(width);
+                    let indicator = self.omitted_indicator();
+                    let indicator_height = indicator.line_count(width);
+                    if height > OMITTED_PREVIEW_LINES + indicator_height {
+                        OMITTED_PREVIEW_LINES + indicator_height
+                    } else {
+                        height
+                    }
+                }
+            })
+            .unwrap_or_default();
+        input_height + output_height
+    }
+
+    fn is_actionable(&self) -> bool {
+        self.output_widget.is_some()
+            && matches!(
+                self.state.display_state,
+                DisplayState::Collapsed | DisplayState::Expanded
+            )
+    }
+
+    fn block_with_shortcuts_desc<'b>(&self, block: Block<'b>) -> Block<'b> {
+        if !self.is_actionable() {
+            return block;
+        }
+        let toggle_text = match self.state.display_state {
+            DisplayState::Collapsed => ("Unfold", "e"),
+            DisplayState::Expanded => ("Fold", "e"),
+            DisplayState::Omitted => return block,
+        };
+        block.title_bottom(crate::components::shortcuts_desc(&[toggle_text]))
+    }
+}
+
+impl Persistable for List<'static> {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: Inner = session::load(session)?;
+        Ok(Self {
+            input_widget: generate_input_widget(state.input.clone()),
+            output_widget: state.output.clone().map(generate_output_widget),
+            output_line_cnt: state
+                .output
+                .as_ref()
+                .map(|x| x.lines().count())
+                .unwrap_or_default(),
+            state: State::new(state),
+        })
+    }
+}
+
+impl Component for List<'static> {
+    fn handle_event(&mut self, event: &Event) {
+        match event {
+            Event::Answer(AnswerEvent::ToolResult { output, .. }) => {
+                self.update_output(output.to_owned());
+            }
+            _ => {
+                handle_component_event!(self, event);
+            }
+        }
+    }
+
+    fn handle_key_event(&mut self, key: &KeyEvent) {
+        if let (KeyModifiers::NONE, KeyCode::Char('e')) = (key.modifiers, key.code)
+            && self.is_actionable()
+        {
+            self.toggle_display_state();
+        }
+    }
+
+    fn update(&mut self, action: &Action) {
+        if matches!(action, Action::Blur) {
+            self.on_blur();
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        use Constraint::{Length, Min};
+        let width = area.width;
+        let height_input = self.input_widget.line_count(width);
+
+        let Some(output_widget) = &self.output_widget else {
+            frame.render_widget(&self.input_widget, area);
+            return Ok(());
+        };
+
+        if self.state.display_state == DisplayState::Collapsed {
+            frame.render_widget(&self.input_widget, area);
+            return Ok(());
+        }
+
+        let [area_input, area_output] =
+            Layout::vertical([Length(height_input as u16), Min(1)]).areas(area);
+
+        frame.render_widget(&self.input_widget, area_input);
+
+        match self.state.display_state {
+            DisplayState::Expanded => {
+                frame.render_widget(output_widget, area_output);
+            }
+            DisplayState::Omitted => {
+                let height = output_widget.line_count(width);
+                let indicator = self.omitted_indicator();
+                let indicator_height = indicator.line_count(width);
+                if height > OMITTED_PREVIEW_LINES + indicator_height {
+                    let [area_output, area_indicator] =
+                        Layout::vertical([Min(1), Length(indicator_height as u16)])
+                            .areas(area_output);
+                    frame.render_widget(indicator, area_indicator);
+                    frame.render_widget(output_widget, area_output);
+                } else {
+                    frame.render_widget(output_widget, area_output);
+                }
+            }
+            DisplayState::Collapsed => (),
+        }
+
+        Ok(())
+    }
+}
+
+impl ContentComponent for List<'static> {}

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -6,8 +6,8 @@ use snafu::prelude::*;
 use crate::{
     TextEdit, error,
     tools::{
-        self, BashTool, Final, READ_TOOL_NAME, ReadTool, STR_REPLACE_TOOL_NAME, StrReplaceTool,
-        Tool,
+        self, BashTool, Final, LIST_TOOL_NAME, ListTool, READ_TOOL_NAME, ReadTool,
+        STR_REPLACE_TOOL_NAME, StrReplaceTool, Tool,
     },
 };
 
@@ -21,6 +21,7 @@ pub struct Executor {
 lazy_static! {
     static ref BASH_TOOL: Arc<dyn Tool + 'static> = Arc::new(BashTool::default());
     static ref READ_TOOL: Arc<dyn Tool + 'static> = Arc::new(ReadTool::default());
+    static ref LIST_TOOL: Arc<dyn Tool + 'static> = Arc::new(ListTool::default());
     static ref STR_REPLACE_TOOL: Arc<dyn Tool + 'static> = Arc::new(StrReplaceTool::default());
     static ref DEFAULT_TOOLS: HashMap<String, Arc<dyn Tool + 'static>> = {
         let mut m = HashMap::<String, Arc<dyn Tool + 'static>>::new();
@@ -28,6 +29,7 @@ lazy_static! {
             [
                 BASH_TOOL.clone(),
                 READ_TOOL.clone(),
+                LIST_TOOL.clone(),
                 STR_REPLACE_TOOL.clone(),
             ]
             .into_iter()
@@ -128,7 +130,10 @@ impl Executor {
                 unimplemented!("Permission control list validation not yet implemented")
             } else {
                 // Some tools can execute without explicit permission
-                if !matches!(name, STR_REPLACE_TOOL_NAME | READ_TOOL_NAME) {
+                if !matches!(
+                    name,
+                    STR_REPLACE_TOOL_NAME | READ_TOOL_NAME | LIST_TOOL_NAME
+                ) {
                     // For other tools, request permission if no permission control entries are found
                     return Ok(Output::AskPermission);
                 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -15,11 +15,13 @@ macro_rules! err_msg {
 }
 
 mod bash;
+mod list;
 mod read;
 mod str_replace;
 
 use crate::{AppliedTextEdit, TextEdit};
 pub use bash::{BASH_TOOL_NAME, BashInput, BashOutput, BashTool};
+pub use list::{DEFAULT_ENTRY_LIMIT, LIST_TOOL_NAME, ListInput, ListTool, MAX_ENTRY_LIMIT};
 pub use read::{
     DEFAULT_LINE_LIMIT, DEFAULT_LINE_OFFSET, MAX_LINE_LIMIT, READ_TOOL_NAME, ReadInput, ReadTool,
 };

--- a/src/tools/list.rs
+++ b/src/tools/list.rs
@@ -1,0 +1,267 @@
+use async_trait::async_trait;
+use indoc::formatdoc;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::fs;
+
+use super::{ExecuteResult, Final, Input, Tool};
+
+#[derive(Default)]
+pub struct ListTool {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListInput {
+    pub path: String,
+    #[serde(default = "default_entry_limit")]
+    pub entry_limit: usize,
+}
+
+pub const LIST_TOOL_NAME: &str = "list";
+pub const DEFAULT_ENTRY_LIMIT: usize = 1000;
+pub const MAX_ENTRY_LIMIT: usize = 1000;
+const MAX_BYTES_LIMIT: usize = 1000 * 100; // 100 KB
+
+fn default_entry_limit() -> usize {
+    DEFAULT_ENTRY_LIMIT
+}
+
+#[async_trait]
+impl Tool for ListTool {
+    fn name(&self) -> &'static str {
+        LIST_TOOL_NAME
+    }
+
+    fn description(&self) -> &'static str {
+        "List directory entries with permission and type info"
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The relative path from the working directory to the file or directory to list"
+                },
+                "entry_limit": {
+                    "type": "number",
+                    "description": formatdoc! {"
+                        The maximum number of entries to return.
+                        By default list up to {MAX_ENTRY_LIMIT} entries, which is the max allowed value.
+                        Set this value when the directory is too large to list at once.
+                    "}.trim(),
+                    "maximum": MAX_ENTRY_LIMIT,
+                    "default": DEFAULT_ENTRY_LIMIT,
+                    "ge": 1,
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    async fn execute<'a>(&self, input: Input<'a>) -> ExecuteResult {
+        let Input::Starter(input) = input else {
+            return err_msg!("Input should be Starter variant, not other variants");
+        };
+        let ListInput { path, entry_limit } =
+            serde_json::from_value(input).map_err(|err| format!("Invalid input format: {err}"))?;
+
+        if entry_limit > MAX_ENTRY_LIMIT {
+            return err_msg!("Exceeded maximum entry limit for listing");
+        }
+
+        let path = path
+            .parse::<std::path::PathBuf>()
+            .map_err(|err| format!("Invalid path format: {err}"))?;
+        if path.is_absolute() {
+            return err_msg!("Path must be relative to the working directory, not absolute");
+        }
+
+        let metadata = fs::symlink_metadata(&path)
+            .await
+            .map_err(|err| format!("Failed to read path metadata: {err}"))?;
+
+        let output = if metadata.is_dir() {
+            list_dir(&path, entry_limit).await?
+        } else {
+            list_single(&path, &metadata)?
+        };
+
+        Ok(Final::Message(output).into())
+    }
+}
+
+async fn list_dir(path: &std::path::Path, entry_limit: usize) -> Result<String, Final> {
+    let mut rd = fs::read_dir(path)
+        .await
+        .map_err(|err| format!("Failed to read directory: {err}"))?;
+
+    let mut entries: Vec<EntryInfo> = Vec::new();
+    let mut truncated = false;
+    while let Some(entry) = rd
+        .next_entry()
+        .await
+        .map_err(|err| format!("Failed to read directory entry: {err}"))?
+    {
+        if entries.len() >= entry_limit {
+            truncated = true;
+            break;
+        }
+        entries.push(EntryInfo::from(entry));
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut output = String::new();
+    let mut bytes = 0;
+    for entry in entries {
+        let metadata = fs::symlink_metadata(&entry.path)
+            .await
+            .map_err(|err| format!("Failed to read entry metadata: {err}"))?;
+        let line = format!("{} {}\n", format_mode(&metadata), entry.name);
+        output.push_str(&line);
+        bytes += line.len();
+        if bytes > MAX_BYTES_LIMIT {
+            return Err(format!("Exceeded maximum bytes limit for listing: {bytes}").into());
+        }
+    }
+
+    if truncated {
+        let line = format!("... (truncated, showing first {entry_limit} entries)\n");
+        output.push_str(&line);
+        bytes += line.len();
+        if bytes > MAX_BYTES_LIMIT {
+            return Err(format!("Exceeded maximum bytes limit for listing: {bytes}").into());
+        }
+    }
+
+    Ok(output)
+}
+
+fn list_single(path: &std::path::Path, metadata: &std::fs::Metadata) -> Result<String, Final> {
+    let name = path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+    Ok(format!("{} {}\n", format_mode(metadata), name))
+}
+
+struct EntryInfo {
+    name: String,
+    path: std::path::PathBuf,
+}
+
+impl From<fs::DirEntry> for EntryInfo {
+    fn from(entry: fs::DirEntry) -> Self {
+        Self {
+            name: entry.file_name().to_string_lossy().to_string(),
+            path: entry.path(),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn format_mode(metadata: &std::fs::Metadata) -> String {
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+
+    let file_type = metadata.file_type();
+    let type_char = if file_type.is_dir() {
+        'd'
+    } else if file_type.is_file() {
+        '-'
+    } else if file_type.is_symlink() {
+        'l'
+    } else if file_type.is_block_device() {
+        'b'
+    } else if file_type.is_char_device() {
+        'c'
+    } else if file_type.is_fifo() {
+        'p'
+    } else if file_type.is_socket() {
+        's'
+    } else {
+        '?'
+    };
+
+    let mode = metadata.permissions().mode();
+    let mut chars = ['-'; 10];
+    chars[0] = type_char;
+
+    let flags = [
+        (0o400, 1, 'r'),
+        (0o200, 2, 'w'),
+        (0o100, 3, 'x'),
+        (0o040, 4, 'r'),
+        (0o020, 5, 'w'),
+        (0o010, 6, 'x'),
+        (0o004, 7, 'r'),
+        (0o002, 8, 'w'),
+        (0o001, 9, 'x'),
+    ];
+    for (bit, idx, ch) in flags {
+        if mode & bit != 0 {
+            chars[idx] = ch;
+        }
+    }
+
+    if mode & 0o4000 != 0 {
+        chars[3] = if chars[3] == 'x' { 's' } else { 'S' };
+    }
+    if mode & 0o2000 != 0 {
+        chars[6] = if chars[6] == 'x' { 's' } else { 'S' };
+    }
+    if mode & 0o1000 != 0 {
+        chars[9] = if chars[9] == 'x' { 't' } else { 'T' };
+    }
+
+    chars.into_iter().collect()
+}
+
+#[cfg(not(unix))]
+fn format_mode(metadata: &std::fs::Metadata) -> String {
+    let type_char = if metadata.is_dir() { 'd' } else { '-' };
+    format!("{type_char}?????????")
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn format_mode_for_file_and_dir() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let dir_path = dir.path().join("demo_dir");
+        std::fs::create_dir(&dir_path).expect("create dir");
+        std::fs::set_permissions(&dir_path, std::fs::Permissions::from_mode(0o755))
+            .expect("set dir permissions");
+
+        let file_path = dir.path().join("demo_file");
+        std::fs::write(&file_path, "data").expect("write file");
+        std::fs::set_permissions(&file_path, std::fs::Permissions::from_mode(0o640))
+            .expect("set file permissions");
+
+        let dir_meta = std::fs::symlink_metadata(&dir_path).expect("dir metadata");
+        let file_meta = std::fs::symlink_metadata(&file_path).expect("file metadata");
+
+        assert_eq!(format_mode(&dir_meta), "drwxr-xr-x");
+        assert_eq!(format_mode(&file_meta), "-rw-r-----");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn format_mode_for_symlink() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target = dir.path().join("target");
+        std::fs::write(&target, "data").expect("write target");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let meta = std::fs::symlink_metadata(&link).expect("link metadata");
+        let mode = format_mode(&meta);
+        assert!(mode.starts_with('l'));
+    }
+}


### PR DESCRIPTION
- Add new list tool with support for listing directory entries with permission and type info
- Implement TUI component for list tool with three-state display (Omitted, Collapsed, Expanded)
- Add list tool to executor with automatic permission handling
- Support Unix-style permission formatting with proper file type indicators
- Add keyboard shortcut 'e' to toggle between Collapsed and Expanded states
- Implement automatic state transition from Omitted to Collapsed on blur action
- Add entry limit parameter with default of 1000 entries and maximum limit validation
- Include proper error handling for path validation and metadata reading
- Add comprehensive unit tests for permission formatting and symlink handling