### PR TITLE
feat: add safe command bypass for trusted bash commands

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,6 +8,7 @@ use super::Config;
 use crate::Result;
 use executor::PermissionControl;
 
+mod bash_executor;
 mod executor;
 pub use anthropic::{Block, Content, Message, Role, StopReason, ToolUse};
 pub use executor::{Executor, Input, Output};

--- a/src/agent/bash_executor.rs
+++ b/src/agent/bash_executor.rs
@@ -1,0 +1,132 @@
+use lazy_static::lazy_static;
+use serde::Deserialize;
+use toml as serde_toml;
+use tracing::warn;
+
+use crate::tools::BashInput;
+
+#[derive(Clone)]
+struct SafeCommandRule {
+    name: String,
+    args: ArgPolicy,
+}
+
+#[derive(Clone)]
+enum ArgPolicy {
+    Any,
+    Deny,
+}
+
+const SAFE_COMMANDS_TOML: &str = include_str!("safe_commands.toml");
+
+#[derive(Deserialize)]
+struct SafeCommandConfig {
+    commands: Vec<SafeCommandConfigEntry>,
+}
+
+#[derive(Deserialize)]
+struct SafeCommandConfigEntry {
+    name: String,
+    #[serde(default)]
+    allow_any: bool,
+}
+
+lazy_static! {
+    static ref SAFE_COMMAND_RULES: Vec<SafeCommandRule> = load_safe_command_rules();
+}
+
+const SHELL_UNSAFE_CHARS: &[char] = &[';', '|', '&', '>', '<', '`', '\n', '\r'];
+
+pub fn should_bypass_permission(input: &BashInput) -> bool {
+    is_safe_command(&input.command)
+}
+
+fn is_safe_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if trimmed.contains("$(") {
+        return false;
+    }
+
+    if trimmed.chars().any(|ch| SHELL_UNSAFE_CHARS.contains(&ch)) {
+        return false;
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    let Some(cmd) = parts.next() else {
+        return false;
+    };
+
+    let args: Vec<&str> = parts.collect();
+    let Some(rule) = SAFE_COMMAND_RULES.iter().find(|rule| rule.name == cmd) else {
+        return false;
+    };
+    is_safe_args(&args, &rule.args)
+}
+
+fn is_safe_args(_args: &[&str], policy: &ArgPolicy) -> bool {
+    if matches!(policy, ArgPolicy::Any) {
+        return true;
+    }
+    false
+}
+
+fn load_safe_command_rules() -> Vec<SafeCommandRule> {
+    let config: SafeCommandConfig = match serde_toml::from_str(SAFE_COMMANDS_TOML) {
+        Ok(config) => config,
+        Err(err) => {
+            warn!("failed to parse safe_commands.toml: {err}");
+            return Vec::new();
+        }
+    };
+
+    config
+        .commands
+        .into_iter()
+        .map(|entry| {
+            if entry.allow_any {
+                return SafeCommandRule {
+                    name: entry.name,
+                    args: ArgPolicy::Any,
+                };
+            }
+            SafeCommandRule {
+                name: entry.name,
+                args: ArgPolicy::Deny,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_command_allows_simple_invocation() {
+        assert!(is_safe_command("ls"));
+        assert!(is_safe_command("pwd"));
+        assert!(is_safe_command("cat README.md"));
+        assert!(is_safe_command("ls -la"));
+    }
+
+    #[test]
+    fn unsafe_command_rejects_shell_chaining_or_substitution() {
+        assert!(!is_safe_command("ls; rm -rf /"));
+        assert!(!is_safe_command("cat file | head -n 1"));
+        assert!(!is_safe_command("echo $(whoami)"));
+        assert!(!is_safe_command("whoami && id"));
+        assert!(!is_safe_command("ls > out.txt"));
+    }
+
+    #[test]
+    fn unsafe_command_rejects_unknown_or_empty() {
+        assert!(!is_safe_command(""));
+        assert!(!is_safe_command("   "));
+        assert!(!is_safe_command("bash -c ls"));
+        assert!(!is_safe_command("sudo ls"));
+    }
+}

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use lazy_static::lazy_static;
 use snafu::prelude::*;
 
+use super::bash_executor;
 use crate::{
     OutputChunk, TextEdit, error,
     tools::{
@@ -152,10 +153,21 @@ impl Executor {
                 unimplemented!("Permission control list validation not yet implemented")
             } else {
                 // Some tools can execute without explicit permission
-                if !matches!(
-                    name,
-                    STR_REPLACE_TOOL_NAME | READ_TOOL_NAME | LIST_TOOL_NAME
-                ) {
+                let bypass_permission = match (&input, name) {
+                    (Input::Starter(value), BASH_TOOL_NAME) => {
+                        serde_json::from_value::<BashInput>(value.clone())
+                            .ok()
+                            .map(|input| bash_executor::should_bypass_permission(&input))
+                            .unwrap_or(false)
+                    }
+                    _ => false,
+                };
+                if !bypass_permission
+                    && !matches!(
+                        name,
+                        STR_REPLACE_TOOL_NAME | READ_TOOL_NAME | LIST_TOOL_NAME
+                    )
+                {
                     on_output(Output::AskPermission);
                     return Ok(());
                 }

--- a/src/agent/safe_commands.toml
+++ b/src/agent/safe_commands.toml
@@ -1,0 +1,95 @@
+[[commands]]
+name = "cat"
+allow_any = true
+
+[[commands]]
+name = "cd"
+allow_any = true
+
+[[commands]]
+name = "cut"
+allow_any = true
+
+[[commands]]
+name = "echo"
+allow_any = true
+
+[[commands]]
+name = "expr"
+allow_any = true
+
+[[commands]]
+name = "false"
+allow_any = true
+
+[[commands]]
+name = "grep"
+allow_any = true
+
+[[commands]]
+name = "head"
+allow_any = true
+
+[[commands]]
+name = "id"
+allow_any = true
+
+[[commands]]
+name = "ls"
+allow_any = true
+
+[[commands]]
+name = "nl"
+allow_any = true
+
+[[commands]]
+name = "paste"
+allow_any = true
+
+[[commands]]
+name = "pwd"
+allow_any = true
+
+[[commands]]
+name = "tail"
+allow_any = true
+
+[[commands]]
+name = "rev"
+allow_any = true
+
+[[commands]]
+name = "seq"
+allow_any = true
+
+[[commands]]
+name = "stat"
+allow_any = true
+
+[[commands]]
+name = "tr"
+allow_any = true
+
+[[commands]]
+name = "true"
+allow_any = true
+
+[[commands]]
+name = "uname"
+allow_any = true
+
+[[commands]]
+name = "uniq"
+allow_any = true
+
+[[commands]]
+name = "wc"
+allow_any = true
+
+[[commands]]
+name = "which"
+allow_any = true
+
+[[commands]]
+name = "whoami"
+allow_any = true


### PR DESCRIPTION
- Add bash_executor module with safe command validation logic
- Implement TOML-based configuration for safe commands (safe_commands.toml)
- Add permission bypass for trusted commands like ls, cat, pwd, grep, etc.
- Prevent bypass for commands with shell unsafe characters (;, |, &, >, <, `, $())
- Maintain security by requiring permission for unknown or potentially dangerous commands
- Add comprehensive test suite for safe/unsafe command detection