### PR TITLE
feat: implement exit confirmation and cancellation system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tree-sitter = { version = "0.25" }
 tree-sitter-md = { version = "0.3.2" }
 futures-core = "0.3.31"
 futures-util = "0.3.31"
+tokio-util = "0.7.16"
 
 # Core dependencies for CLI and application functionality
 [dependencies]
@@ -57,6 +58,7 @@ snafu.workspace = true
 
 # Async runtime
 tokio.workspace = true
+tokio-util.workspace = true
 async-trait = "0.1.89"
 futures-core.workspace = true
 futures-util.workspace = true

--- a/crates/anthropic/src/types.rs
+++ b/crates/anthropic/src/types.rs
@@ -69,6 +69,18 @@ pub enum Content {
     Multiple(Vec<Block>),
 }
 
+impl Content {
+    pub fn user_cancel(self) -> Self {
+        match self {
+            Self::Text(text) => Self::Text(format!("User cancelled!\n{text}")),
+            Self::Multiple(mut blocks) => {
+                blocks.insert(0, "User cancelled!".into());
+                Self::Multiple(blocks)
+            }
+        }
+    }
+}
+
 impl From<&str> for Content {
     fn from(value: &str) -> Self {
         Self::Text(value.to_string())

--- a/crates/anthropic/src/types.rs
+++ b/crates/anthropic/src/types.rs
@@ -62,6 +62,12 @@ impl From<&str> for Block {
     }
 }
 
+impl From<String> for Block {
+    fn from(value: String) -> Self {
+        Self::Text { text: value }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Content {
@@ -71,10 +77,11 @@ pub enum Content {
 
 impl Content {
     pub fn user_cancel(self) -> Self {
+        let msg = Block::text("User interrupted!");
         match self {
-            Self::Text(text) => Self::Text(format!("User cancelled!\n{text}")),
+            Self::Text(text) => Self::Multiple(vec![msg, text.into()]),
             Self::Multiple(mut blocks) => {
-                blocks.insert(0, "User cancelled!".into());
+                blocks.insert(0, msg);
                 Self::Multiple(blocks)
             }
         }

--- a/crates/coco-tui/Cargo.toml
+++ b/crates/coco-tui/Cargo.toml
@@ -25,7 +25,7 @@ crossterm = { version = "0.28.1", features = ["event-stream"] }
 
 # Async utilities
 tokio.workspace = true
-tokio-util = "0.7.16"
+tokio-util.workspace = true
 futures = "0.3.31"
 
 # Terminal UI framework

--- a/crates/coco-tui/src/app.rs
+++ b/crates/coco-tui/src/app.rs
@@ -6,7 +6,7 @@ use std::{
 use code_combo::Config;
 use crossterm::{
     cursor,
-    event::{Event as CrosstermEvent, EventStream, KeyCode, KeyEvent, KeyModifiers},
+    event::{Event as CrosstermEvent, EventStream, KeyEvent},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
 use futures::{FutureExt, StreamExt};
@@ -216,14 +216,7 @@ impl App {
     }
 
     fn on_key_event(&mut self, key: KeyEvent) {
-        match (key.modifiers, key.code) {
-            (KeyModifiers::CONTROL, KeyCode::Char('c') | KeyCode::Char('C')) => {
-                self.send_action(Action::Quit);
-            }
-            _ => {
-                self.root.handle_event(&Event::Key(key));
-            }
-        }
+        self.root.handle_event(&Event::Key(key));
     }
 
     fn handle_action(&mut self) -> Result<()> {

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -293,10 +293,9 @@ impl Chat<'static> {
                 let content = self.build_user_content(ChatContent::Text(combo.to_markdown()));
                 self.spawn_chat_task(content);
             }
-            ComboEvent::Discovered { .. } => {
-                self.set_ready();
-            }
-            ComboEvent::NotFound { .. } | ComboEvent::Cancelled { .. } => {
+            ComboEvent::Discovered { .. }
+            | ComboEvent::NotFound { .. }
+            | ComboEvent::Cancelled { .. } => {
                 self.set_ready();
             }
         }
@@ -905,18 +904,7 @@ async fn task_combo_execute(name: String, cancel_token: CancellationToken) {
 
     tx.send(ComboEvent::Discovering.into()).unwrap();
     let result = discover_with_cancel(&combo_dir, cancel_token.clone()).await;
-    if result.cancelled {
-        tx.send(
-            ComboEvent::Cancelled {
-                name: Some(name.clone()),
-            }
-            .into(),
-        )
-        .unwrap();
-        return;
-    }
-
-    if cancel_token.is_cancelled() {
+    if result.cancelled || cancel_token.is_cancelled() {
         tx.send(
             ComboEvent::Cancelled {
                 name: Some(name.clone()),
@@ -943,6 +931,7 @@ async fn task_combo_execute(name: String, cancel_token: CancellationToken) {
         return;
     };
 
+    // Skip the `ComboEvent::Discovered` event and advance directly to `ComboEvent::Executing`
     tx.send(ComboEvent::Executing { name: name.clone() }.into())
         .unwrap();
 
@@ -989,18 +978,7 @@ async fn task_combo_execute(name: String, cancel_token: CancellationToken) {
         }
     };
 
-    if cancel_token.is_cancelled() {
-        tx.send(
-            ComboEvent::Cancelled {
-                name: Some(name.clone()),
-            }
-            .into(),
-        )
-        .unwrap();
-        return;
-    }
-
-    if matches!(&starter.combo, Err(StarterError::Cancelled)) {
+    if cancel_token.is_cancelled() || matches!(&starter.combo, Err(StarterError::Cancelled)) {
         tx.send(
             ComboEvent::Cancelled {
                 name: Some(name.clone()),

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,9 +1,11 @@
 use coco_macro::ComponentExt;
 use code_combo::{
-    Agent, Block as ChatBlock, Config, Content as ChatContent, Message as ChatMessage, Output,
+    Agent, Block as ChatBlock, Config, Content as ChatContent, ExecuteStatus,
+    Message as ChatMessage, Output, SessionEnv, StarterCommand, StarterError, StarterEvent,
     StopReason, TextEdit, ToolUse,
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use futures::StreamExt;
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
@@ -14,8 +16,9 @@ use ratatui::{
 };
 
 use serde::{Deserialize, Serialize};
+use std::{path::Path, time::Duration};
 use time::OffsetDateTime;
-use tokio::time::Instant;
+use tokio::{fs, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -44,6 +47,7 @@ pub struct Chat<'a> {
     indicator: ThrobberState,
 
     token_schedule_session_save: Option<CancellationToken>,
+    cancellation_guard: CancellationGuard,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -80,12 +84,11 @@ impl Default for Inner {
     }
 }
 
-#[derive(Default, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
 enum ChatState {
     #[default]
     Ready,
     Procesing,
-    ComboDiscovering,
 }
 
 impl std::fmt::Display for ChatState {
@@ -93,7 +96,6 @@ impl std::fmt::Display for ChatState {
         match self {
             Self::Ready => f.write_str("Ready"),
             Self::Procesing => f.write_str("Procesing"),
-            Self::ComboDiscovering => f.write_str("Discovering"),
         }
     }
 }
@@ -105,6 +107,70 @@ enum Focus {
     InputBlur,
     Messages,
     CommandPalette,
+}
+
+const CTRL_C_WINDOW: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Default)]
+struct CancellationGuard {
+    last_hit: State<Option<Instant>>,
+    cancel_token: Option<CancellationToken>,
+}
+
+impl CancellationGuard {
+    pub fn try_fire(&mut self) -> bool {
+        let now = Instant::now();
+        if let Some(last) = self.last_hit.get()
+            && now.duration_since(last) <= CTRL_C_WINDOW
+        {
+            // fire
+            self.cancel_token();
+            self.reset();
+            return true;
+        }
+
+        *self.last_hit.write() = Some(now);
+
+        false
+    }
+
+    pub fn reset(&mut self) {
+        *self.last_hit.write() = None;
+    }
+
+    pub fn on_trick(&mut self) {
+        let Some(last) = self.last_hit.get() else {
+            return;
+        };
+        if Instant::now().duration_since(last) > CTRL_C_WINDOW {
+            self.reset();
+        }
+    }
+
+    pub fn is_armed(&self) -> bool {
+        self.last_hit.is_some()
+    }
+
+    pub fn token(&mut self) -> CancellationToken {
+        if let Some(token) = &self.cancel_token {
+            return token.clone();
+        }
+        let token = CancellationToken::new();
+        self.cancel_token = Some(token.clone());
+        token
+    }
+
+    pub fn start_token(&mut self) -> CancellationToken {
+        self.cancel_token();
+        self.reset();
+        self.token()
+    }
+
+    fn cancel_token(&mut self) {
+        if let Some(token) = self.cancel_token.take() {
+            token.cancel();
+        }
+    }
 }
 
 const COMMAND_NEW_SESSION: &str = "New Session";
@@ -125,6 +191,7 @@ impl Chat<'static> {
             messages: Messages::default(),
             indicator: ThrobberState::default(),
             token_schedule_session_save: None,
+            cancellation_guard: CancellationGuard::default(),
         }
     }
 
@@ -219,19 +286,19 @@ impl Chat<'static> {
     fn handle_combo_event(&mut self, event: &ComboEvent) {
         debug!(?event, "receive combo event");
         match event {
-            ComboEvent::Discovering => {
-                self.state.write().state = ChatState::ComboDiscovering;
-            }
-            ComboEvent::Executing { .. } | ComboEvent::Output { .. } => {
-                self.state.write().state = ChatState::Procesing;
+            ComboEvent::Discovering | ComboEvent::Executing { .. } | ComboEvent::Output { .. } => {
+                self.set_processing();
             }
             ComboEvent::Executed { starter, .. } => {
                 let combo = starter.combo.as_ref().unwrap();
                 let content = self.build_user_content(ChatContent::Text(combo.to_markdown()));
-                tokio::task::spawn(task_chat(self.agent.clone(), content));
+                self.spawn_chat_task(content);
             }
-            ComboEvent::Discovered { .. } | ComboEvent::NotFound { .. } => {
-                self.state.write().state = ChatState::Ready;
+            ComboEvent::Discovered { .. } => {
+                self.set_ready();
+            }
+            ComboEvent::NotFound { .. } | ComboEvent::Cancelled { .. } => {
+                self.set_ready();
             }
         }
     }
@@ -273,14 +340,61 @@ impl Chat<'static> {
         }
     }
 
+    fn spawn_chat_task(&mut self, content: ChatContent) {
+        let cancel_token = self.cancellation_guard.start_token();
+        tokio::task::spawn(task_chat(self.agent.clone(), content, cancel_token));
+    }
+
+    fn spawn_combo_discover(&mut self) {
+        let cancel_token = self.cancellation_guard.start_token();
+        tokio::task::spawn(task_combo_discover(cancel_token));
+    }
+
+    fn spawn_combo_execute(&mut self, name: String) {
+        let cancel_token = self.cancellation_guard.start_token();
+        tokio::task::spawn(task_combo_execute(name, cancel_token));
+    }
+
+    fn set_processing(&mut self) {
+        if self.state.state != ChatState::Procesing {
+            self.state.write().state = ChatState::Procesing;
+        }
+    }
+
+    fn set_ready(&mut self) {
+        if self.state.state != ChatState::Ready {
+            // Avoid quitting the app while trying to cancel processing
+            self.cancellation_guard.reset();
+            self.state.write().state = ChatState::Ready;
+        }
+    }
+
+    fn is_ready_for_exit(&self) -> bool {
+        self.state.state == ChatState::Ready
+    }
+
+    fn handle_ctrl_c(&mut self) {
+        if !self.cancellation_guard.try_fire() {
+            return;
+        }
+
+        if self.is_ready_for_exit() {
+            global::action_tx().send(Action::Quit).unwrap();
+        }
+    }
+
     fn on_submit(&mut self) {
-        if matches!(self.state.state, ChatState::Ready) {
+        if self.state.state == ChatState::Ready {
             let value = self.input.clear();
+            if value.is_empty() {
+                debug!("submitting with empty value, skipping");
+                return;
+            }
             debug!(?value, "submiting");
             self.messages
                 .push(Message::user(Plain::new(value.clone()).into()));
             let content = self.build_user_content(ChatContent::Text(value));
-            tokio::task::spawn(task_chat(self.agent.clone(), content));
+            self.spawn_chat_task(content);
         } else {
             // TODO: Display an alert when input submission is not available
         }
@@ -310,11 +424,23 @@ impl Chat<'static> {
         }
     }
 
+    fn ctrl_c_reminder_line(&self) -> Option<Line<'static>> {
+        if !self.cancellation_guard.is_armed() {
+            return None;
+        }
+        let message = if self.is_ready_for_exit() {
+            "Press Ctrl+C again to exit"
+        } else {
+            "Press Ctrl+C again to cancel"
+        };
+        Some(Line::from(format!(" {message} ")).yellow())
+    }
+
     fn widget_state_indicator(&self) -> Line<'_> {
         let state = &self.state.state;
         (match state {
             ChatState::Ready => Line::from(format!(" {state} ").green()),
-            ChatState::Procesing | ChatState::ComboDiscovering => Line::from(vec![
+            ChatState::Procesing => Line::from(vec![
                 " ".into(),
                 Throbber::default()
                     .throbber_set(BRAILLE_EIGHT_DOUBLE)
@@ -381,6 +507,7 @@ impl Chat<'static> {
             focus: Focus::InputBlur,
             ..Default::default()
         };
+        self.cancellation_guard.reset();
 
         // 4. Reset focus to Input from InputBlur to trigger the input component
         self.update_focus(Focus::Input);
@@ -429,10 +556,9 @@ impl Component for Chat<'static> {
     }
 
     fn on_tick(&mut self) {
-        if matches!(
-            self.state.state,
-            ChatState::Procesing | ChatState::ComboDiscovering
-        ) {
+        self.cancellation_guard.on_trick();
+
+        if self.state.state == ChatState::Procesing {
             self.indicator.calc_next();
             global::signal_dirty();
         }
@@ -450,10 +576,10 @@ impl Component for Chat<'static> {
                 handle_component_event!(self, event);
             }
             Event::Ask(AskEvent::Bot) => {
-                self.state.write().state = ChatState::Procesing;
+                self.set_processing();
             }
             Event::Answer(AnswerEvent::Bot(msgs)) => {
-                self.state.write().state = ChatState::Ready;
+                self.set_ready();
                 self.messages
                     .extend(msgs.iter().cloned().map(|msg| match msg {
                         BotMessage::Plain(text) => Message::bot(Plain::new(text).into()),
@@ -464,6 +590,9 @@ impl Component for Chat<'static> {
                     }));
                 // Trigger session save after receiving bot response
                 global::trigger_schedule_session_save();
+            }
+            Event::Answer(AnswerEvent::Cancelled) => {
+                self.set_ready();
             }
             Event::Ask(AskEvent::ToolUsePermission(_) | AskEvent::TextEdit { .. }) => {
                 if let Some(idx) = self.messages.on_tool_event(event) {
@@ -495,7 +624,7 @@ impl Component for Chat<'static> {
                     content: output.try_into().unwrap(),
                 }]);
                 let content = self.build_user_content(content);
-                tokio::task::spawn(task_chat(self.agent.clone(), content));
+                self.spawn_chat_task(content);
                 // Trigger session save after tool result
                 global::trigger_schedule_session_save();
             }
@@ -515,6 +644,17 @@ impl Component for Chat<'static> {
         use KeyModifiers as KM;
 
         let focus = &self.state.focus;
+        if matches!(
+            key,
+            KeyEvent {
+                code: Char('c') | Char('C'),
+                modifiers: KM::CONTROL,
+                ..
+            }
+        ) {
+            self.handle_ctrl_c();
+            return;
+        }
         match (focus, key.modifiers, key.code) {
             // Focus switching
             (Input, KM::NONE, Esc) => self.update_focus(InputBlur),
@@ -575,15 +715,28 @@ impl Component for Chat<'static> {
         debug!(?action, "updating");
 
         match action {
-            Action::Combo(ComboAction::Execute { name }) => {
-                let combo = Combo::new(name);
-                self.messages.push(Message::user(combo.into()));
-                debug!("Combo message pushed");
-            }
+            Action::Combo(combo_action) => match combo_action {
+                ComboAction::Discover => {
+                    self.spawn_combo_discover();
+                }
+                ComboAction::Execute { name } => {
+                    let combo = Combo::new(name);
+                    self.messages.push(Message::user(combo.into()));
+                    self.spawn_combo_execute(name.clone());
+                    debug!("Combo message pushed");
+                }
+            },
             Action::Tool(action) => match action {
                 ToolAction::Grant(tool_use) => {
+                    self.set_processing();
                     self.agent.grant_once(&tool_use.id, &tool_use.name);
-                    tokio::task::spawn(task_tool_use(self.agent.clone(), tool_use.to_owned()));
+                    let cancel_token = self.cancellation_guard.token();
+
+                    tokio::task::spawn(task_tool_use(
+                        self.agent.clone(),
+                        tool_use.to_owned(),
+                        cancel_token,
+                    ));
                 }
                 ToolAction::Cancel(tool_use) => {
                     // Move focus back to Input when tool use is cancelled.
@@ -622,6 +775,7 @@ impl Component for Chat<'static> {
                             *hunk_idx,
                         );
                     } else {
+                        self.set_processing();
                         tokio::task::spawn(task_apply_text_edit(
                             self.agent.clone(),
                             id.to_owned(),
@@ -686,20 +840,23 @@ impl Component for Chat<'static> {
             .border_set(border::THICK);
         frame.render_widget(self.block_bottom_with_shortcuts_desc(block), divider);
 
-        let mut block = Block::new().borders(Borders::BOTTOM);
-        block = if !matches!(self.state.focus, Focus::Messages) {
-            block.border_set(border::THICK).border_style(Style::reset())
+        let mut bottom_block = Block::new().borders(Borders::BOTTOM);
+        bottom_block = if !matches!(self.state.focus, Focus::Messages) {
+            bottom_block
+                .border_set(border::THICK)
+                .border_style(Style::reset())
         } else {
-            block
+            bottom_block
                 .border_set(border::PLAIN)
                 .border_style(Style::default().dark_gray())
         };
-        frame.render_widget(
-            block
-                .title_bottom(Line::from(""))
-                .title_bottom(self.widget_state_indicator()),
-            bottom,
-        );
+        bottom_block = bottom_block
+            .title_bottom(Line::from(""))
+            .title_bottom(self.widget_state_indicator());
+        if let Some(line) = self.ctrl_c_reminder_line() {
+            bottom_block = bottom_block.title_bottom(line);
+        }
+        frame.render_widget(bottom_block, bottom);
         self.input.draw(frame, area_input)?;
 
         if self.state.focus == Focus::CommandPalette {
@@ -711,13 +868,259 @@ impl Component for Chat<'static> {
     }
 }
 
-async fn task_chat(mut agent: Agent, content: ChatContent) {
+struct DiscoverResult {
+    starters: Vec<code_combo::Starter>,
+    cancelled: bool,
+}
+
+async fn task_combo_discover(cancel_token: CancellationToken) {
+    let tx = global::event_tx();
+    let config = global::config().await;
+    let combo_dir = config.combo_dir();
+
+    tx.send(ComboEvent::Discovering.into()).unwrap();
+    let result = discover_with_cancel(&combo_dir, cancel_token).await;
+    if result.cancelled {
+        tx.send(ComboEvent::Cancelled { name: None }.into())
+            .unwrap();
+        return;
+    }
+    tx.send(
+        ComboEvent::Discovered {
+            starters: result.starters,
+        }
+        .into(),
+    )
+    .unwrap();
+}
+
+async fn task_combo_execute(name: String, cancel_token: CancellationToken) {
+    let tx = global::event_tx();
+    let config = global::config().await;
+    let combo_dir = config.combo_dir();
+
+    tx.send(ComboEvent::Discovering.into()).unwrap();
+    let result = discover_with_cancel(&combo_dir, cancel_token.clone()).await;
+    if result.cancelled {
+        tx.send(
+            ComboEvent::Cancelled {
+                name: Some(name.clone()),
+            }
+            .into(),
+        )
+        .unwrap();
+        return;
+    }
+
+    if cancel_token.is_cancelled() {
+        tx.send(
+            ComboEvent::Cancelled {
+                name: Some(name.clone()),
+            }
+            .into(),
+        )
+        .unwrap();
+        return;
+    }
+
+    let Some(starter) = result
+        .starters
+        .into_iter()
+        .find(|starter| match &starter.combo {
+            Ok(combo) => combo.metadata.name == name,
+            Err(err) => {
+                warn!(?starter.path, ?err, "Failed to load combo");
+                false
+            }
+        })
+    else {
+        tx.send(ComboEvent::NotFound { name: name.clone() }.into())
+            .unwrap();
+        return;
+    };
+
+    tx.send(ComboEvent::Executing { name: name.clone() }.into())
+        .unwrap();
+
+    let session_env = SessionEnv::builder()
+        .build()
+        .expect("failed to build session");
+    let starter_path = starter.path.clone();
+    let execution = StarterCommand::new(&starter.path)
+        .session_env(session_env)
+        .execute();
+
+    let starter = match run_execution_with_cancel(execution, cancel_token.clone(), |event| {
+        if let StarterEvent::Output { chunk } = event {
+            tx.send(
+                ComboEvent::Output {
+                    name: name.clone(),
+                    chunk,
+                }
+                .into(),
+            )
+            .unwrap();
+        }
+    })
+    .await
+    {
+        Ok(starter) => starter,
+        Err(err) => {
+            warn!(?err, "starter join error");
+            let starter = code_combo::Starter {
+                path: starter_path,
+                combo: Err(StarterError::Invalid {
+                    reason: format!("starter join error: {err}"),
+                }),
+            };
+            tx.send(
+                ComboEvent::Executed {
+                    name: name.clone(),
+                    starter,
+                }
+                .into(),
+            )
+            .unwrap();
+            return;
+        }
+    };
+
+    if cancel_token.is_cancelled() {
+        tx.send(
+            ComboEvent::Cancelled {
+                name: Some(name.clone()),
+            }
+            .into(),
+        )
+        .unwrap();
+        return;
+    }
+
+    if matches!(&starter.combo, Err(StarterError::Cancelled)) {
+        tx.send(
+            ComboEvent::Cancelled {
+                name: Some(name.clone()),
+            }
+            .into(),
+        )
+        .unwrap();
+        return;
+    }
+
+    tx.send(
+        ComboEvent::Executed {
+            name: name.clone(),
+            starter,
+        }
+        .into(),
+    )
+    .unwrap();
+}
+
+async fn discover_with_cancel(combo_dir: &Path, cancel_token: CancellationToken) -> DiscoverResult {
+    let mut starters = Vec::new();
+    let mut entries = match fs::read_dir(combo_dir).await {
+        Ok(entries) => entries,
+        Err(err) => {
+            warn!(?combo_dir, ?err, "read dir error");
+            return DiscoverResult {
+                starters,
+                cancelled: false,
+            };
+        }
+    };
+
+    loop {
+        let entry = tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return DiscoverResult { starters, cancelled: true };
+            }
+            entry = entries.next_entry() => entry,
+        };
+        let entry = match entry {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(err) => {
+                warn!(?combo_dir, ?err, "read dir error");
+                break;
+            }
+        };
+
+        let path = entry.path();
+        let session_env = SessionEnv::builder()
+            .build()
+            .expect("failed to build session");
+        let execution = StarterCommand::new(path.to_string_lossy())
+            .discovery(true)
+            .session_env(session_env)
+            .execute();
+        let starter = match run_execution_with_cancel(execution, cancel_token.clone(), |_| {}).await
+        {
+            Ok(starter) => starter,
+            Err(err) => {
+                warn!(?err, "starter join error");
+                continue;
+            }
+        };
+
+        if matches!(&starter.combo, Err(StarterError::Cancelled)) || cancel_token.is_cancelled() {
+            return DiscoverResult {
+                starters,
+                cancelled: true,
+            };
+        }
+
+        starters.push(starter);
+    }
+
+    DiscoverResult {
+        starters,
+        cancelled: false,
+    }
+}
+
+async fn run_execution_with_cancel<F>(
+    mut execution: code_combo::StarterExecution,
+    cancel_token: CancellationToken,
+    mut on_event: F,
+) -> Result<code_combo::Starter, tokio::task::JoinError>
+where
+    F: FnMut(StarterEvent),
+{
+    let mut cancelled = false;
+    loop {
+        tokio::select! {
+            _ = cancel_token.cancelled(), if !cancelled => {
+                cancelled = true;
+                execution.cancel();
+            }
+            event = execution.next() => {
+                let Some(event) = event else {
+                    break;
+                };
+                on_event(event);
+            }
+        }
+    }
+    execution.wait().await
+}
+
+async fn task_chat(mut agent: Agent, content: ChatContent, cancel_token: CancellationToken) {
     let tx = global::event_tx();
 
+    if cancel_token.is_cancelled() {
+        return;
+    }
     let msg = ChatMessage::user(content);
     tx.send(Event::Ask(AskEvent::Bot)).unwrap();
 
-    let chat_resp = agent.chat(msg).await.expect("failed to chat with LLM");
+    let chat_resp = tokio::select! {
+        _ = cancel_token.cancelled() => {
+            tx.send(AnswerEvent::Cancelled.into()).ok();
+            return;
+        }
+        chat_resp = agent.chat(msg) => chat_resp.expect("failed to chat with LLM"),
+    };
 
     let mut to_execute: Vec<code_combo::ToolUse> = vec![];
     let mut bot_messages = match chat_resp.message.content {
@@ -770,6 +1173,10 @@ async fn task_chat(mut agent: Agent, content: ChatContent) {
         }
     }
 
+    if cancel_token.is_cancelled() {
+        tx.send(AnswerEvent::Cancelled.into()).ok();
+        return;
+    }
     tx.send(AnswerEvent::Bot(bot_messages).into()).unwrap();
 
     if !to_execute.is_empty() {
@@ -777,77 +1184,101 @@ async fn task_chat(mut agent: Agent, content: ChatContent) {
             executions_cnt = to_execute.len(),
             "run executions parallelly"
         );
+        if cancel_token.is_cancelled() {
+            return;
+        }
         // Parallel execution
         let handles = to_execute
             .into_iter()
             .map(|tool_use| {
                 let agent = agent.clone();
-                tokio::task::spawn(task_tool_use(agent, tool_use))
+                let cancel_token = cancel_token.clone();
+                tokio::task::spawn(task_tool_use(agent, tool_use, cancel_token))
             })
             .collect::<Vec<_>>();
-        futures::future::join_all(handles).await;
+        tokio::select! {
+            _ = cancel_token.cancelled() => {}
+            _ = futures::future::join_all(handles) => {}
+        }
     }
 }
 
-async fn task_tool_use(mut agent: Agent, tool_use: ToolUse) {
+async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: CancellationToken) {
     let tx = global::event_tx();
-    let code_combo::ToolUse { id, name, input } = tool_use;
-    let _ = agent
+    let action_tx = global::action_tx();
+    let code_combo::ToolUse { id, name, input } = tool_use.clone();
+    let status = agent
         .execute_with_output(
             &id,
             &name,
             code_combo::Input::Starter(input),
-            |out| match out {
-                Output::ToolOutput(chunk) => {
-                    tx.send(
-                        AnswerEvent::ToolOutput {
-                            id: id.clone(),
-                            chunk,
-                        }
-                        .into(),
-                    )
-                    .unwrap();
+            cancel_token.clone(),
+            |out| {
+                if cancel_token.is_cancelled() {
+                    return;
                 }
-                Output::AskPermission => {
-                    tx.send(AskEvent::ToolUsePermission(id.clone()).into())
+                match out {
+                    Output::ToolOutput(chunk) => {
+                        tx.send(
+                            AnswerEvent::ToolOutput {
+                                id: id.clone(),
+                                chunk,
+                            }
+                            .into(),
+                        )
                         .unwrap();
+                    }
+                    Output::AskPermission => {
+                        tx.send(AskEvent::ToolUsePermission(id.clone()).into())
+                            .unwrap();
+                    }
+                    Output::TextEdit(edit) => {
+                        tx.send(
+                            AskEvent::TextEdit {
+                                id: id.clone(),
+                                edit,
+                            }
+                            .into(),
+                        )
+                        .unwrap();
+                    }
+                    Output::Success(output) => {
+                        tx.send(
+                            AnswerEvent::ToolResult {
+                                id: id.clone(),
+                                is_error: false,
+                                output,
+                            }
+                            .into(),
+                        )
+                        .unwrap();
+                    }
+                    Output::Failure(output) => {
+                        tx.send(
+                            AnswerEvent::ToolResult {
+                                id: id.clone(),
+                                is_error: true,
+                                output,
+                            }
+                            .into(),
+                        )
+                        .unwrap();
+                    }
+                    Output::Denied => (),
                 }
-                Output::TextEdit(edit) => {
-                    tx.send(
-                        AskEvent::TextEdit {
-                            id: id.clone(),
-                            edit,
-                        }
-                        .into(),
-                    )
-                    .unwrap();
-                }
-                Output::Success(output) => {
-                    tx.send(
-                        AnswerEvent::ToolResult {
-                            id: id.clone(),
-                            is_error: false,
-                            output,
-                        }
-                        .into(),
-                    )
-                    .unwrap();
-                }
-                Output::Failure(output) => {
-                    tx.send(
-                        AnswerEvent::ToolResult {
-                            id: id.clone(),
-                            is_error: true,
-                            output,
-                        }
-                        .into(),
-                    )
-                    .unwrap();
-                }
-                Output::Denied => (),
             },
         )
         .await;
+    match status {
+        Ok(ExecuteStatus::Completed) => {}
+        Ok(ExecuteStatus::Cancelled) => {
+            action_tx.send(ToolAction::Cancel(tool_use).into()).ok();
+            tx.send(AnswerEvent::Cancelled.into()).ok();
+        }
+        Err(err) => {
+            warn!(?err, "failed to execute tool");
+        }
+    }
 }
 
 async fn task_apply_text_edit(

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1213,59 +1213,54 @@ async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: Cancel
             &name,
             code_combo::Input::Starter(input),
             cancel_token.clone(),
-            |out| {
-                if cancel_token.is_cancelled() {
-                    return;
+            |out| match out {
+                Output::ToolOutput(chunk) => {
+                    tx.send(
+                        AnswerEvent::ToolOutput {
+                            id: id.clone(),
+                            chunk,
+                        }
+                        .into(),
+                    )
+                    .unwrap();
                 }
-                match out {
-                    Output::ToolOutput(chunk) => {
-                        tx.send(
-                            AnswerEvent::ToolOutput {
-                                id: id.clone(),
-                                chunk,
-                            }
-                            .into(),
-                        )
+                Output::AskPermission => {
+                    tx.send(AskEvent::ToolUsePermission(id.clone()).into())
                         .unwrap();
-                    }
-                    Output::AskPermission => {
-                        tx.send(AskEvent::ToolUsePermission(id.clone()).into())
-                            .unwrap();
-                    }
-                    Output::TextEdit(edit) => {
-                        tx.send(
-                            AskEvent::TextEdit {
-                                id: id.clone(),
-                                edit,
-                            }
-                            .into(),
-                        )
-                        .unwrap();
-                    }
-                    Output::Success(output) => {
-                        tx.send(
-                            AnswerEvent::ToolResult {
-                                id: id.clone(),
-                                is_error: false,
-                                output,
-                            }
-                            .into(),
-                        )
-                        .unwrap();
-                    }
-                    Output::Failure(output) => {
-                        tx.send(
-                            AnswerEvent::ToolResult {
-                                id: id.clone(),
-                                is_error: true,
-                                output,
-                            }
-                            .into(),
-                        )
-                        .unwrap();
-                    }
-                    Output::Denied => (),
                 }
+                Output::TextEdit(edit) => {
+                    tx.send(
+                        AskEvent::TextEdit {
+                            id: id.clone(),
+                            edit,
+                        }
+                        .into(),
+                    )
+                    .unwrap();
+                }
+                Output::Success(output) => {
+                    tx.send(
+                        AnswerEvent::ToolResult {
+                            id: id.clone(),
+                            is_error: false,
+                            output,
+                        }
+                        .into(),
+                    )
+                    .unwrap();
+                }
+                Output::Failure(output) => {
+                    tx.send(
+                        AnswerEvent::ToolResult {
+                            id: id.clone(),
+                            is_error: true,
+                            output,
+                        }
+                        .into(),
+                    )
+                    .unwrap();
+                }
+                Output::Denied => (),
             },
         )
         .await;

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,8 +1,7 @@
 use coco_macro::ComponentExt;
 use code_combo::{
-    Agent, Block as ChatBlock, Config, Content as ChatContent, ExecuteStatus,
-    Message as ChatMessage, Output, SessionEnv, StarterCommand, StarterError, StarterEvent,
-    StopReason, TextEdit, ToolUse,
+    Agent, Block as ChatBlock, Config, Content as ChatContent, Message as ChatMessage, Output,
+    SessionEnv, StarterCommand, StarterError, StarterEvent, StopReason, TextEdit, ToolUse,
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use futures::StreamExt;
@@ -605,6 +604,7 @@ impl Component for Chat<'static> {
             }
             Event::Answer(AnswerEvent::ToolResult {
                 id,
+                is_user_cancelled,
                 is_error,
                 output,
             }) => {
@@ -617,11 +617,15 @@ impl Component for Chat<'static> {
                     self.messages.blur();
                 }
                 // Add ToolResult message to send execution result to LLM API Server
+                let mut content: code_combo::Content = output.try_into().unwrap();
+                if *is_user_cancelled {
+                    content = content.user_cancel();
+                }
                 // TODO: Allow user to retry if tool use fails.
                 let content = ChatContent::Multiple(vec![code_combo::Block::ToolResult {
                     tool_use_id: id.clone(),
                     is_error: Some(*is_error),
-                    content: output.try_into().unwrap(),
+                    content,
                 }]);
                 let content = self.build_user_content(content);
                 self.spawn_chat_task(content);
@@ -1173,10 +1177,6 @@ async fn task_chat(mut agent: Agent, content: ChatContent, cancel_token: Cancell
         }
     }
 
-    if cancel_token.is_cancelled() {
-        tx.send(AnswerEvent::Cancelled.into()).ok();
-        return;
-    }
     tx.send(AnswerEvent::Bot(bot_messages).into()).unwrap();
 
     if !to_execute.is_empty() {
@@ -1205,9 +1205,8 @@ async fn task_chat(mut agent: Agent, content: ChatContent, cancel_token: Cancell
 
 async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: CancellationToken) {
     let tx = global::event_tx();
-    let action_tx = global::action_tx();
     let code_combo::ToolUse { id, name, input } = tool_use.clone();
-    let status = agent
+    let _ = agent
         .execute_with_output(
             &id,
             &name,
@@ -1243,6 +1242,7 @@ async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: Cancel
                         AnswerEvent::ToolResult {
                             id: id.clone(),
                             is_error: false,
+                            is_user_cancelled: cancel_token.is_cancelled(),
                             output,
                         }
                         .into(),
@@ -1254,6 +1254,7 @@ async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: Cancel
                         AnswerEvent::ToolResult {
                             id: id.clone(),
                             is_error: true,
+                            is_user_cancelled: cancel_token.is_cancelled(),
                             output,
                         }
                         .into(),
@@ -1264,16 +1265,6 @@ async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: Cancel
             },
         )
         .await;
-    match status {
-        Ok(ExecuteStatus::Completed) => {}
-        Ok(ExecuteStatus::Cancelled) => {
-            action_tx.send(ToolAction::Cancel(tool_use).into()).ok();
-            tx.send(AnswerEvent::Cancelled.into()).ok();
-        }
-        Err(err) => {
-            warn!(?err, "failed to execute tool");
-        }
-    }
 }
 
 async fn task_apply_text_edit(
@@ -1302,6 +1293,7 @@ async fn task_apply_text_edit(
                     AnswerEvent::ToolResult {
                         id,
                         is_error,
+                        is_user_cancelled: false,
                         output,
                     }
                     .into(),

--- a/crates/coco-tui/src/components/input.rs
+++ b/crates/coco-tui/src/components/input.rs
@@ -37,7 +37,9 @@ impl Input<'_> {
     pub fn clear(&mut self) -> String {
         self.textarea.select_all();
         self.textarea.cut();
-        self.textarea.yank_text()
+        let ans = self.textarea.yank_text();
+        self.textarea.set_yank_text("");
+        ans
     }
 }
 

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -1,9 +1,7 @@
 use std::collections::VecDeque;
 
 use coco_macro::{ComponentExt, ContentComponentExt};
-use code_combo::{SessionEnv, StarterCommand};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use futures::StreamExt;
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout},
@@ -13,14 +11,14 @@ use ratatui::{
     widgets::{Block, Borders},
 };
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::{
-    actions::{Action, ComboAction},
+    actions::Action,
     components::{Component, Content, ContentComponent, Persistable, Plain},
     error::*,
     events::{ComboEvent, Event},
-    global::{self, State},
+    global::State,
     session::{self, Session},
     widgets::Paragraph,
 };
@@ -30,6 +28,7 @@ enum StarterState {
     #[default]
     Discovering,
     NotFound,
+    Cancelled,
     Executing {
         output: VecDeque<DisplayedLine>,
     },
@@ -112,17 +111,32 @@ impl Combo {
             }
             ComboEvent::Executed { name, starter, .. } => {
                 if &self.state.name == name {
-                    let mut state = self.state.write();
-                    let output = match &starter.combo {
-                        Ok(combo) => combo.to_markdown(),
-                        Err(err) => {
-                            state.is_error = true;
-                            format!("Failed to execute starter: {err}")
-                        }
-                    };
-                    self.widget = Some(Plain::new(output.clone()));
-                    state.starter_state = StarterState::Finalized { output };
-                    state.collapsed = false;
+                    {
+                        let mut state = self.state.write();
+                        let output = match &starter.combo {
+                            Ok(combo) => combo.to_markdown(),
+                            Err(err) => {
+                                state.is_error = true;
+                                format!("Failed to execute starter: {err}")
+                            }
+                        };
+                        self.widget = Some(Plain::new(output.clone()));
+                        state.starter_state = StarterState::Finalized { output };
+                        state.collapsed = false;
+                    }
+                }
+            }
+            ComboEvent::Cancelled { name } => {
+                if name
+                    .as_ref()
+                    .map(|name| name == &self.state.name)
+                    .unwrap_or(true)
+                {
+                    {
+                        let mut state = self.state.write();
+                        state.starter_state = StarterState::Cancelled;
+                        state.collapsed = false;
+                    }
                 }
             }
             _ => (),
@@ -170,6 +184,10 @@ impl Combo {
             StarterState::NotFound => {
                 spans.push(self.state.name.clone().cyan());
                 spans.push("   Not found".red())
+            }
+            StarterState::Cancelled => {
+                spans.push(self.state.name.clone().cyan());
+                spans.push("   Cancelled".red());
             }
             StarterState::Executing { .. } => {
                 spans.push(self.state.name.clone().cyan());
@@ -289,17 +307,8 @@ impl Component for Combo {
 
     fn update(&mut self, action: &Action) {
         debug!(?action, "updating");
-        match action {
-            Action::Combo(combo) => match combo {
-                ComboAction::Discover => {
-                    tokio::task::spawn(discover());
-                }
-                ComboAction::Execute { name } => {
-                    tokio::task::spawn(execute(name.to_owned()));
-                }
-            },
-            Action::Blur => self.on_blur(),
-            _ => (),
+        if let Action::Blur = action {
+            self.on_blur()
         }
     }
 
@@ -335,93 +344,6 @@ impl Component for Combo {
 }
 
 impl ContentComponent for Combo {}
-
-async fn discover() {
-    let tx = global::event_tx();
-    let config = global::config().await;
-    let combo_dir = config.combo_dir();
-
-    tx.send(ComboEvent::Discovering.into()).unwrap();
-    let starters = code_combo::discover_combo_starters(&combo_dir.to_string_lossy()).await;
-    tx.send(ComboEvent::Discovered { starters }.into()).unwrap();
-}
-
-async fn execute(name: String) {
-    let tx = global::event_tx();
-    let config = global::config().await;
-    let combo_dir = config.combo_dir();
-    let starters = {
-        tx.send(ComboEvent::Discovering.into()).unwrap();
-        let starters = code_combo::discover_combo_starters(&combo_dir.to_string_lossy()).await;
-        tx.send(
-            ComboEvent::Discovered {
-                starters: starters.clone(),
-            }
-            .into(),
-        )
-        .unwrap();
-        starters
-    };
-    if let Some(starter) = starters.into_iter().find(|starter| match &starter.combo {
-        Ok(combo) => combo.metadata.name == name,
-        Err(err) => {
-            warn!(?starter.path, ?err,"Failed to load combo");
-            false
-        }
-    }) && let Ok(_combo) = &starter.combo
-    {
-        tx.send(ComboEvent::Executing { name: name.clone() }.into())
-            .unwrap();
-
-        let session_env = SessionEnv::builder()
-            .build()
-            .expect("failed to build session");
-        let mut execution = StarterCommand::new(&starter.path)
-            .session_env(session_env)
-            .execute();
-        while let Some(event) = execution.next().await {
-            match event {
-                code_combo::StarterEvent::Output { chunk } => {
-                    tx.send(
-                        ComboEvent::Output {
-                            name: name.clone(),
-                            chunk,
-                        }
-                        .into(),
-                    )
-                    .unwrap();
-                }
-                code_combo::StarterEvent::Failed { reason } => {
-                    tx.send(
-                        ComboEvent::Executed {
-                            name: name.clone(),
-                            starter: code_combo::Starter {
-                                path: starter.path.clone(),
-                                combo: Err(code_combo::StarterError::Invalid { reason }),
-                            },
-                        }
-                        .into(),
-                    )
-                    .unwrap();
-                    return;
-                }
-                _ => (),
-            }
-        }
-        let starter = execution.wait().await.unwrap();
-        tx.send(
-            ComboEvent::Executed {
-                name: name.clone(),
-                starter,
-            }
-            .into(),
-        )
-        .unwrap();
-    } else {
-        tx.send(ComboEvent::NotFound { name: name.clone() }.into())
-            .unwrap();
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -585,6 +585,7 @@ mod tests {
         bash.handle_event(&Event::Answer(AnswerEvent::ToolResult {
             id: "tool_1".to_string(),
             is_error: false,
+            is_user_cancelled: false,
             output: Final::Json(value),
         }));
         assert!(!bash.state.collapsed);
@@ -595,6 +596,7 @@ mod tests {
         bash.handle_event(&Event::Answer(AnswerEvent::ToolResult {
             id: "tool_1".to_string(),
             is_error: true,
+            is_user_cancelled: false,
             output: Final::Json(value),
         }));
         assert!(!bash.state.collapsed);
@@ -698,6 +700,7 @@ mod tests {
         bash.handle_event(&Event::Answer(AnswerEvent::ToolResult {
             id: "tool_1".to_string(),
             is_error: false,
+            is_user_cancelled: false,
             output: Final::Json(value),
         }));
         assert!(!bash.state.collapsed);

--- a/crates/coco-tui/src/components/messages/tool/str_replace.rs
+++ b/crates/coco-tui/src/components/messages/tool/str_replace.rs
@@ -793,6 +793,7 @@ mod tests {
         widget.handle_event(&Event::Answer(AnswerEvent::ToolResult {
             id: "tool_1".to_string(),
             is_error: false,
+            is_user_cancelled: false,
             output: Final::Message("Success".to_string()),
         }));
 
@@ -814,6 +815,7 @@ mod tests {
         widget.handle_event(&Event::Answer(AnswerEvent::ToolResult {
             id: "tool_1".to_string(),
             is_error: true,
+            is_user_cancelled: false,
             output: Final::Message("Write failed".to_string()),
         }));
 
@@ -854,6 +856,7 @@ mod tests {
         widget1.handle_event(&Event::Answer(AnswerEvent::ToolResult {
             id: "tool_1".to_string(),
             is_error: false,
+            is_user_cancelled: false,
             output: Final::Message("Success".to_string()),
         }));
 
@@ -886,6 +889,7 @@ mod tests {
         widget2.handle_event(&Event::Answer(AnswerEvent::ToolResult {
             id: "tool_2".to_string(),
             is_error: true,
+            is_user_cancelled: false,
             output: Final::Message("Failed".to_string()),
         }));
 

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -33,6 +33,7 @@ impl From<AskEvent> for Event {
 #[derive(Debug, Clone)]
 pub enum AnswerEvent {
     Bot(Vec<BotMessage>),
+    Cancelled,
     // Below events come from User
     ToolOutput {
         id: String,
@@ -61,6 +62,7 @@ pub enum ComboEvent {
     Executed { name: String, starter: Starter },
 
     NotFound { name: String },
+    Cancelled { name: Option<String> },
 }
 
 impl From<ComboEvent> for Event {

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -42,6 +42,7 @@ pub enum AnswerEvent {
     ToolResult {
         id: String,
         is_error: bool,
+        is_user_cancelled: bool,
         output: Final,
     },
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anthropic::Client;
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use super::Config;
@@ -10,7 +11,7 @@ use executor::PermissionControl;
 
 mod executor;
 pub use anthropic::{Block, Content, Message, Role, StopReason, ToolUse};
-pub use executor::{Executor, Input, Output};
+pub use executor::{ExecuteStatus, Executor, Input, Output};
 
 #[derive(Clone)]
 pub struct Agent {
@@ -94,13 +95,14 @@ impl Agent {
         id: &str,
         name: &str,
         input: executor::Input<'a>,
+        cancel_token: CancellationToken,
         on_output: F,
-    ) -> Result<()>
+    ) -> Result<ExecuteStatus>
     where
         F: FnMut(Output) + Send,
     {
         self.executor
-            .execute_with_output(id, name, input, on_output)
+            .execute_with_output(id, name, input, cancel_token, on_output)
             .await
     }
 

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use lazy_static::lazy_static;
 use snafu::prelude::*;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     OutputChunk, TextEdit, error,
@@ -61,6 +62,12 @@ pub use tools::Input;
 //    ToolInput(tools::Input<'a>),
 //}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecuteStatus {
+    Completed,
+    Cancelled,
+}
+
 #[derive(Debug)]
 pub enum Output {
     Success(Final),
@@ -114,12 +121,17 @@ impl Executor {
         input: Input<'a>,
     ) -> error::Result<Output> {
         let mut final_output: Option<Output> = None;
-        self.execute_with_output(id, name, input, |out| {
-            if !matches!(out, Output::ToolOutput(_)) {
-                final_output = Some(out);
-            }
-        })
-        .await?;
+        let cancel_token = CancellationToken::new();
+        let status = self
+            .execute_with_output(id, name, input, cancel_token, |out| {
+                if !matches!(out, Output::ToolOutput(_)) {
+                    final_output = Some(out);
+                }
+            })
+            .await?;
+        if matches!(status, ExecuteStatus::Cancelled) {
+            return Ok(Output::Denied);
+        }
         Ok(final_output.unwrap_or(Output::Denied))
     }
 
@@ -128,11 +140,16 @@ impl Executor {
         id: &str,
         name: &str,
         input: Input<'a>,
+        cancel_token: CancellationToken,
         mut on_output: F,
-    ) -> error::Result<()>
+    ) -> error::Result<ExecuteStatus>
     where
         F: FnMut(Output) + Send,
     {
+        if cancel_token.is_cancelled() {
+            return Ok(ExecuteStatus::Cancelled);
+        }
+
         // Check tool
         let Some(tool) = self.tools.get(name).cloned() else {
             return Err(NotFoundSnafu {
@@ -157,7 +174,7 @@ impl Executor {
                     STR_REPLACE_TOOL_NAME | READ_TOOL_NAME | LIST_TOOL_NAME
                 ) {
                     on_output(Output::AskPermission);
-                    return Ok(());
+                    return Ok(ExecuteStatus::Completed);
                 }
             };
         }
@@ -168,20 +185,32 @@ impl Executor {
                     let parsed: Result<BashInput, _> = serde_json::from_value(value.clone());
                     match parsed {
                         Ok(input) => {
-                            let output = match run_bash_chunked(input, |chunk| {
-                                on_output(Output::ToolOutput(chunk.clone()));
-                            })
-                            .await
-                            {
-                                Ok(output) => output,
-                                Err(err) => BashOutput {
-                                    exit_code: 255,
-                                    stdout: String::new(),
-                                    stderr: err,
-                                    chunks: Vec::new(),
-                                    timed_out: false,
-                                },
-                            };
+                            let output =
+                                match run_bash_chunked(input, cancel_token.clone(), |chunk| {
+                                    if cancel_token.is_cancelled() {
+                                        return;
+                                    }
+                                    on_output(Output::ToolOutput(chunk.clone()));
+                                })
+                                .await
+                                {
+                                    Ok(output) => output,
+                                    Err(err) => {
+                                        if cancel_token.is_cancelled() {
+                                            return Ok(ExecuteStatus::Cancelled);
+                                        }
+                                        BashOutput {
+                                            exit_code: 255,
+                                            stdout: String::new(),
+                                            stderr: err,
+                                            chunks: Vec::new(),
+                                            timed_out: false,
+                                        }
+                                    }
+                                };
+                            if cancel_token.is_cancelled() {
+                                return Ok(ExecuteStatus::Cancelled);
+                            }
                             let is_error = output.exit_code != 0;
                             let final_output = Final::Json(serde_json::to_value(output).unwrap());
                             on_output(if is_error {
@@ -189,23 +218,41 @@ impl Executor {
                             } else {
                                 Output::Success(final_output)
                             });
-                            return Ok(());
+                            return Ok(ExecuteStatus::Completed);
                         }
                         Err(_) => {
-                            on_output(tool.execute(Input::Starter(value)).await.into());
-                            return Ok(());
+                            let output = tokio::select! {
+                                _ = cancel_token.cancelled() => {
+                                    return Ok(ExecuteStatus::Cancelled);
+                                }
+                                output = tool.execute(Input::Starter(value)) => output,
+                            };
+                            on_output(output.into());
+                            return Ok(ExecuteStatus::Completed);
                         }
                     }
                 }
                 _ => {
-                    on_output(tool.execute(input).await.into());
-                    return Ok(());
+                    let output = tokio::select! {
+                        _ = cancel_token.cancelled() => {
+                            return Ok(ExecuteStatus::Cancelled);
+                        }
+                        output = tool.execute(input) => output,
+                    };
+                    on_output(output.into());
+                    return Ok(ExecuteStatus::Completed);
                 }
             }
         }
 
-        on_output(tool.execute(input).await.into());
-        Ok(())
+        let output = tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return Ok(ExecuteStatus::Cancelled);
+            }
+            output = tool.execute(input) => output,
+        };
+        on_output(output.into());
+        Ok(ExecuteStatus::Completed)
     }
 
     /// Update Permission Control List

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -8,8 +8,8 @@ use super::bash_executor;
 use crate::{
     OutputChunk, TextEdit, error,
     tools::{
-        self, BASH_TOOL_NAME, BashInput, BashOutput, BashTool, Final, LIST_TOOL_NAME, ListTool,
-        READ_TOOL_NAME, ReadTool, STR_REPLACE_TOOL_NAME, StrReplaceTool, Tool, run_bash_chunked,
+        self, BASH_TOOL_NAME, BashInput, BashTool, Final, LIST_TOOL_NAME, ListTool, READ_TOOL_NAME,
+        ReadTool, STR_REPLACE_TOOL_NAME, StrReplaceTool, Tool, run_bash_chunked,
     },
 };
 
@@ -192,68 +192,15 @@ impl Executor {
         }
 
         if name == BASH_TOOL_NAME {
-            match input {
-                Input::Starter(value) => {
-                    let parsed: Result<BashInput, _> = serde_json::from_value(value.clone());
-                    match parsed {
-                        Ok(input) => {
-                            let output =
-                                match run_bash_chunked(input, cancel_token.clone(), |chunk| {
-                                    if cancel_token.is_cancelled() {
-                                        return;
-                                    }
-                                    on_output(Output::ToolOutput(chunk.clone()));
-                                })
-                                .await
-                                {
-                                    Ok(output) => output,
-                                    Err(err) => {
-                                        if cancel_token.is_cancelled() {
-                                            return Ok(ExecuteStatus::Cancelled);
-                                        }
-                                        BashOutput {
-                                            exit_code: 255,
-                                            stdout: String::new(),
-                                            stderr: err,
-                                            chunks: Vec::new(),
-                                            timed_out: false,
-                                        }
-                                    }
-                                };
-                            if cancel_token.is_cancelled() {
-                                return Ok(ExecuteStatus::Cancelled);
-                            }
-                            let is_error = output.exit_code != 0;
-                            let final_output = Final::Json(serde_json::to_value(output).unwrap());
-                            on_output(if is_error {
-                                Output::Failure(final_output)
-                            } else {
-                                Output::Success(final_output)
-                            });
-                            return Ok(ExecuteStatus::Completed);
-                        }
-                        Err(_) => {
-                            let output = tokio::select! {
-                                _ = cancel_token.cancelled() => {
-                                    return Ok(ExecuteStatus::Cancelled);
-                                }
-                                output = tool.execute(Input::Starter(value)) => output,
-                            };
-                            on_output(output.into());
-                            return Ok(ExecuteStatus::Completed);
-                        }
-                    }
-                }
-                _ => {
-                    let output = tokio::select! {
-                        _ = cancel_token.cancelled() => {
-                            return Ok(ExecuteStatus::Cancelled);
-                        }
-                        output = tool.execute(input) => output,
-                    };
-                    on_output(output.into());
-                    return Ok(ExecuteStatus::Completed);
-                }
+            let output = run_bash_chunked(input, cancel_token.clone(), |chunk| {
+                on_output(Output::ToolOutput(chunk.clone()));
+            })
+            .await;
+            on_output(output.into());
+            if cancel_token.is_cancelled() {
+                return Ok(ExecuteStatus::Cancelled);
+            } else {
+                return Ok(ExecuteStatus::Completed);
             }
         }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -20,8 +20,8 @@ mod read;
 mod str_replace;
 
 use crate::{AppliedTextEdit, TextEdit};
+pub(crate) use bash::run_bash_chunked;
 pub use bash::{BASH_TOOL_NAME, BashInput, BashOutput, BashTool};
-pub use bash::{run_bash, run_bash_chunked};
 pub use list::{DEFAULT_ENTRY_LIMIT, LIST_TOOL_NAME, ListInput, ListTool, MAX_ENTRY_LIMIT};
 pub use read::{
     DEFAULT_LINE_LIMIT, DEFAULT_LINE_OFFSET, MAX_LINE_LIMIT, READ_TOOL_NAME, ReadInput, ReadTool,

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -5,6 +5,7 @@ use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 
 use super::{ExecuteResult, Final, Input, Tool};
 use crate::exec::{ChunkConfig, ExecCommand, OutputChunk, ProcessEvent, StreamKind};
@@ -38,7 +39,11 @@ fn default_timeout_ms() -> u64 {
 
 pub const BASH_TOOL_NAME: &str = "bash";
 
-pub async fn run_bash_chunked<F>(input: BashInput, mut on_chunk: F) -> Result<BashOutput, String>
+pub async fn run_bash_chunked<F>(
+    input: BashInput,
+    cancel_token: CancellationToken,
+    mut on_chunk: F,
+) -> Result<BashOutput, String>
 where
     F: FnMut(&OutputChunk) + Send,
 {
@@ -64,6 +69,11 @@ where
 
     loop {
         tokio::select! {
+            _ = cancel_token.cancelled() => {
+                output.exit_code = 130;
+                proc.killer.kill();
+                break;
+            }
             _ = &mut timeout_sleep => {
                 output.timed_out = true;
                 output.exit_code = 124;
@@ -115,7 +125,7 @@ where
 }
 
 pub async fn run_bash(input: BashInput) -> Result<BashOutput, String> {
-    run_bash_chunked(input, |_| {}).await
+    run_bash_chunked(input, CancellationToken::new(), |_| {}).await
 }
 
 #[async_trait]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -39,7 +39,56 @@ fn default_timeout_ms() -> u64 {
 
 pub const BASH_TOOL_NAME: &str = "bash";
 
-pub async fn run_bash_chunked<F>(
+pub async fn run_bash_chunked<'a, F>(
+    input: Input<'a>,
+    cancel_token: CancellationToken,
+    mut on_chunk: F,
+) -> ExecuteResult
+where
+    F: FnMut(&OutputChunk) + Send,
+{
+    let Input::Starter(input) = input else {
+        return err_msg!("Input should be Starter variant, not other variants");
+    };
+    let input: BashInput = match serde_json::from_value(input) {
+        Ok(value) => value,
+        Err(err) => {
+            let output = BashOutput {
+                exit_code: 255,
+                stdout: String::new(),
+                stderr: format!("Invalid input format: {err}"),
+                chunks: Vec::new(),
+                timed_out: false,
+            };
+            let output = serde_json::to_value(&output)
+                .map_err(|err| format!("Failed to serialize tool output: {err}"))?;
+            return Final::Json(output).err();
+        }
+    };
+
+    let output = match run_bash_chunked_raw(input, cancel_token, |chunk| on_chunk(chunk)).await {
+        Ok(output) => output,
+        Err(err) => BashOutput {
+            exit_code: 255,
+            stdout: String::new(),
+            stderr: err,
+            chunks: Vec::new(),
+            timed_out: false,
+        },
+    };
+
+    let exit_code = output.exit_code;
+    let output = serde_json::to_value(&output)
+        .map_err(|err| format!("Failed to serialize tool output: {err}"))?;
+    let output = Final::from(output);
+    if exit_code == 0 {
+        output.ok()
+    } else {
+        output.err()
+    }
+}
+
+async fn run_bash_chunked_raw<F>(
     input: BashInput,
     cancel_token: CancellationToken,
     mut on_chunk: F,
@@ -124,10 +173,6 @@ where
     Ok(output)
 }
 
-pub async fn run_bash(input: BashInput) -> Result<BashOutput, String> {
-    run_bash_chunked(input, CancellationToken::new(), |_| {}).await
-}
-
 #[async_trait]
 impl Tool for BashTool {
     fn name(&self) -> &'static str {
@@ -150,45 +195,7 @@ impl Tool for BashTool {
     }
 
     async fn execute<'a>(&self, input: Input<'a>) -> ExecuteResult {
-        let Input::Starter(input) = input else {
-            return err_msg!("Input should be Starter variant, not other variants");
-        };
-        let input: BashInput = match serde_json::from_value(input) {
-            Ok(value) => value,
-            Err(err) => {
-                let output = BashOutput {
-                    exit_code: 255,
-                    stdout: String::new(),
-                    stderr: format!("Invalid input format: {err}"),
-                    chunks: Vec::new(),
-                    timed_out: false,
-                };
-                let value = serde_json::to_value(&output)
-                    .map_err(|err| format!("Failed to serialize tool output: {err}"))?;
-                return Final::Json(value).err();
-            }
-        };
-
-        let output = match run_bash(input).await {
-            Ok(output) => output,
-            Err(err) => BashOutput {
-                exit_code: 255,
-                stdout: String::new(),
-                stderr: err,
-                chunks: Vec::new(),
-                timed_out: false,
-            },
-        };
-
-        let exit_code = output.exit_code;
-        let output = serde_json::to_value(&output)
-            .map_err(|err| format!("Failed to serialize tool output: {err}"))?;
-        let output = Final::from(output);
-        if exit_code == 0 {
-            output.ok()
-        } else {
-            output.err()
-        }
+        run_bash_chunked(input, CancellationToken::new(), |_| {}).await
     }
 }
 
@@ -254,5 +261,22 @@ mod tests {
 
         assert!(output.timed_out);
         assert_eq!(output.exit_code, 124);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bash_invalid_input_returns_json_error() {
+        let tool = BashTool::default();
+        let input = Input::Starter(json!({
+            "timeout": "bad",
+        }));
+
+        let err = tool.execute(input).await.unwrap_err();
+        let Final::Json(value) = err else {
+            panic!("expected JSON Final error output");
+        };
+        let output: BashOutput = serde_json::from_value(value).unwrap();
+
+        assert_eq!(output.exit_code, 255);
+        assert!(output.stderr.contains("Invalid input format"));
     }
 }


### PR DESCRIPTION
- Add Ctrl+C double-tap confirmation for exit with 2-second window
- Implement cancellation guard system for all async operations (chat, combo discovery/execution, tool execution)
- Add cancellation support to bash tool execution with proper exit code handling
- Refactor combo discovery and execution with proper cancellation handling
- Add cancellation status tracking and UI reminders for Ctrl+C actions
- Move Ctrl+C handling from app.rs to chat component for better UX
- Update dependencies to use workspace versions for tokio-util consistency
- Fix input clearing to properly reset yank text buffer
- Improve state management with dedicated ready/processing state methods