### PR TITLE
feat: add session-based permission grant for bash tool

### DIFF
--- a/crates/coco-tui/src/actions.rs
+++ b/crates/coco-tui/src/actions.rs
@@ -54,6 +54,7 @@ impl From<ComboAction> for Action {
 #[derive(Debug, Clone)]
 pub enum ToolAction {
     Grant(ToolUse),
+    GrantSession(ToolUse),
     Cancel(ToolUse),
     ApplyTextEdit {
         id: String,

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -353,6 +353,16 @@ impl Chat<'static> {
         tokio::task::spawn(task_combo_execute(name, cancel_token));
     }
 
+    fn spawn_tool_use(&mut self, tool_use: &ToolUse) {
+        self.set_processing();
+        let cancel_token = self.cancellation_guard.token();
+        tokio::task::spawn(task_tool_use(
+            self.agent.clone(),
+            tool_use.to_owned(),
+            cancel_token,
+        ));
+    }
+
     fn set_processing(&mut self) {
         if self.state.state != ChatState::Procesing {
             self.state.write().state = ChatState::Procesing;
@@ -731,15 +741,12 @@ impl Component for Chat<'static> {
             },
             Action::Tool(action) => match action {
                 ToolAction::Grant(tool_use) => {
-                    self.set_processing();
                     self.agent.grant_once(&tool_use.id, &tool_use.name);
-                    let cancel_token = self.cancellation_guard.token();
-
-                    tokio::task::spawn(task_tool_use(
-                        self.agent.clone(),
-                        tool_use.to_owned(),
-                        cancel_token,
-                    ));
+                    self.spawn_tool_use(tool_use);
+                }
+                ToolAction::GrantSession(tool_use) => {
+                    self.agent.grant_session(tool_use);
+                    self.spawn_tool_use(tool_use);
                 }
                 ToolAction::Cancel(tool_use) => {
                     // Move focus back to Input when tool use is cancelled.

--- a/crates/coco-tui/src/components/messages/tool.rs
+++ b/crates/coco-tui/src/components/messages/tool.rs
@@ -203,6 +203,11 @@ impl Component for Tool {
                     self.update_state(ToolState::Executing);
                 }
             }
+            Action::Tool(ToolAction::GrantSession(ToolUse { id, .. })) => {
+                if self.tool_use_id() == id {
+                    self.update_state(ToolState::Executing);
+                }
+            }
             Action::Tool(ToolAction::ApplyTextEdit {
                 id, is_rejecting, ..
             }) => {

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -278,7 +278,7 @@ impl<'a> Content for Bash<'a> {
     fn block_with_shortcuts_desc<'b>(&self, block: Block<'b>) -> Block<'b> {
         if self.state.requiring_confirmation {
             return block
-                .title_bottom(shortcuts_desc(&[("Run", "CR")]))
+                .title_bottom(shortcuts_desc(&[("Run", "CR"), ("Allow in Session", "A")]))
                 .title_bottom(shortcuts_desc(&[("Cancel", "Esc")]));
         }
 
@@ -427,6 +427,16 @@ impl Component for Bash<'static> {
                 self.state.write().collapsed = false;
                 global::action_tx()
                     .send(ToolAction::Grant(self.state.tool_use.to_owned()).into())
+                    .unwrap();
+                self.state.write().requiring_confirmation = false;
+            }
+            (KeyModifiers::NONE, KeyCode::Char('a') | KeyCode::Char('A')) => {
+                if !self.state.requiring_confirmation {
+                    return;
+                }
+                self.state.write().collapsed = false;
+                global::action_tx()
+                    .send(ToolAction::GrantSession(self.state.tool_use.to_owned()).into())
                     .unwrap();
                 self.state.write().requiring_confirmation = false;
             }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -79,6 +79,10 @@ impl Agent {
             .update_pcl(name, PermissionControl::Once(id.to_string()))
     }
 
+    pub fn grant_session(&mut self, tool_use: &ToolUse) {
+        self.executor.grant_session(&tool_use.name, &tool_use.input)
+    }
+
     pub async fn execute<'a>(
         &mut self,
         id: &str,

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use lazy_static::lazy_static;
 use snafu::prelude::*;
@@ -18,6 +21,7 @@ pub struct Executor {
     tools: HashMap<String, Arc<dyn Tool>>,
     tools_pcl: HashMap<String, Vec<(String, PermissionControl)>>,
     tools_once_pcl: HashMap<String, Vec<String>>,
+    bash_session_allowlist: HashSet<String>,
 }
 
 lazy_static! {
@@ -47,6 +51,7 @@ impl Default for Executor {
             tools_pcl: HashMap::default(),
             tools_once_pcl: HashMap::default(),
             tools: DEFAULT_TOOLS.clone(),
+            bash_session_allowlist: HashSet::default(),
         }
     }
 }
@@ -96,6 +101,23 @@ pub enum PermissionControl {
     Once(String),
     Session,
     Always,
+}
+
+fn bash_permission_key_from_value(value: &serde_json::Value) -> Option<String> {
+    let input: BashInput = serde_json::from_value(value.clone()).ok()?;
+    let trimmed = input.command.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn bash_permission_key(input: &Input<'_>) -> Option<String> {
+    match input {
+        Input::Starter(value) => bash_permission_key_from_value(value),
+        _ => None,
+    }
 }
 
 impl Executor {
@@ -162,8 +184,9 @@ impl Executor {
 
         // Check Permission
         let granted_once = self.take_once_permission(name, id);
+        let granted_session = self.has_session_permission(name, &input);
 
-        if !granted_once {
+        if !granted_once && !granted_session {
             // Check if the tool has permission control entries for this session
             if let Some(_pcl) = self.tools_pcl.get(name) {
                 // TODO: Implement permission control list validation logic
@@ -231,6 +254,26 @@ impl Executor {
         }
     }
 
+    pub fn grant_session(&mut self, name: &str, input: &serde_json::Value) {
+        if name != BASH_TOOL_NAME {
+            return;
+        }
+        let Some(key) = bash_permission_key_from_value(input) else {
+            return;
+        };
+        self.bash_session_allowlist.insert(key);
+    }
+
+    fn has_session_permission(&self, name: &str, input: &Input<'_>) -> bool {
+        if name != BASH_TOOL_NAME {
+            return false;
+        }
+        let Some(key) = bash_permission_key(input) else {
+            return false;
+        };
+        self.bash_session_allowlist.contains(&key)
+    }
+
     /// Generate a list of Tools of Anthropic API
     pub fn anthropic_tools(&self) -> Vec<anthropic::Tool> {
         self.tools
@@ -241,5 +284,62 @@ impl Executor {
                 input_schema: t.input_schema(),
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bash_input_value(command: &str) -> serde_json::Value {
+        serde_json::to_value(BashInput {
+            command: command.to_string(),
+            timeout: 1_000,
+        })
+        .expect("serialize BashInput")
+    }
+
+    #[tokio::test]
+    async fn bash_session_permission_allows_repeat_command() {
+        let mut executor = Executor::default();
+        let input_value = bash_input_value("printf 'ok'");
+
+        let mut outputs = Vec::new();
+        let _ = executor
+            .execute_with_output(
+                "1",
+                BASH_TOOL_NAME,
+                Input::Starter(input_value.clone()),
+                CancellationToken::new(),
+                |out| outputs.push(out),
+            )
+            .await
+            .expect("execute without session permission");
+        assert!(
+            outputs
+                .iter()
+                .any(|out| matches!(out, Output::AskPermission)),
+            "expected permission request before granting"
+        );
+
+        executor.grant_session(BASH_TOOL_NAME, &input_value);
+
+        let mut outputs = Vec::new();
+        let _ = executor
+            .execute_with_output(
+                "2",
+                BASH_TOOL_NAME,
+                Input::Starter(input_value),
+                CancellationToken::new(),
+                |out| outputs.push(out),
+            )
+            .await
+            .expect("execute with session permission");
+        assert!(
+            !outputs
+                .iter()
+                .any(|out| matches!(out, Output::AskPermission)),
+            "did not expect permission request after granting session"
+        );
     }
 }

--- a/src/combo/starter.rs
+++ b/src/combo/starter.rs
@@ -781,7 +781,7 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::{path::PathBuf, sync::OnceLock};
 
-    use indoc::formatdoc;
+    use indoc::{formatdoc, indoc};
     use tempfile::TempDir;
 
     use crate::combo::{RecordStartPayload, SessionSocketClient};
@@ -793,7 +793,7 @@ mod tests {
     fn coco_binary() -> PathBuf {
         COCO_BIN_PATH
             .get_or_init(|| {
-                if let Ok(path) = std::env::var("COCO_BIN") {
+                if let Ok(path) = std::env::var("COCO_TEST_BIN") {
                     return PathBuf::from(path);
                 }
                 PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -808,7 +808,11 @@ mod tests {
         let path = coco_binary();
         assert!(
             path.exists(),
-            "coco binary not found at {:?}; build `cargo build -p code-combo --bin coco` first or set COCO_BIN",
+            indoc! {"
+                coco binary not found at {:?};
+                build `cargo build -p code-combo --bin coco` first
+                or set COCO_TEST_BIN
+            "},
             path
         );
         SessionEnv::builder()


### PR DESCRIPTION
- Add ToolAction::GrantSession variant for session-level permissions
- Implement bash session allowlist in Executor with grant_session() method
- Add 'A' key shortcut in bash component UI for session permission grant
- Update permission check logic to consider both once and session permissions
- Add comprehensive test for bash session permission functionality
- Fix test environment variable name from COCO_BIN to COCO_TEST_BIN