### PR TITLE
feat: enhance bash output display with three-state preview system

### DIFF
--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -38,7 +38,7 @@ struct Inner {
     #[serde(default)]
     view: BashOutputView,
     #[serde(default)]
-    collapsed: bool,
+    display_state: DisplayState,
 }
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -49,6 +49,8 @@ pub struct Bash<'a> {
     input: CodeHighlight<'a>,
     output_text: Paragraph<'a>,
     output_markers: Option<Paragraph<'a>>,
+    output_preview_text: Paragraph<'a>,
+    output_preview_markers: Option<Paragraph<'a>>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,6 +71,18 @@ impl BashOutputView {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DisplayState {
+    Collapsed,
+    #[default]
+    Preview,
+    Expanded,
+}
+
+const OUTPUT_PREVIEW_LINES: usize = 6;
+const TAB_PANEL_HEIGHT: usize = 3;
 
 fn tab_panel_width(total_width: u16) -> u16 {
     let min_total_width = 24u16;
@@ -106,10 +120,32 @@ fn render_tabs_panel(view: BashOutputView) -> Paragraph<'static> {
     Paragraph::new(lines)
 }
 
-fn generate_output<'a>(output: Option<&BashOutput>, view: BashOutputView) -> Paragraph<'a> {
+fn limit_tail_lines<T>(mut lines: Vec<T>, max_lines: Option<usize>) -> Vec<T> {
+    let Some(max_lines) = max_lines else {
+        return lines;
+    };
+    if lines.len() > max_lines {
+        let start = lines.len() - max_lines;
+        lines = lines.split_off(start);
+    }
+    lines
+}
+
+fn build_output_view<'a>(
+    output: Option<&BashOutput>,
+    view: BashOutputView,
+    max_lines: Option<usize>,
+) -> (Paragraph<'a>, Option<Paragraph<'a>>) {
     let mut lines: Vec<Line<'a>> = Vec::new();
     let Some(output) = output else {
-        return Paragraph::new_wrap(lines, Wrap { trim: false });
+        return (
+            Paragraph::new_wrap(lines, Wrap { trim: false }),
+            if view == BashOutputView::Mixed {
+                Some(Paragraph::new(Vec::<Line>::new()))
+            } else {
+                None
+            },
+        );
     };
 
     match view {
@@ -117,73 +153,48 @@ fn generate_output<'a>(output: Option<&BashOutput>, view: BashOutputView) -> Par
             for line in output.stdout.lines() {
                 lines.push(Line::from(line.to_string()));
             }
-            Paragraph::new_wrap(lines, Wrap { trim: false })
+            let lines = limit_tail_lines(lines, max_lines);
+            (Paragraph::new_wrap(lines, Wrap { trim: false }), None)
         }
         BashOutputView::Stderr => {
             for line in output.stderr.lines() {
                 lines.push(Line::from(line.to_string()));
             }
-            Paragraph::new_wrap(lines, Wrap { trim: false })
+            let lines = limit_tail_lines(lines, max_lines);
+            (Paragraph::new_wrap(lines, Wrap { trim: false }), None)
         }
         BashOutputView::Mixed => {
+            let mut markers: Vec<Line<'a>> = Vec::new();
             if output.chunks.is_empty() {
-                for text in [&output.stderr, &output.stdout] {
+                for (marker_style, text) in [
+                    (Style::default().red(), &output.stderr),
+                    (Style::default().blue(), &output.stdout),
+                ] {
                     if text.is_empty() {
                         continue;
                     }
                     for line in text.lines() {
                         lines.push(Line::from(line.to_string()));
+                        markers.push(Line::from(Span::styled("▌", marker_style)));
                     }
                 }
             } else {
                 for chunk in &output.chunks {
+                    let marker_style = match chunk.stream {
+                        code_combo::StreamKind::Stdout => Style::default().blue(),
+                        code_combo::StreamKind::Stderr => Style::default().red(),
+                    };
                     for line in &chunk.lines {
                         lines.push(Line::from(line.clone()));
+                        markers.push(Line::from(Span::styled("▌", marker_style)));
                     }
                 }
             }
-            Paragraph::new(lines)
+            let lines = limit_tail_lines(lines, max_lines);
+            let markers = limit_tail_lines(markers, max_lines);
+            (Paragraph::new(lines), Some(Paragraph::new(markers)))
         }
     }
-}
-
-fn generate_output_markers<'a>(
-    output: Option<&BashOutput>,
-    view: BashOutputView,
-) -> Option<Paragraph<'a>> {
-    if view != BashOutputView::Mixed {
-        return None;
-    }
-    let Some(output) = output else {
-        return Some(Paragraph::new(Vec::<Line>::new()));
-    };
-
-    let mut lines: Vec<Line<'a>> = Vec::new();
-    if output.chunks.is_empty() {
-        for (marker_style, text) in [
-            (Style::default().red(), &output.stderr),
-            (Style::default().blue(), &output.stdout),
-        ] {
-            if text.is_empty() {
-                continue;
-            }
-            for _ in text.lines() {
-                lines.push(Line::from(Span::styled("▌", marker_style)));
-            }
-        }
-    } else {
-        for chunk in &output.chunks {
-            let marker_style = match chunk.stream {
-                code_combo::StreamKind::Stdout => Style::default().blue(),
-                code_combo::StreamKind::Stderr => Style::default().red(),
-            };
-            for _ in &chunk.lines {
-                lines.push(Line::from(Span::styled("▌", marker_style)));
-            }
-        }
-    }
-
-    Some(Paragraph::new(lines))
 }
 
 fn generate_input<'b>(tool_use: &ToolUse) -> CodeHighlight<'b> {
@@ -201,8 +212,14 @@ impl<'a> Bash<'a> {
             .map(serde_json::from_value)
             .transpose()
             .whatever_context("failed to parse BashOutput")?;
-        let output_text = generate_output(output.as_ref(), BashOutputView::default());
-        let output_markers = generate_output_markers(output.as_ref(), BashOutputView::default());
+        let (output_text, output_markers) =
+            build_output_view(output.as_ref(), BashOutputView::default(), None);
+        let (output_preview_text, output_preview_markers) = build_output_view(
+            output.as_ref(),
+            BashOutputView::default(),
+            Some(OUTPUT_PREVIEW_LINES),
+        );
+        let display_state = display_state_for_output(output.as_ref(), DisplayState::Preview);
 
         Ok(Self {
             state: State::new(Inner {
@@ -210,17 +227,28 @@ impl<'a> Bash<'a> {
                 requiring_confirmation: false,
                 output,
                 view: BashOutputView::default(),
-                collapsed: false,
+                display_state,
             }),
             input,
             output_text,
             output_markers,
+            output_preview_text,
+            output_preview_markers,
         })
     }
 
     fn rebuild_output(&mut self) {
-        self.output_text = generate_output(self.state.output.as_ref(), self.state.view);
-        self.output_markers = generate_output_markers(self.state.output.as_ref(), self.state.view);
+        let (output_text, output_markers) =
+            build_output_view(self.state.output.as_ref(), self.state.view, None);
+        let (output_preview_text, output_preview_markers) = build_output_view(
+            self.state.output.as_ref(),
+            self.state.view,
+            Some(OUTPUT_PREVIEW_LINES),
+        );
+        self.output_text = output_text;
+        self.output_markers = output_markers;
+        self.output_preview_text = output_preview_text;
+        self.output_preview_markers = output_preview_markers;
     }
 
     pub fn update_output(&mut self, output: Option<Final>) -> Result<()> {
@@ -256,17 +284,28 @@ impl<'a> Bash<'a> {
 
 impl<'a> Content for Bash<'a> {
     fn height(&self, width: u16) -> usize {
-        if self.state.requiring_confirmation || self.state.collapsed || !self.has_output_content() {
+        if self.state.requiring_confirmation
+            || self.state.display_state == DisplayState::Collapsed
+            || !self.has_output_content()
+        {
             return self.input.height(width);
         }
         let height_input = self.input.height(width);
-        let height_tabs = 3;
+        let min_height = TAB_PANEL_HEIGHT;
 
-        let width_tab = tab_panel_width(width);
+        let width_tab = if self.state.display_state == DisplayState::Preview {
+            0
+        } else {
+            tab_panel_width(width)
+        };
         let width_body = width.saturating_sub(width_tab).max(1);
         let width_marker = output_marker_width(self.state.view);
         let width_text = width_body.saturating_sub(width_marker).max(1);
-        let height_output = self.output_text.line_count(width_text).max(height_tabs);
+        let height_output = match self.state.display_state {
+            DisplayState::Preview => OUTPUT_PREVIEW_LINES.max(min_height),
+            DisplayState::Expanded => self.output_text.line_count(width_text).max(min_height),
+            DisplayState::Collapsed => 0,
+        };
 
         height_input + height_output
     }
@@ -275,7 +314,7 @@ impl<'a> Content for Bash<'a> {
         true
     }
 
-    fn block_with_shortcuts_desc<'b>(&self, block: Block<'b>) -> Block<'b> {
+    fn block_with_shortcuts_desc<'b>(&self, mut block: Block<'b>) -> Block<'b> {
         if self.state.requiring_confirmation {
             return block
                 .title_bottom(shortcuts_desc(&[("Run", "CR"), ("Allow in Session", "A")]))
@@ -286,20 +325,21 @@ impl<'a> Content for Bash<'a> {
             return block;
         }
 
-        let toggle_text = if self.state.collapsed {
-            ("Unfold", "z")
-        } else {
-            ("Fold", "z")
+        let toggle_text = match self.state.display_state {
+            DisplayState::Expanded => ("Fold", "z"),
+            DisplayState::Preview | DisplayState::Collapsed => ("Expand", "z"),
         };
 
-        let view = match self.state.view {
-            BashOutputView::Stdout => "Stdout",
-            BashOutputView::Stderr => "Stderr",
-            BashOutputView::Mixed => "Mixed",
-        };
-        block
-            .title_bottom(shortcuts_desc(&[(view, "1/2/3")]))
-            .title_bottom(shortcuts_desc(&[toggle_text]))
+        if matches!(self.state.display_state, DisplayState::Expanded) {
+            let view = match self.state.view {
+                BashOutputView::Stdout => "Stdout",
+                BashOutputView::Stderr => "Stderr",
+                BashOutputView::Mixed => "Mixed",
+            };
+            block = block.title_bottom(shortcuts_desc(&[(view, "1/2/3")]));
+        }
+
+        block.title_bottom(shortcuts_desc(&[toggle_text]))
     }
 
     fn reminder_line(&self) -> Option<Line<'static>> {
@@ -307,8 +347,12 @@ impl<'a> Content for Bash<'a> {
         if let Some(summary) = self.empty_output_summary() {
             spans.push(Span::raw(format!(" - {summary}")).dark_gray());
         }
-        if self.state.collapsed && self.has_output_content() {
-            spans.push(Span::raw(" (folded)").dark_gray());
+        if self.has_output_content() {
+            match self.state.display_state {
+                DisplayState::Collapsed => spans.push(Span::raw(" (folded)").dark_gray()),
+                DisplayState::Preview => spans.push(Span::raw(" (preview)").dark_gray()),
+                DisplayState::Expanded => {}
+            }
         }
         if spans.is_empty() {
             None
@@ -325,10 +369,19 @@ impl Persistable for Bash<'static> {
 
     fn load(session: Session) -> Result<Self> {
         let state: Inner = session::load(session)?;
+        let (output_text, output_markers) =
+            build_output_view(state.output.as_ref(), state.view, None);
+        let (output_preview_text, output_preview_markers) = build_output_view(
+            state.output.as_ref(),
+            state.view,
+            Some(OUTPUT_PREVIEW_LINES),
+        );
         Ok(Self {
             input: generate_input(&state.tool_use),
-            output_text: generate_output(state.output.as_ref(), state.view),
-            output_markers: generate_output_markers(state.output.as_ref(), state.view),
+            output_text,
+            output_markers,
+            output_preview_text,
+            output_preview_markers,
             state: global::State::new(state),
         })
     }
@@ -340,7 +393,7 @@ impl Component for Bash<'static> {
             Event::Ask(AskEvent::ToolUsePermission(_)) => {
                 let mut state = self.state.write();
                 state.requiring_confirmation = true;
-                state.collapsed = false;
+                state.display_state = DisplayState::Preview;
             }
             Event::Answer(AnswerEvent::ToolOutput { id, chunk }) => {
                 if id != &self.state.tool_use.id {
@@ -375,7 +428,8 @@ impl Component for Bash<'static> {
                     warn!(?err, "failed to update tool output");
                 };
                 let mut state = self.state.write();
-                state.collapsed = false;
+                state.display_state =
+                    display_state_for_output(state.output.as_ref(), state.display_state);
                 state.requiring_confirmation = false;
             }
             _ => (),
@@ -383,64 +437,66 @@ impl Component for Bash<'static> {
     }
 
     fn handle_key_event(&mut self, key: &KeyEvent) {
-        match (key.modifiers, key.code) {
-            (KeyModifiers::NONE, KeyCode::Char('1')) => {
+        match (self.state.display_state, key.modifiers, key.code) {
+            (DisplayState::Expanded, KeyModifiers::NONE, KeyCode::Char('1')) => {
                 if !self.has_output_content() {
                     return;
                 }
                 let mut state = self.state.write();
                 state.view = BashOutputView::Stdout;
-                state.collapsed = false;
                 drop(state);
                 self.rebuild_output();
             }
-            (KeyModifiers::NONE, KeyCode::Char('2')) => {
+            (DisplayState::Expanded, KeyModifiers::NONE, KeyCode::Char('2')) => {
                 if !self.has_output_content() {
                     return;
                 }
                 let mut state = self.state.write();
                 state.view = BashOutputView::Stderr;
-                state.collapsed = false;
+                state.display_state = DisplayState::Expanded;
                 drop(state);
                 self.rebuild_output();
             }
-            (KeyModifiers::NONE, KeyCode::Char('3')) => {
+            (DisplayState::Expanded, KeyModifiers::NONE, KeyCode::Char('3')) => {
                 if !self.has_output_content() {
                     return;
                 }
                 let mut state = self.state.write();
                 state.view = BashOutputView::Mixed;
-                state.collapsed = false;
                 drop(state);
                 self.rebuild_output();
             }
-            (KeyModifiers::NONE, KeyCode::Char('z')) => {
+            (_, KeyModifiers::NONE, KeyCode::Char('z')) => {
                 if !self.has_output_content() {
                     return;
                 }
-                self.state.write().collapsed = !self.state.collapsed;
+                let mut state = self.state.write();
+                state.display_state = match state.display_state {
+                    DisplayState::Expanded => DisplayState::Collapsed,
+                    DisplayState::Collapsed | DisplayState::Preview => DisplayState::Expanded,
+                };
             }
-            (KeyModifiers::NONE, KeyCode::Enter) => {
+            (_, KeyModifiers::NONE, KeyCode::Enter) => {
                 if !self.state.requiring_confirmation {
                     return;
                 }
-                self.state.write().collapsed = false;
+                self.state.write().display_state = DisplayState::Preview;
                 global::action_tx()
                     .send(ToolAction::Grant(self.state.tool_use.to_owned()).into())
                     .unwrap();
                 self.state.write().requiring_confirmation = false;
             }
-            (KeyModifiers::NONE, KeyCode::Char('a') | KeyCode::Char('A')) => {
+            (_, KeyModifiers::NONE, KeyCode::Char('a') | KeyCode::Char('A')) => {
                 if !self.state.requiring_confirmation {
                     return;
                 }
-                self.state.write().collapsed = false;
+                self.state.write().display_state = DisplayState::Preview;
                 global::action_tx()
                     .send(ToolAction::GrantSession(self.state.tool_use.to_owned()).into())
                     .unwrap();
                 self.state.write().requiring_confirmation = false;
             }
-            (KeyModifiers::NONE, KeyCode::Esc) => {
+            (_, KeyModifiers::NONE, KeyCode::Esc) => {
                 if !self.state.requiring_confirmation {
                     return;
                 }
@@ -463,13 +519,16 @@ impl Component for Bash<'static> {
         if !self.has_output_content() {
             return;
         }
+        if self.state.display_state != DisplayState::Preview {
+            return;
+        }
         let Some(output) = self.state.output.as_ref() else {
             return;
         };
         if output.exit_code != 0 {
             return;
         }
-        self.state.write().collapsed = true;
+        self.state.write().display_state = DisplayState::Collapsed;
     }
 
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
@@ -482,40 +541,58 @@ impl Component for Bash<'static> {
         let width = area.width.max(1);
         let height_input = self.input.height(width);
 
-        if self.state.collapsed || self.state.requiring_confirmation || !self.has_output_content() {
+        if self.state.display_state == DisplayState::Collapsed
+            || self.state.requiring_confirmation
+            || !self.has_output_content()
+        {
             let [area_input] = Layout::vertical([Length(height_input as u16)]).areas(area);
             self.input.draw(frame, area_input)?;
             return Ok(());
         }
 
-        let tab_width = tab_panel_width(width);
-        let marker_width = output_marker_width(self.state.view);
-        let body_width = width.saturating_sub(tab_width).max(1);
-        let text_width = body_width.saturating_sub(marker_width).max(1);
-        let height_output = self.output_text.line_count(text_width).max(1);
+        let width_tabs = if self.state.display_state == DisplayState::Preview {
+            0
+        } else {
+            tab_panel_width(width)
+        };
+        let width_marker = output_marker_width(self.state.view);
+        let width_body = width.saturating_sub(width_tabs).max(1);
+        let width_text = width_body.saturating_sub(width_marker).max(1);
+        let min_height = TAB_PANEL_HEIGHT;
+        let height_output = match self.state.display_state {
+            DisplayState::Preview => OUTPUT_PREVIEW_LINES.max(min_height),
+            DisplayState::Expanded => self.output_text.line_count(width_text).max(min_height),
+            DisplayState::Collapsed => 0,
+        };
         let [area_input, area_output] =
             Layout::vertical([Length(height_input as u16), Length(height_output as u16)])
                 .areas(area);
 
         self.input.draw(frame, area_input)?;
 
-        let (area_output_view, area_output_tabs) = if tab_width == 0 {
+        let (area_output_view, area_output_tabs) = if width_tabs == 0 {
             (area_output, None)
         } else {
             let [view, tabs] =
-                Layout::horizontal([Constraint::Min(1), Constraint::Length(tab_width)])
+                Layout::horizontal([Constraint::Min(1), Constraint::Length(width_tabs)])
                     .areas(area_output);
             (view, Some(tabs))
         };
 
-        if marker_width == 0 {
-            frame.render_widget(&self.output_text, area_output_view);
+        let (output_text, output_markers) = match self.state.display_state {
+            DisplayState::Preview => (&self.output_preview_text, &self.output_preview_markers),
+            DisplayState::Expanded => (&self.output_text, &self.output_markers),
+            DisplayState::Collapsed => (&self.output_text, &self.output_markers),
+        };
+
+        if width_marker == 0 {
+            frame.render_widget(output_text, area_output_view);
         } else {
             let [area_text, area_markers] =
-                Layout::horizontal([Constraint::Min(1), Constraint::Length(marker_width)])
+                Layout::horizontal([Constraint::Min(1), Constraint::Length(width_marker)])
                     .areas(area_output_view);
-            frame.render_widget(&self.output_text, area_text);
-            if let Some(markers) = &self.output_markers {
+            frame.render_widget(output_text, area_text);
+            if let Some(markers) = output_markers {
                 frame.render_widget(markers, area_markers);
             }
         }
@@ -529,6 +606,20 @@ impl Component for Bash<'static> {
 }
 
 impl ContentComponent for Bash<'static> {}
+
+fn display_state_for_output(output: Option<&BashOutput>, current: DisplayState) -> DisplayState {
+    let Some(output) = output else {
+        return current;
+    };
+    if output.exit_code != 0 {
+        return DisplayState::Expanded;
+    }
+    if current == DisplayState::Expanded {
+        DisplayState::Expanded
+    } else {
+        DisplayState::Preview
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -592,7 +683,7 @@ mod tests {
     async fn bash_auto_collapses_on_success_and_stays_open_on_failure() {
         let tool_use = tool_use();
         let mut bash = Bash::try_new().tool_use(&tool_use).call().unwrap();
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Preview);
 
         let value = serde_json::to_value(bash_output()).unwrap();
         bash.handle_event(&Event::Answer(AnswerEvent::ToolResult {
@@ -601,9 +692,9 @@ mod tests {
             is_user_cancelled: false,
             output: Final::Json(value),
         }));
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Preview);
         bash.update(&Action::Blur);
-        assert!(bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Collapsed);
 
         let value = serde_json::to_value(bash_output_with_exit(1)).unwrap();
         bash.handle_event(&Event::Answer(AnswerEvent::ToolResult {
@@ -612,9 +703,9 @@ mod tests {
             is_user_cancelled: false,
             output: Final::Json(value),
         }));
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Expanded);
         bash.update(&Action::Blur);
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Expanded);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -627,20 +718,37 @@ mod tests {
             .call()
             .unwrap();
 
-        bash.state.write().collapsed = true;
+        bash.state.write().display_state = DisplayState::Collapsed;
         bash.handle_key_event(&key(KeyCode::Char('1')));
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Collapsed);
+
+        bash.state.write().display_state = DisplayState::Expanded;
+        bash.handle_key_event(&key(KeyCode::Char('1')));
+        assert_eq!(bash.state.display_state, DisplayState::Expanded);
         assert_eq!(bash.state.view.index(), 0);
 
-        bash.state.write().collapsed = true;
         bash.handle_key_event(&key(KeyCode::Char('2')));
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Expanded);
         assert_eq!(bash.state.view.index(), 1);
 
-        bash.state.write().collapsed = true;
         bash.handle_key_event(&key(KeyCode::Char('3')));
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Expanded);
         assert_eq!(bash.state.view.index(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bash_preview_expands_on_toggle() {
+        let tool_use = tool_use();
+        let value = serde_json::to_value(bash_output()).unwrap();
+        let mut bash = Bash::try_new()
+            .tool_use(&tool_use)
+            .output(value)
+            .call()
+            .unwrap();
+
+        assert_eq!(bash.state.display_state, DisplayState::Preview);
+        bash.handle_key_event(&key(KeyCode::Char('z')));
+        assert_eq!(bash.state.display_state, DisplayState::Expanded);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -696,7 +804,7 @@ mod tests {
             .call()
             .unwrap();
 
-        bash.state.write().collapsed = true;
+        bash.state.write().display_state = DisplayState::Collapsed;
         let height = bash.height(80);
         let input_height = bash.input.height(80);
 
@@ -716,11 +824,11 @@ mod tests {
             is_user_cancelled: false,
             output: Final::Json(value),
         }));
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Preview);
         assert_eq!(bash.height(80), bash.input.height(80));
 
         bash.update(&Action::Blur);
-        assert!(!bash.state.collapsed);
+        assert_eq!(bash.state.display_state, DisplayState::Preview);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
- Replace boolean `collapsed` field with `DisplayState` enum (Collapsed/Preview/Expanded)
- Add output preview mode showing last 6 lines by default
- Implement `limit_tail_lines()` helper for output truncation
- Refactor `generate_output()` into `build_output_view()` with line limiting
- Update height calculation to respect display state and preview constraints
- Modify keyboard shortcuts: 'z' toggles between Preview/Expanded/Collapsed
- Add auto-expand behavior for non-zero exit codes
- Update UI to show '(preview)' indicator in reminder line
- Refactor tab panel display to only show in Expanded mode
- Fix tests to work with new display state system
- Improve visual feedback for different output states