### PR TITLE
feat: add auto-accept functionality for text edits

### DIFF
--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -501,7 +501,15 @@ impl Chat<'static> {
         let new_edit = edit.reject_hunk(context_radius, hunk_idx);
         if let Some(edit) = new_edit {
             // Notify components that text edits have been updated and need confirmation again
-            tx.send(AskEvent::TextEdit { id, edit }.into()).unwrap();
+            tx.send(
+                AskEvent::TextEdit {
+                    id,
+                    edit,
+                    auto_accept: false,
+                }
+                .into(),
+            )
+            .unwrap();
         } else {
             // Move focus back to Input when the tool interaction ends.
             if let Some(idx) = self.messages.locate_tool_message(&id)
@@ -638,9 +646,20 @@ impl Component for Chat<'static> {
             Event::Answer(AnswerEvent::Cancelled) => {
                 self.set_ready();
             }
-            Event::Ask(AskEvent::ToolUsePermission(_) | AskEvent::TextEdit { .. }) => {
+            Event::Ask(AskEvent::ToolUsePermission(_)) => {
                 if let Some(idx) = self.messages.on_tool_event(event) {
                     // Move focus to tool use message when permission is required
+                    self.update_focus(Focus::Messages);
+                    self.messages.focus(idx);
+                }
+                // Trigger session save after ask event
+                global::trigger_schedule_session_save();
+            }
+            Event::Ask(AskEvent::TextEdit { auto_accept, .. }) => {
+                if let Some(idx) = self.messages.on_tool_event(event)
+                    && !*auto_accept
+                {
+                    // Move focus to tool use message when confirmation is required
                     self.update_focus(Focus::Messages);
                     self.messages.focus(idx);
                 }
@@ -1233,6 +1252,7 @@ async fn task_chat(mut agent: Agent, content: ChatContent, cancel_token: Cancell
 async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: CancellationToken) {
     let tx = global::event_tx();
     let code_combo::ToolUse { id, name, input } = tool_use.clone();
+    let auto_accept = agent.auto_accept_edits();
     let _ = agent
         .execute_with_output(
             &id,
@@ -1259,6 +1279,7 @@ async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: Cancel
                         AskEvent::TextEdit {
                             id: id.clone(),
                             edit,
+                            auto_accept,
                         }
                         .into(),
                     )
@@ -1328,7 +1349,15 @@ async fn task_apply_text_edit(
                 .unwrap();
             } else if let Some(edit) = new_edit {
                 // Notify components that text edits have been updated and need confirmation again
-                tx.send(AskEvent::TextEdit { id, edit }.into()).unwrap();
+                tx.send(
+                    AskEvent::TextEdit {
+                        id,
+                        edit,
+                        auto_accept: false,
+                    }
+                    .into(),
+                )
+                .unwrap();
             }
         }
         _ => (),

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -10,7 +10,7 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     prelude::*,
     symbols::border,
-    text::Line,
+    text::{Line, Span},
     widgets::{Block, Borders},
 };
 
@@ -56,6 +56,8 @@ struct Inner {
 
     state: ChatState,
     focus: Focus,
+    #[serde(default)]
+    auto_accept_edits: bool,
     pending_chats: Vec<ChatBlock>,
     #[serde(with = "time::serde::rfc3339")]
     created_at: time::OffsetDateTime,
@@ -71,6 +73,7 @@ impl Default for Inner {
             messages: vec![],
             state: ChatState::Ready,
             focus: Focus::Input,
+            auto_accept_edits: false,
             pending_chats: Vec::new(),
             created_at: now,
             updated_at: now,
@@ -408,13 +411,25 @@ impl Chat<'static> {
         }
     }
 
+    fn toggle_auto_accept_edits(&mut self) {
+        let enabled = {
+            let mut state = self.state.write();
+            state.auto_accept_edits = !state.auto_accept_edits;
+            state.auto_accept_edits
+        };
+        self.agent.set_auto_accept_edits(enabled);
+        global::trigger_schedule_session_save();
+    }
+
     fn block_bottom_with_shortcuts_desc<'a>(&self, mut block: Block<'a>) -> Block<'a> {
         block = block.title_bottom(Line::from(""));
         match self.state.focus {
             Focus::Input => block
+                .title_bottom(shortcuts_desc(&[("AutoAccept", "S-Tab")]))
                 .title_bottom(shortcuts_desc(&[("Blur", "Esc")]))
                 .title_bottom(shortcuts_desc(&[("Submit", "CR")])),
             Focus::InputBlur => block
+                .title_bottom(shortcuts_desc(&[("AutoAccept", "S-Tab")]))
                 .title_bottom(shortcuts_desc(&[("Focus", "CR")]))
                 .title_bottom(shortcuts_desc(&[("Commands", "C-p")]))
                 .title_bottom(shortcuts_desc(&[("Up", "k"), ("Down", "j")])),
@@ -424,6 +439,7 @@ impl Chat<'static> {
                     block = block.title_bottom(shortcuts_desc(&[("Back", "Esc")]));
                 }
                 block
+                    .title_bottom(shortcuts_desc(&[("AutoAccept", "S-Tab")]))
                     .title_bottom(shortcuts_desc(&[("Up", "k"), ("Down", "j")]))
                     .title_bottom(shortcuts_desc(&[("Scroll Up", "C-y"), ("Down", "C-e")]))
                     .title_bottom(shortcuts_desc(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]))
@@ -457,6 +473,20 @@ impl Chat<'static> {
             ]),
         })
         .bold()
+    }
+
+    fn auto_accept_indicator(&self) -> Line<'static> {
+        let label = if self.state.auto_accept_edits {
+            "AutoAccept: ON"
+        } else {
+            "AutoAccept: OFF"
+        };
+        let style = if self.state.auto_accept_edits {
+            Style::default().green()
+        } else {
+            Style::default().dark_gray()
+        };
+        Line::from(Span::styled(format!(" {label} "), style))
     }
 
     fn reject_text_edit(
@@ -507,15 +537,19 @@ impl Chat<'static> {
             self.save_now();
         }
 
+        let auto_accept_edits = self.state.auto_accept_edits;
+
         // 2. Clear messages
         self.messages.clear();
 
         // 3. Reset state
         *self.state.write() = Inner {
             focus: Focus::InputBlur,
+            auto_accept_edits,
             ..Default::default()
         };
         self.cancellation_guard.reset();
+        self.agent.set_auto_accept_edits(auto_accept_edits);
 
         // 4. Reset focus to Input from InputBlur to trigger the input component
         self.update_focus(Focus::Input);
@@ -545,6 +579,7 @@ impl Persistable for Chat<'static> {
     fn load(session: Session) -> Result<Self> {
         let (mut state, session): (Inner, Session) = session::load_related(session)?;
         let mut inst = Self::new(global::config_sync());
+        let auto_accept_edits = state.auto_accept_edits;
 
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current()
@@ -553,6 +588,7 @@ impl Persistable for Chat<'static> {
         });
         inst.state = State::new(state);
         inst.messages = Messages::load(session)?;
+        inst.agent.set_auto_accept_edits(auto_accept_edits);
         Ok(inst)
     }
 }
@@ -655,6 +691,11 @@ impl Component for Chat<'static> {
         use Focus::*;
         use KeyCode::*;
         use KeyModifiers as KM;
+
+        if matches!(key.code, BackTab) {
+            self.toggle_auto_accept_edits();
+            return;
+        }
 
         let focus = &self.state.focus;
         if matches!(
@@ -863,6 +904,7 @@ impl Component for Chat<'static> {
         bottom_block = bottom_block
             .title_bottom(Line::from(""))
             .title_bottom(self.widget_state_indicator());
+        bottom_block = bottom_block.title_bottom(self.auto_accept_indicator());
         if let Some(line) = self.ctrl_c_reminder_line() {
             bottom_block = bottom_block.title_bottom(line);
         }

--- a/crates/coco-tui/src/components/messages/tool.rs
+++ b/crates/coco-tui/src/components/messages/tool.rs
@@ -171,10 +171,23 @@ impl Component for Tool {
 
     fn handle_event(&mut self, event: &Event) {
         match event {
-            Event::Ask(AskEvent::ToolUsePermission(id) | AskEvent::TextEdit { id, .. }) => {
+            Event::Ask(AskEvent::ToolUsePermission(id)) => {
                 if self.tool_use_id() == id {
                     debug!(?event, "state change to pending confirmation");
                     self.update_state(ToolState::PendingConfirmation);
+                    handle_component_event!(self, event);
+                }
+            }
+            Event::Ask(AskEvent::TextEdit {
+                id, auto_accept, ..
+            }) => {
+                if self.tool_use_id() == id {
+                    if *auto_accept {
+                        self.update_state(ToolState::Executing);
+                    } else {
+                        debug!(?event, "state change to pending confirmation");
+                        self.update_state(ToolState::PendingConfirmation);
+                    }
                     handle_component_event!(self, event);
                 }
             }

--- a/crates/coco-tui/src/components/messages/tool/str_replace.rs
+++ b/crates/coco-tui/src/components/messages/tool/str_replace.rs
@@ -69,6 +69,8 @@ struct Inner {
     #[serde(default)]
     pending_apply_diff: Option<String>,
     #[serde(default)]
+    auto_accept_pending: bool,
+    #[serde(default)]
     result_message: Option<String>,
     #[serde(default)]
     result_is_error: Option<bool>,
@@ -313,6 +315,7 @@ impl<'a> StrReplace<'a> {
                 applied_diffs: Vec::new(),
                 rejected_diffs: Vec::new(),
                 pending_apply_diff: None,
+                auto_accept_pending: false,
                 result_message: None,
                 result_is_error: None,
             }),
@@ -337,6 +340,7 @@ impl<'a> StrReplace<'a> {
         state.edit = Some(edit);
         state.display_state = DisplayState::Preview;
         state.collapsed = false;
+        state.auto_accept_pending = false;
         clamp_hunk_idx(&mut state);
         drop(state);
         self.rebuild_view();
@@ -368,6 +372,29 @@ impl<'a> StrReplace<'a> {
         }
         let idx = state.hunk_idx.min(total - 1);
         build_hunk_diff(edit, state.context_radius, idx)
+    }
+
+    fn record_auto_accept_diffs(&mut self, edit: &TextEdit) {
+        let context_radius = self.state.context_radius;
+        let total = hunk_total(Some(edit), context_radius);
+        let mut diffs = Vec::with_capacity(total);
+        for idx in 0..total {
+            if let Some(diff) = build_hunk_diff(edit, context_radius, idx)
+                && !diff.is_empty()
+            {
+                diffs.push(diff);
+            }
+        }
+
+        let mut state = self.state.write();
+        state.applied_diffs = diffs;
+        state.rejected_diffs.clear();
+        state.pending_apply_diff = None;
+        state.edit = None;
+        state.result_view = ResultView::Applied;
+        state.auto_accept_pending = true;
+        drop(state);
+        self.rebuild_view();
     }
 
     fn queue_pending_apply(&mut self) -> bool {
@@ -612,9 +639,15 @@ impl Component for StrReplace<'static> {
 
     fn handle_event(&mut self, event: &Event) {
         match event {
-            Event::Ask(AskEvent::TextEdit { edit, .. }) => {
+            Event::Ask(AskEvent::TextEdit {
+                edit, auto_accept, ..
+            }) => {
                 self.finalize_pending_apply(false);
-                self.update_text_edit(edit.clone());
+                if *auto_accept {
+                    self.record_auto_accept_diffs(edit);
+                } else {
+                    self.update_text_edit(edit.clone());
+                }
             }
             Event::Answer(AnswerEvent::ToolResult {
                 is_error, output, ..
@@ -628,6 +661,13 @@ impl Component for StrReplace<'static> {
                     }
                 };
                 let mut state = self.state.write();
+                if state.auto_accept_pending {
+                    if *is_error && !state.applied_diffs.is_empty() {
+                        let applied = std::mem::take(&mut state.applied_diffs);
+                        state.rejected_diffs.extend(applied);
+                    }
+                    state.auto_accept_pending = false;
+                }
                 state.result_message = message;
                 state.result_is_error = Some(*is_error);
                 state.display_state = DisplayState::Result;
@@ -833,11 +873,31 @@ mod tests {
         widget.handle_event(&Event::Ask(AskEvent::TextEdit {
             id: "tool_1".to_string(),
             edit: text_edit_two_hunks(),
+            auto_accept: false,
         }));
 
         assert_eq!(widget.state.applied_diffs.len(), 1);
         assert!(widget.state.pending_apply_diff.is_none());
         assert_eq!(widget.state.display_state, DisplayState::Preview);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn str_replace_auto_accept_collects_applied_diffs() {
+        let tool_use = tool_use();
+        let mut widget = StrReplace::new(&tool_use);
+        let edit = text_edit_two_hunks();
+        let total = hunk_total(Some(&edit), widget.state.context_radius);
+
+        widget.handle_event(&Event::Ask(AskEvent::TextEdit {
+            id: "tool_1".to_string(),
+            edit,
+            auto_accept: true,
+        }));
+
+        assert_eq!(widget.state.applied_diffs.len(), total);
+        assert!(widget.state.rejected_diffs.is_empty());
+        assert!(widget.state.pending_apply_diff.is_none());
+        assert!(widget.state.edit.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -21,7 +21,11 @@ pub enum AskEvent {
     Bot,
     // Below events come from Bot
     ToolUsePermission(String),
-    TextEdit { id: String, edit: TextEdit },
+    TextEdit {
+        id: String,
+        edit: TextEdit,
+        auto_accept: bool,
+    },
 }
 
 impl From<AskEvent> for Event {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -87,6 +87,10 @@ impl Agent {
         self.executor.set_auto_accept_edits(enabled);
     }
 
+    pub fn auto_accept_edits(&self) -> bool {
+        self.executor.auto_accept_edits()
+    }
+
     pub async fn execute<'a>(
         &mut self,
         id: &str,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -83,6 +83,10 @@ impl Agent {
         self.executor.grant_session(&tool_use.name, &tool_use.input)
     }
 
+    pub fn set_auto_accept_edits(&mut self, enabled: bool) {
+        self.executor.set_auto_accept_edits(enabled);
+    }
+
     pub async fn execute<'a>(
         &mut self,
         id: &str,

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -127,6 +127,10 @@ impl Executor {
         self.auto_accept_edits = enabled;
     }
 
+    pub fn auto_accept_edits(&self) -> bool {
+        self.auto_accept_edits
+    }
+
     pub fn take_once_permission(&mut self, name: &str, id: &str) -> bool {
         if let Some(pcl) = self.tools_once_pcl.get_mut(name) {
             let mut granted_idx: Option<usize> = None;
@@ -239,20 +243,18 @@ impl Executor {
             }
             output = tool.execute(input) => output,
         };
-        let output = if self.auto_accept_edits {
-            match output {
-                Ok(tools::Output::TextEdit(edit)) => {
-                    let applied = AppliedTextEdit {
-                        path: edit.path.as_path(),
-                        text: edit.new_text.as_str(),
-                    };
-                    tool.execute(Input::AppliedTextEdit(applied)).await
-                }
-                other => other,
-            }
-        } else {
-            output
-        };
+        if self.auto_accept_edits
+            && let Ok(tools::Output::TextEdit(edit)) = output
+        {
+            on_output(Output::TextEdit(edit.clone()));
+            let applied = AppliedTextEdit {
+                path: edit.path.as_path(),
+                text: edit.new_text.as_str(),
+            };
+            let applied_output = tool.execute(Input::AppliedTextEdit(applied)).await;
+            on_output(applied_output.into());
+            return Ok(ExecuteStatus::Completed);
+        }
         on_output(output.into());
         Ok(ExecuteStatus::Completed)
     }

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::bash_executor;
 use crate::{
-    OutputChunk, TextEdit, error,
+    AppliedTextEdit, OutputChunk, TextEdit, error,
     tools::{
         self, BASH_TOOL_NAME, BashInput, BashTool, Final, LIST_TOOL_NAME, ListTool, READ_TOOL_NAME,
         ReadTool, STR_REPLACE_TOOL_NAME, StrReplaceTool, Tool, run_bash_chunked,
@@ -22,6 +22,7 @@ pub struct Executor {
     tools_pcl: HashMap<String, Vec<(String, PermissionControl)>>,
     tools_once_pcl: HashMap<String, Vec<String>>,
     bash_session_allowlist: HashSet<String>,
+    auto_accept_edits: bool,
 }
 
 lazy_static! {
@@ -52,6 +53,7 @@ impl Default for Executor {
             tools_once_pcl: HashMap::default(),
             tools: DEFAULT_TOOLS.clone(),
             bash_session_allowlist: HashSet::default(),
+            auto_accept_edits: false,
         }
     }
 }
@@ -121,6 +123,10 @@ fn bash_permission_key(input: &Input<'_>) -> Option<String> {
 }
 
 impl Executor {
+    pub fn set_auto_accept_edits(&mut self, enabled: bool) {
+        self.auto_accept_edits = enabled;
+    }
+
     pub fn take_once_permission(&mut self, name: &str, id: &str) -> bool {
         if let Some(pcl) = self.tools_once_pcl.get_mut(name) {
             let mut granted_idx: Option<usize> = None;
@@ -233,6 +239,20 @@ impl Executor {
             }
             output = tool.execute(input) => output,
         };
+        let output = if self.auto_accept_edits {
+            match output {
+                Ok(tools::Output::TextEdit(edit)) => {
+                    let applied = AppliedTextEdit {
+                        path: edit.path.as_path(),
+                        text: edit.new_text.as_str(),
+                    };
+                    tool.execute(Input::AppliedTextEdit(applied)).await
+                }
+                other => other,
+            }
+        } else {
+            output
+        };
         on_output(output.into());
         Ok(ExecuteStatus::Completed)
     }
@@ -290,6 +310,7 @@ impl Executor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::StrReplaceInput;
 
     fn bash_input_value(command: &str) -> serde_json::Value {
         serde_json::to_value(BashInput {
@@ -341,5 +362,41 @@ mod tests {
                 .any(|out| matches!(out, Output::AskPermission)),
             "did not expect permission request after granting session"
         );
+    }
+
+    #[tokio::test]
+    async fn auto_accept_text_edit_applies_changes() {
+        let cwd = std::env::current_dir().expect("get cwd");
+        let dir = tempfile::Builder::new()
+            .prefix("auto-accept")
+            .tempdir_in(&cwd)
+            .expect("create tempdir");
+        let path = dir.path().join("demo.txt");
+        tokio::fs::write(&path, "hello\n")
+            .await
+            .expect("write test file");
+        let rel_path = path.strip_prefix(&cwd).expect("strip prefix");
+
+        let input = StrReplaceInput {
+            path: rel_path.to_string_lossy().to_string(),
+            old_str: "hello\n".to_string(),
+            new_str: "world\n".to_string(),
+            expected_replacements: 1,
+        };
+        let input_value = serde_json::to_value(input).expect("serialize input");
+
+        let mut executor = Executor::default();
+        executor.set_auto_accept_edits(true);
+
+        let output = executor
+            .execute("1", STR_REPLACE_TOOL_NAME, Input::Starter(input_value))
+            .await
+            .expect("execute str_replace");
+        assert!(matches!(output, Output::Success(_)));
+
+        let updated = tokio::fs::read_to_string(&path)
+            .await
+            .expect("read updated file");
+        assert_eq!(updated, "world\n");
     }
 }


### PR DESCRIPTION
## Summary
Adds auto-accept functionality for text edits with Shift+Tab toggle.

## Changes
- feat: add auto-accept functionality for text edits
- feat: add auto-accept edits toggle with Shift+Tab shortcut