### PR TITLE
feat: add AGENTS.md system prompt support and refactor app initialization

### DIFF
--- a/crates/anthropic/src/client.rs
+++ b/crates/anthropic/src/client.rs
@@ -48,6 +48,7 @@ impl Client {
     #[builder]
     pub async fn messages(
         &self,
+        system_prompt: Option<&str>,
         conversations: Vec<Message>,
         tools: Vec<Tool>,
     ) -> Result<MessagesResponse> {
@@ -55,6 +56,7 @@ impl Client {
             &self.cli,
             &self.base_url,
             MessagesRequest::builder()
+                .maybe_system(system_prompt)
                 .messages(conversations)
                 .model(&self.model)
                 .tools(tools)

--- a/crates/anthropic/src/client/messages.rs
+++ b/crates/anthropic/src/client/messages.rs
@@ -63,6 +63,8 @@ pub struct MessagesRequest {
     pub messages: Vec<Message>,
     /// The maximum number of tokens to generate before stopping.
     pub max_tokens: usize,
+    /// System prompt
+    pub system: String,
     /// Amount of randomness injected into the response.
     ///
     /// Defaults to 1.0. Ranges from 0.0 to 1.0. Use temperature closer to 0.0 for analytical / multiple choice,
@@ -81,10 +83,16 @@ pub struct MessagesRequest {
 #[bon]
 impl MessagesRequest {
     #[builder]
-    pub fn new(model: &str, messages: Vec<Message>, #[builder(default)] tools: Vec<Tool>) -> Self {
+    pub fn new(
+        model: &str,
+        system: Option<&str>,
+        messages: Vec<Message>,
+        #[builder(default)] tools: Vec<Tool>,
+    ) -> Self {
         Self {
             model: model.to_string(),
             messages,
+            system: system.unwrap_or_default().to_string(),
             max_tokens: 32000,
             temperature: None,
             tool_choice: None,

--- a/crates/coco-tui/examples/draw_components.rs
+++ b/crates/coco-tui/examples/draw_components.rs
@@ -52,7 +52,6 @@ async fn main() -> Result<()> {
     config.config_dir = config_dir;
     global::set_config(config.clone()).await;
 
-    let mut app = app::App::new(config.clone())?;
     let component: Box<dyn Component> = match args.command {
         Some(Commands::CodeHighlight) => {
             let app = CodeHighlight::try_new(
@@ -79,9 +78,13 @@ async fn main() -> Result<()> {
             let (type_id, s): (String, Session) = session::load_related(s)?;
             session::load_component(&type_id, s)?
         }
-        None => Box::new(Chat::new(config)),
+        None => {
+            let mut app = Chat::new(config);
+            app.setup().await;
+            Box::new(app)
+        }
     };
-    app.set_root(component);
+    let mut app = app::App::new(component)?;
 
     let result = app.run().await;
 

--- a/crates/coco-tui/src/app.rs
+++ b/crates/coco-tui/src/app.rs
@@ -3,7 +3,6 @@ use std::{
     time::Duration,
 };
 
-use code_combo::Config;
 use crossterm::{
     cursor,
     event::{Event as CrosstermEvent, EventStream, KeyEvent},
@@ -20,13 +19,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, trace, warn};
 
-use crate::{
-    actions::Action,
-    components::{Chat, Component},
-    error::Result,
-    events::Event,
-    global,
-};
+use crate::{actions::Action, components::Component, error::Result, events::Event, global};
 
 pub struct App {
     terminal: ratatui::Terminal<Backend<Stdout>>,
@@ -49,7 +42,7 @@ pub struct App {
 
 impl App {
     /// Construct a new instance of [`App`].
-    pub fn new(config: Config) -> Result<Self> {
+    pub fn new(root: Box<dyn Component>) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let (action_tx, action_rx) = mpsc::unbounded_channel();
 
@@ -66,7 +59,7 @@ impl App {
             action_tx,
             action_rx,
             dirty: true,
-            root: Box::new(Chat::new(config)),
+            root,
             frame_rate: 60.0,
             tick_rate: 4.0,
         })

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -52,6 +52,7 @@ pub struct Chat<'a> {
 #[derive(Clone, Serialize, Deserialize)]
 struct Inner {
     // Placeholder field for serialization
+    system_prompt: String,
     messages: Vec<code_combo::Message>,
 
     state: ChatState,
@@ -70,6 +71,7 @@ impl Default for Inner {
     fn default() -> Self {
         let now = time::OffsetDateTime::now_utc();
         Self {
+            system_prompt: String::new(),
             messages: vec![],
             state: ChatState::Ready,
             focus: Focus::Input,
@@ -177,11 +179,15 @@ impl CancellationGuard {
 
 const COMMAND_NEW_SESSION: &str = "New Session";
 
+const AGENTS_MD_FILENAME: &str = "AGENTS.md";
+
 impl Chat<'static> {
     pub fn new(config: Config) -> Self {
+        let agent = Agent::new(config);
+
         Self {
             state: State::default(),
-            agent: Agent::new(config),
+            agent,
             command_palette: CommandPalette::new(&[
                 Command {
                     name: COMMAND_NEW_SESSION.to_string(),
@@ -194,6 +200,23 @@ impl Chat<'static> {
             indicator: ThrobberState::default(),
             token_schedule_session_save: None,
             cancellation_guard: CancellationGuard::default(),
+        }
+    }
+
+    pub async fn setup(&mut self) {
+        // read AGENTS.md file
+        let workspace_path = global::workspace_dir().join(AGENTS_MD_FILENAME);
+        let global_path = global::config().await.config_dir.join(AGENTS_MD_FILENAME);
+        for path in [workspace_path, global_path] {
+            match tokio::fs::read_to_string(&path).await {
+                Ok(system_prompt) => {
+                    self.agent.set_system_prompt(&system_prompt);
+                    break;
+                }
+                Err(err) => {
+                    warn!(?path, ?err, "failed to read file");
+                }
+            }
         }
     }
 
@@ -212,6 +235,7 @@ impl Chat<'static> {
 
         tokio::spawn(async move {
             // Take a snapshot immediately to avoid persisting later dirty state
+            state.system_prompt = agent.system_prompt().to_string();
             state.messages = agent.dump_messages().await;
 
             let session_dir = std::path::Path::new(".coco/sessions").to_path_buf();
@@ -574,14 +598,8 @@ impl Chat<'static> {
 
 impl Persistable for Chat<'static> {
     fn save(&self) -> Session {
-        // Save LLM messages
-        let agent_messages = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.agent.dump_messages())
-        });
-        let mut state = self.state.get();
-        state.messages = agent_messages;
-
-        session::save_related(&state, self.messages.save())
+        // Chat persists via schedule_save_task, not through this method
+        unreachable!("Chat has special way to do persisting")
     }
 
     fn load(session: Session) -> Result<Self> {
@@ -594,9 +612,11 @@ impl Persistable for Chat<'static> {
                 .block_on(inst.agent.restore_messages(&state.messages));
             state.messages.clear();
         });
+        inst.agent.set_system_prompt(&state.system_prompt);
+        inst.agent.set_auto_accept_edits(auto_accept_edits);
+
         inst.state = State::new(state);
         inst.messages = Messages::load(session)?;
-        inst.agent.set_auto_accept_edits(auto_accept_edits);
         Ok(inst)
     }
 }

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -11,6 +11,7 @@ use snafu::prelude::*;
 use coco_tui::{
     actions::{Action, ComboAction},
     app,
+    components::Chat,
     error::Result,
     global, version,
 };
@@ -116,7 +117,9 @@ async fn main() -> Result<()> {
     config.config_dir = config_dir;
     global::set_config(config.clone()).await;
 
-    let mut app = app::App::new(config)?;
+    let mut root_view = Chat::new(config);
+    root_view.setup().await;
+    let mut app = app::App::new(Box::new(root_view))?;
     match args.command {
         Some(Commands::Combo(combo_cmd)) => match combo_cmd {
             ComboCommands::Run { name } => {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -18,6 +18,8 @@ pub use executor::{ExecuteStatus, Executor, Input, Output};
 pub struct Agent {
     config: Config,
     executor: Executor,
+
+    system_prompt: String,
     /// Shared messages across cloned instances.
     messages: Arc<Mutex<Vec<Message>>>,
 }
@@ -31,9 +33,18 @@ impl Agent {
     pub fn new(config: Config) -> Self {
         Self {
             config,
+            system_prompt: String::new(),
             executor: Executor::default(),
             messages: Arc::new(Mutex::new(vec![])),
         }
+    }
+
+    pub fn system_prompt(&self) -> &str {
+        &self.system_prompt
+    }
+
+    pub fn set_system_prompt(&mut self, system_prompt: &str) {
+        self.system_prompt = system_prompt.to_string()
     }
 
     pub async fn dump_messages(&self) -> Vec<Message> {
@@ -52,6 +63,7 @@ impl Agent {
 
         let response = client
             .messages()
+            .system_prompt(&self.system_prompt)
             .conversations(messages.clone())
             .tools(self.executor.anthropic_tools())
             .call()


### PR DESCRIPTION
- Add system prompt parameter to Anthropic client messages API
- Update MessagesRequest to accept optional system prompt
- Add system_prompt field to Agent struct with getter/setter methods
- Implement AGENTS.md file discovery in workspace and global config directories
- Refactor Chat component to load AGENTS.md as system prompt during setup
- Update app initialization to use Chat::setup() async method
- Modify App::new() to accept root component instead of creating Chat internally
- Fix Chat persistence to save system prompt and restore properly
- Update examples/draw_components.rs to match new initialization pattern
- Remove redundant persistence logic in Chat::save() method