### PR TITLE
feat: add folding status reminder line to all tool components

### DIFF
--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -184,8 +184,8 @@ impl Combo {
                 });
             }
         }
-        if self.has_collapsible_body() && self.state.collapsed {
-            spans.push(" (folded)".dark_gray());
+        if let Some(line) = self.reminder_line() {
+            spans.extend(line.spans);
         }
         spans.push(" ".into());
         spans
@@ -222,6 +222,14 @@ impl Content for Combo {
             ("Fold", "z")
         };
         block.title_bottom(crate::components::shortcuts_desc(&[toggle_text]))
+    }
+
+    fn reminder_line(&self) -> Option<Line<'static>> {
+        if self.has_collapsible_body() && self.state.collapsed {
+            Some(Line::from(Span::raw(" (folded)").dark_gray()))
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -300,8 +300,18 @@ impl<'a> Content for Bash<'a> {
     }
 
     fn reminder_line(&self) -> Option<Line<'static>> {
-        let summary = self.empty_output_summary()?;
-        Some(Line::from(Span::raw(format!(" - {summary}")).dark_gray()))
+        let mut spans = Vec::new();
+        if let Some(summary) = self.empty_output_summary() {
+            spans.push(Span::raw(format!(" - {summary}")).dark_gray());
+        }
+        if self.state.collapsed && self.has_output_content() {
+            spans.push(Span::raw(" (folded)").dark_gray());
+        }
+        if spans.is_empty() {
+            None
+        } else {
+            Some(Line::from(spans))
+        }
     }
 }
 

--- a/crates/coco-tui/src/components/messages/tool/list.rs
+++ b/crates/coco-tui/src/components/messages/tool/list.rs
@@ -172,6 +172,14 @@ impl Content for List<'_> {
         };
         block.title_bottom(crate::components::shortcuts_desc(&[toggle_text]))
     }
+
+    fn reminder_line(&self) -> Option<Line<'static>> {
+        if self.state.display_state == DisplayState::Collapsed {
+            Some(Line::from(Span::raw(" (folded)").dark_gray()))
+        } else {
+            None
+        }
+    }
 }
 
 impl Persistable for List<'static> {

--- a/crates/coco-tui/src/components/messages/tool/read.rs
+++ b/crates/coco-tui/src/components/messages/tool/read.rs
@@ -186,6 +186,14 @@ impl Content for Read<'_> {
         };
         block.title_bottom(crate::components::shortcuts_desc(&[toggle_text]))
     }
+
+    fn reminder_line(&self) -> Option<Line<'static>> {
+        if self.state.display_state == DisplayState::Collapsed {
+            Some(Line::from(Span::raw(" (folded)").dark_gray()))
+        } else {
+            None
+        }
+    }
 }
 
 impl Persistable for Read<'static> {

--- a/crates/coco-tui/src/components/messages/tool/str_replace.rs
+++ b/crates/coco-tui/src/components/messages/tool/str_replace.rs
@@ -492,6 +492,15 @@ impl Content for StrReplace<'_> {
 
         block
     }
+
+    fn reminder_line(&self) -> Option<Line<'static>> {
+        let state = self.state.read();
+        if state.display_state == DisplayState::Result && state.collapsed {
+            Some(Line::from(Span::raw(" (folded)").dark_gray()))
+        } else {
+            None
+        }
+    }
 }
 
 impl Persistable for StrReplace<'static> {


### PR DESCRIPTION
- Implement reminder_line() method for Combo, Bash, List, Read, and StrReplace components
- Show '(folded)' status in dark gray when components are collapsed
- Move folded status from title spans to dedicated reminder_line method
- Consolidate empty output summary and folded status in Bash component
- Maintain consistent UX across all tool components for folding state visibility