### PR TITLE
refactor: extract FoldState, StreamedLines and remove debug logging

### DIFF
--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -23,6 +23,7 @@ use crate::{
 use super::{Action, AnswerEvent, AskEvent, Component, Content, Event, Message};
 
 mod combo;
+mod fold;
 mod plain;
 mod tool;
 pub use combo::Combo;

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -25,6 +25,7 @@ use super::{Action, AnswerEvent, AskEvent, Component, Content, Event, Message};
 mod combo;
 mod fold;
 mod plain;
+mod streaming;
 mod tool;
 pub use combo::Combo;
 pub use plain::Plain;

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -13,6 +13,7 @@ use ratatui::{
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
+use super::fold::FoldState;
 use crate::{
     actions::Action,
     components::{Component, Content, ContentComponent, Persistable, Plain},
@@ -48,8 +49,8 @@ struct Inner {
     name: String,
     is_error: bool,
     starter_state: StarterState,
-    #[serde(default = "default_collapsed")]
-    collapsed: bool,
+    #[serde(default = "default_display_state")]
+    display_state: FoldState,
 }
 
 impl Default for Inner {
@@ -58,7 +59,7 @@ impl Default for Inner {
             name: String::new(),
             is_error: false,
             starter_state: StarterState::default(),
-            collapsed: default_collapsed(),
+            display_state: default_display_state(),
         }
     }
 }
@@ -73,8 +74,8 @@ pub struct Combo {
 
 const LIMIT: usize = 10;
 
-fn default_collapsed() -> bool {
-    true
+fn default_display_state() -> FoldState {
+    FoldState::Collapsed
 }
 
 impl Combo {
@@ -106,7 +107,7 @@ impl Combo {
                     state.starter_state = StarterState::Executing {
                         output: VecDeque::new(),
                     };
-                    state.collapsed = false;
+                    state.display_state.expand();
                 }
             }
             ComboEvent::Executed { name, starter, .. } => {
@@ -122,7 +123,7 @@ impl Combo {
                         };
                         self.widget = Some(Plain::new(output.clone()));
                         state.starter_state = StarterState::Finalized { output };
-                        state.collapsed = false;
+                        state.display_state.expand();
                     }
                 }
             }
@@ -135,7 +136,7 @@ impl Combo {
                     {
                         let mut state = self.state.write();
                         state.starter_state = StarterState::Cancelled;
-                        state.collapsed = false;
+                        state.display_state.expand();
                     }
                 }
             }
@@ -166,13 +167,14 @@ impl Combo {
         }
     }
 
-    fn toggle_collapsed(&mut self) {
-        self.state.write().collapsed = !self.state.collapsed;
+    fn toggle_display_state(&mut self) {
+        let mut state = self.state.write();
+        state.display_state = state.display_state.toggle();
     }
 
     fn on_blur(&mut self) {
         if self.has_collapsible_body() {
-            self.state.write().collapsed = true;
+            self.state.write().display_state.collapse();
         }
     }
 
@@ -213,7 +215,7 @@ impl Combo {
 impl Content for Combo {
     fn height(&self, width: u16) -> usize {
         let border_height = 1;
-        if self.has_collapsible_body() && self.state.collapsed {
+        if self.has_collapsible_body() && self.state.display_state.is_collapsed() {
             return border_height;
         }
         if let Some(plain) = &self.widget {
@@ -234,7 +236,7 @@ impl Content for Combo {
         if !self.has_collapsible_body() {
             return block;
         }
-        let toggle_text = if self.state.collapsed {
+        let toggle_text = if self.state.display_state.is_collapsed() {
             ("Unfold", "z")
         } else {
             ("Fold", "z")
@@ -243,7 +245,7 @@ impl Content for Combo {
     }
 
     fn reminder_line(&self) -> Option<Line<'static>> {
-        if self.has_collapsible_body() && self.state.collapsed {
+        if self.has_collapsible_body() && self.state.display_state.is_collapsed() {
             Some(Line::from(Span::raw(" (folded)").dark_gray()))
         } else {
             None
@@ -286,11 +288,11 @@ impl Component for Combo {
         }
 
         if let (KeyModifiers::NONE, KeyCode::Char('z')) = (key.modifiers, key.code) {
-            self.toggle_collapsed();
+            self.toggle_display_state();
             return;
         }
 
-        if !self.state.collapsed
+        if !self.state.display_state.is_collapsed()
             && let Some(widget) = &mut self.widget
         {
             widget.handle_key_event(key);
@@ -323,7 +325,7 @@ impl Component for Combo {
             .title_alignment(Alignment::Left);
         frame.render_widget(&block, area);
 
-        if self.has_collapsible_body() && self.state.collapsed {
+        if self.has_collapsible_body() && self.state.display_state.is_collapsed() {
             return Ok(());
         }
 

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use coco_macro::{ComponentExt, ContentComponentExt};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
@@ -14,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use super::fold::FoldState;
+use super::streaming::StreamedLines;
 use crate::{
     actions::Action,
     components::{Component, Content, ContentComponent, Persistable, Plain},
@@ -31,17 +30,11 @@ enum StarterState {
     NotFound,
     Cancelled,
     Executing {
-        output: VecDeque<DisplayedLine>,
+        output: StreamedLines,
     },
     Finalized {
         output: String,
     },
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct DisplayedLine {
-    stream: code_combo::StreamKind,
-    text: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -105,7 +98,7 @@ impl Combo {
                 if &self.state.name == name {
                     let mut state = self.state.write();
                     state.starter_state = StarterState::Executing {
-                        output: VecDeque::new(),
+                        output: StreamedLines::new(Some(LIMIT)),
                     };
                     state.display_state.expand();
                 }
@@ -152,18 +145,12 @@ impl Combo {
         else {
             return;
         };
-        for text in &chunk.lines {
-            while lines.len() >= LIMIT {
-                debug!(
-                    limit = LIMIT,
-                    "Line count exceeds limit, removing oldest lines"
-                );
-                lines.pop_front();
-            }
-            lines.push_back(DisplayedLine {
-                stream: chunk.stream,
-                text: text.clone(),
-            });
+        let dropped = lines.push_chunk(chunk);
+        if dropped > 0 {
+            debug!(
+                limit = LIMIT,
+                dropped, "Line count exceeds limit, removing oldest lines"
+            );
         }
     }
 

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -9,7 +9,6 @@ use ratatui::{
     widgets::{Block, Borders},
 };
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 
 use super::fold::FoldState;
 use super::streaming::StreamedLines;
@@ -145,13 +144,7 @@ impl Combo {
         else {
             return;
         };
-        let dropped = lines.push_chunk(chunk);
-        if dropped > 0 {
-            debug!(
-                limit = LIMIT,
-                dropped, "Line count exceeds limit, removing oldest lines"
-            );
-        }
+        lines.push_chunk(chunk);
     }
 
     fn toggle_display_state(&mut self) {
@@ -295,7 +288,6 @@ impl Component for Combo {
     }
 
     fn update(&mut self, action: &Action) {
-        debug!(?action, "updating");
         if let Action::Blur = action {
             self.on_blur()
         }

--- a/crates/coco-tui/src/components/messages/fold.rs
+++ b/crates/coco-tui/src/components/messages/fold.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub(crate) enum FoldState {
+    Collapsed,
+    #[default]
+    Preview,
+    Expanded,
+}
+
+impl FoldState {
+    pub(crate) fn is_collapsed(self) -> bool {
+        matches!(self, Self::Collapsed)
+    }
+
+    pub(crate) fn is_preview(self) -> bool {
+        matches!(self, Self::Preview)
+    }
+
+    pub(crate) fn toggle(self) -> Self {
+        match self {
+            Self::Collapsed => Self::Expanded,
+            Self::Expanded => Self::Collapsed,
+            Self::Preview => Self::Preview,
+        }
+    }
+
+    pub(crate) fn collapse(&mut self) {
+        *self = Self::Collapsed;
+    }
+
+    pub(crate) fn expand(&mut self) {
+        *self = Self::Expanded;
+    }
+
+    pub(crate) fn preview(&mut self) {
+        *self = Self::Preview;
+    }
+}

--- a/crates/coco-tui/src/components/messages/streaming.rs
+++ b/crates/coco-tui/src/components/messages/streaming.rs
@@ -1,0 +1,70 @@
+use std::collections::VecDeque;
+
+use code_combo::{OutputChunk, StreamKind};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct StreamedLine {
+    pub(crate) stream: StreamKind,
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct StreamedLines {
+    #[serde(default)]
+    lines: VecDeque<StreamedLine>,
+    #[serde(default)]
+    max_lines: Option<usize>,
+}
+
+impl StreamedLines {
+    pub(crate) fn new(max_lines: Option<usize>) -> Self {
+        Self {
+            lines: VecDeque::new(),
+            max_lines,
+        }
+    }
+
+    pub(crate) fn from_chunks<'a, I>(chunks: I, max_lines: Option<usize>) -> Self
+    where
+        I: IntoIterator<Item = &'a OutputChunk>,
+    {
+        let mut lines = Self::new(max_lines);
+        for chunk in chunks {
+            lines.push_chunk(chunk);
+        }
+        lines
+    }
+
+    pub(crate) fn push_chunk(&mut self, chunk: &OutputChunk) -> usize {
+        let mut dropped = 0;
+        for text in &chunk.lines {
+            dropped += self.push_line(chunk.stream, text.clone());
+        }
+        dropped
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.lines.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &StreamedLine> {
+        self.lines.iter()
+    }
+
+    fn push_line(&mut self, stream: StreamKind, text: String) -> usize {
+        let mut dropped = 0;
+        if let Some(max_lines) = self.max_lines {
+            while self.lines.len() >= max_lines {
+                self.lines.pop_front();
+                dropped += 1;
+            }
+        }
+        self.lines.push_back(StreamedLine { stream, text });
+        dropped
+    }
+}

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -20,6 +20,7 @@ use snafu::prelude::*;
 use tracing::warn;
 
 use super::super::fold::FoldState;
+use super::super::streaming::StreamedLines;
 use super::{Component, Content, ContentComponent};
 use crate::{
     actions::{Action, ToolAction},
@@ -48,6 +49,7 @@ pub struct Bash<'a> {
     state: State<Inner>,
 
     input: CodeHighlight<'a>,
+    streamed_lines: StreamedLines,
     output_text: Paragraph<'a>,
     output_markers: Option<Paragraph<'a>>,
     output_preview_text: Paragraph<'a>,
@@ -125,6 +127,7 @@ fn limit_tail_lines<T>(mut lines: Vec<T>, max_lines: Option<usize>) -> Vec<T> {
 
 fn build_output_view<'a>(
     output: Option<&BashOutput>,
+    streamed_lines: &StreamedLines,
     view: BashOutputView,
     max_lines: Option<usize>,
 ) -> (Paragraph<'a>, Option<Paragraph<'a>>) {
@@ -157,7 +160,16 @@ fn build_output_view<'a>(
         }
         BashOutputView::Mixed => {
             let mut markers: Vec<Line<'a>> = Vec::new();
-            if output.chunks.is_empty() {
+            if !streamed_lines.is_empty() {
+                for line in streamed_lines.iter() {
+                    let marker_style = match line.stream {
+                        code_combo::StreamKind::Stdout => Style::default().blue(),
+                        code_combo::StreamKind::Stderr => Style::default().red(),
+                    };
+                    lines.push(Line::from(line.text.clone()));
+                    markers.push(Line::from(Span::styled("▌", marker_style)));
+                }
+            } else if output.chunks.is_empty() {
                 for (marker_style, text) in [
                     (Style::default().red(), &output.stderr),
                     (Style::default().blue(), &output.stdout),
@@ -200,14 +212,23 @@ impl<'a> Bash<'a> {
     #[builder]
     pub fn try_new(tool_use: &ToolUse, output: Option<Value>) -> Result<Self> {
         let input = generate_input(tool_use);
-        let output = output
+        let output: Option<BashOutput> = output
             .map(serde_json::from_value)
             .transpose()
             .whatever_context("failed to parse BashOutput")?;
-        let (output_text, output_markers) =
-            build_output_view(output.as_ref(), BashOutputView::default(), None);
+        let streamed_lines = output
+            .as_ref()
+            .map(|output| StreamedLines::from_chunks(&output.chunks, None))
+            .unwrap_or_else(|| StreamedLines::new(None));
+        let (output_text, output_markers) = build_output_view(
+            output.as_ref(),
+            &streamed_lines,
+            BashOutputView::default(),
+            None,
+        );
         let (output_preview_text, output_preview_markers) = build_output_view(
             output.as_ref(),
+            &streamed_lines,
             BashOutputView::default(),
             Some(OUTPUT_PREVIEW_LINES),
         );
@@ -222,6 +243,7 @@ impl<'a> Bash<'a> {
                 display_state,
             }),
             input,
+            streamed_lines,
             output_text,
             output_markers,
             output_preview_text,
@@ -230,10 +252,15 @@ impl<'a> Bash<'a> {
     }
 
     fn rebuild_output(&mut self) {
-        let (output_text, output_markers) =
-            build_output_view(self.state.output.as_ref(), self.state.view, None);
+        let (output_text, output_markers) = build_output_view(
+            self.state.output.as_ref(),
+            &self.streamed_lines,
+            self.state.view,
+            None,
+        );
         let (output_preview_text, output_preview_markers) = build_output_view(
             self.state.output.as_ref(),
+            &self.streamed_lines,
             self.state.view,
             Some(OUTPUT_PREVIEW_LINES),
         );
@@ -245,8 +272,9 @@ impl<'a> Bash<'a> {
 
     pub fn update_output(&mut self, output: Option<Final>) -> Result<()> {
         if let Some(Final::Json(value)) = output {
-            let output =
-                serde_json::from_value(value).whatever_context("failed to parse BashOutput")?;
+            let output = serde_json::from_value::<BashOutput>(value)
+                .whatever_context("failed to parse BashOutput")?;
+            self.streamed_lines = StreamedLines::from_chunks(&output.chunks, None);
             self.state.write().output = Some(output);
             self.rebuild_output();
         }
@@ -361,15 +389,22 @@ impl Persistable for Bash<'static> {
 
     fn load(session: Session) -> Result<Self> {
         let state: Inner = session::load(session)?;
+        let streamed_lines = state
+            .output
+            .as_ref()
+            .map(|output| StreamedLines::from_chunks(&output.chunks, None))
+            .unwrap_or_else(|| StreamedLines::new(None));
         let (output_text, output_markers) =
-            build_output_view(state.output.as_ref(), state.view, None);
+            build_output_view(state.output.as_ref(), &streamed_lines, state.view, None);
         let (output_preview_text, output_preview_markers) = build_output_view(
             state.output.as_ref(),
+            &streamed_lines,
             state.view,
             Some(OUTPUT_PREVIEW_LINES),
         );
         Ok(Self {
             input: generate_input(&state.tool_use),
+            streamed_lines,
             output_text,
             output_markers,
             output_preview_text,
@@ -412,6 +447,7 @@ impl Component for Bash<'static> {
                     }
                 }
                 output.chunks.push(chunk.clone());
+                self.streamed_lines.push_chunk(chunk);
                 drop(state);
                 self.rebuild_output();
             }

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use snafu::prelude::*;
 use tracing::warn;
 
+use super::super::fold::FoldState;
 use super::{Component, Content, ContentComponent};
 use crate::{
     actions::{Action, ToolAction},
@@ -38,7 +39,7 @@ struct Inner {
     #[serde(default)]
     view: BashOutputView,
     #[serde(default)]
-    display_state: DisplayState,
+    display_state: FoldState,
 }
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -70,15 +71,6 @@ impl BashOutputView {
             Self::Mixed => 2,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum DisplayState {
-    Collapsed,
-    #[default]
-    Preview,
-    Expanded,
 }
 
 const OUTPUT_PREVIEW_LINES: usize = 6;
@@ -219,7 +211,7 @@ impl<'a> Bash<'a> {
             BashOutputView::default(),
             Some(OUTPUT_PREVIEW_LINES),
         );
-        let display_state = display_state_for_output(output.as_ref(), DisplayState::Preview);
+        let display_state = display_state_for_output(output.as_ref(), FoldState::Preview);
 
         Ok(Self {
             state: State::new(Inner {
@@ -285,7 +277,7 @@ impl<'a> Bash<'a> {
 impl<'a> Content for Bash<'a> {
     fn height(&self, width: u16) -> usize {
         if self.state.requiring_confirmation
-            || self.state.display_state == DisplayState::Collapsed
+            || self.state.display_state == FoldState::Collapsed
             || !self.has_output_content()
         {
             return self.input.height(width);
@@ -293,7 +285,7 @@ impl<'a> Content for Bash<'a> {
         let height_input = self.input.height(width);
         let min_height = TAB_PANEL_HEIGHT;
 
-        let width_tab = if self.state.display_state == DisplayState::Preview {
+        let width_tab = if self.state.display_state == FoldState::Preview {
             0
         } else {
             tab_panel_width(width)
@@ -302,9 +294,9 @@ impl<'a> Content for Bash<'a> {
         let width_marker = output_marker_width(self.state.view);
         let width_text = width_body.saturating_sub(width_marker).max(1);
         let height_output = match self.state.display_state {
-            DisplayState::Preview => OUTPUT_PREVIEW_LINES.max(min_height),
-            DisplayState::Expanded => self.output_text.line_count(width_text).max(min_height),
-            DisplayState::Collapsed => 0,
+            FoldState::Preview => OUTPUT_PREVIEW_LINES.max(min_height),
+            FoldState::Expanded => self.output_text.line_count(width_text).max(min_height),
+            FoldState::Collapsed => 0,
         };
 
         height_input + height_output
@@ -326,11 +318,11 @@ impl<'a> Content for Bash<'a> {
         }
 
         let toggle_text = match self.state.display_state {
-            DisplayState::Expanded => ("Fold", "z"),
-            DisplayState::Preview | DisplayState::Collapsed => ("Expand", "z"),
+            FoldState::Expanded => ("Fold", "z"),
+            FoldState::Preview | FoldState::Collapsed => ("Expand", "z"),
         };
 
-        if matches!(self.state.display_state, DisplayState::Expanded) {
+        if matches!(self.state.display_state, FoldState::Expanded) {
             let view = match self.state.view {
                 BashOutputView::Stdout => "Stdout",
                 BashOutputView::Stderr => "Stderr",
@@ -349,9 +341,9 @@ impl<'a> Content for Bash<'a> {
         }
         if self.has_output_content() {
             match self.state.display_state {
-                DisplayState::Collapsed => spans.push(Span::raw(" (folded)").dark_gray()),
-                DisplayState::Preview => spans.push(Span::raw(" (preview)").dark_gray()),
-                DisplayState::Expanded => {}
+                FoldState::Collapsed => spans.push(Span::raw(" (folded)").dark_gray()),
+                FoldState::Preview => spans.push(Span::raw(" (preview)").dark_gray()),
+                FoldState::Expanded => {}
             }
         }
         if spans.is_empty() {
@@ -393,7 +385,7 @@ impl Component for Bash<'static> {
             Event::Ask(AskEvent::ToolUsePermission(_)) => {
                 let mut state = self.state.write();
                 state.requiring_confirmation = true;
-                state.display_state = DisplayState::Preview;
+                state.display_state.preview();
             }
             Event::Answer(AnswerEvent::ToolOutput { id, chunk }) => {
                 if id != &self.state.tool_use.id {
@@ -438,7 +430,7 @@ impl Component for Bash<'static> {
 
     fn handle_key_event(&mut self, key: &KeyEvent) {
         match (self.state.display_state, key.modifiers, key.code) {
-            (DisplayState::Expanded, KeyModifiers::NONE, KeyCode::Char('1')) => {
+            (FoldState::Expanded, KeyModifiers::NONE, KeyCode::Char('1')) => {
                 if !self.has_output_content() {
                     return;
                 }
@@ -447,17 +439,17 @@ impl Component for Bash<'static> {
                 drop(state);
                 self.rebuild_output();
             }
-            (DisplayState::Expanded, KeyModifiers::NONE, KeyCode::Char('2')) => {
+            (FoldState::Expanded, KeyModifiers::NONE, KeyCode::Char('2')) => {
                 if !self.has_output_content() {
                     return;
                 }
                 let mut state = self.state.write();
                 state.view = BashOutputView::Stderr;
-                state.display_state = DisplayState::Expanded;
+                state.display_state.expand();
                 drop(state);
                 self.rebuild_output();
             }
-            (DisplayState::Expanded, KeyModifiers::NONE, KeyCode::Char('3')) => {
+            (FoldState::Expanded, KeyModifiers::NONE, KeyCode::Char('3')) => {
                 if !self.has_output_content() {
                     return;
                 }
@@ -472,15 +464,15 @@ impl Component for Bash<'static> {
                 }
                 let mut state = self.state.write();
                 state.display_state = match state.display_state {
-                    DisplayState::Expanded => DisplayState::Collapsed,
-                    DisplayState::Collapsed | DisplayState::Preview => DisplayState::Expanded,
+                    FoldState::Expanded => FoldState::Collapsed,
+                    FoldState::Collapsed | FoldState::Preview => FoldState::Expanded,
                 };
             }
             (_, KeyModifiers::NONE, KeyCode::Enter) => {
                 if !self.state.requiring_confirmation {
                     return;
                 }
-                self.state.write().display_state = DisplayState::Preview;
+                self.state.write().display_state.preview();
                 global::action_tx()
                     .send(ToolAction::Grant(self.state.tool_use.to_owned()).into())
                     .unwrap();
@@ -490,7 +482,7 @@ impl Component for Bash<'static> {
                 if !self.state.requiring_confirmation {
                     return;
                 }
-                self.state.write().display_state = DisplayState::Preview;
+                self.state.write().display_state.preview();
                 global::action_tx()
                     .send(ToolAction::GrantSession(self.state.tool_use.to_owned()).into())
                     .unwrap();
@@ -519,7 +511,7 @@ impl Component for Bash<'static> {
         if !self.has_output_content() {
             return;
         }
-        if self.state.display_state != DisplayState::Preview {
+        if self.state.display_state != FoldState::Preview {
             return;
         }
         let Some(output) = self.state.output.as_ref() else {
@@ -528,7 +520,7 @@ impl Component for Bash<'static> {
         if output.exit_code != 0 {
             return;
         }
-        self.state.write().display_state = DisplayState::Collapsed;
+        self.state.write().display_state.collapse();
     }
 
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
@@ -541,7 +533,7 @@ impl Component for Bash<'static> {
         let width = area.width.max(1);
         let height_input = self.input.height(width);
 
-        if self.state.display_state == DisplayState::Collapsed
+        if self.state.display_state == FoldState::Collapsed
             || self.state.requiring_confirmation
             || !self.has_output_content()
         {
@@ -550,7 +542,7 @@ impl Component for Bash<'static> {
             return Ok(());
         }
 
-        let width_tabs = if self.state.display_state == DisplayState::Preview {
+        let width_tabs = if self.state.display_state == FoldState::Preview {
             0
         } else {
             tab_panel_width(width)
@@ -560,9 +552,9 @@ impl Component for Bash<'static> {
         let width_text = width_body.saturating_sub(width_marker).max(1);
         let min_height = TAB_PANEL_HEIGHT;
         let height_output = match self.state.display_state {
-            DisplayState::Preview => OUTPUT_PREVIEW_LINES.max(min_height),
-            DisplayState::Expanded => self.output_text.line_count(width_text).max(min_height),
-            DisplayState::Collapsed => 0,
+            FoldState::Preview => OUTPUT_PREVIEW_LINES.max(min_height),
+            FoldState::Expanded => self.output_text.line_count(width_text).max(min_height),
+            FoldState::Collapsed => 0,
         };
         let [area_input, area_output] =
             Layout::vertical([Length(height_input as u16), Length(height_output as u16)])
@@ -580,9 +572,9 @@ impl Component for Bash<'static> {
         };
 
         let (output_text, output_markers) = match self.state.display_state {
-            DisplayState::Preview => (&self.output_preview_text, &self.output_preview_markers),
-            DisplayState::Expanded => (&self.output_text, &self.output_markers),
-            DisplayState::Collapsed => (&self.output_text, &self.output_markers),
+            FoldState::Preview => (&self.output_preview_text, &self.output_preview_markers),
+            FoldState::Expanded => (&self.output_text, &self.output_markers),
+            FoldState::Collapsed => (&self.output_text, &self.output_markers),
         };
 
         if width_marker == 0 {
@@ -607,17 +599,17 @@ impl Component for Bash<'static> {
 
 impl ContentComponent for Bash<'static> {}
 
-fn display_state_for_output(output: Option<&BashOutput>, current: DisplayState) -> DisplayState {
+fn display_state_for_output(output: Option<&BashOutput>, current: FoldState) -> FoldState {
     let Some(output) = output else {
         return current;
     };
     if output.exit_code != 0 {
-        return DisplayState::Expanded;
+        return FoldState::Expanded;
     }
-    if current == DisplayState::Expanded {
-        DisplayState::Expanded
+    if current == FoldState::Expanded {
+        FoldState::Expanded
     } else {
-        DisplayState::Preview
+        FoldState::Preview
     }
 }
 
@@ -683,7 +675,7 @@ mod tests {
     async fn bash_auto_collapses_on_success_and_stays_open_on_failure() {
         let tool_use = tool_use();
         let mut bash = Bash::try_new().tool_use(&tool_use).call().unwrap();
-        assert_eq!(bash.state.display_state, DisplayState::Preview);
+        assert_eq!(bash.state.display_state, FoldState::Preview);
 
         let value = serde_json::to_value(bash_output()).unwrap();
         bash.handle_event(&Event::Answer(AnswerEvent::ToolResult {
@@ -692,9 +684,9 @@ mod tests {
             is_user_cancelled: false,
             output: Final::Json(value),
         }));
-        assert_eq!(bash.state.display_state, DisplayState::Preview);
+        assert_eq!(bash.state.display_state, FoldState::Preview);
         bash.update(&Action::Blur);
-        assert_eq!(bash.state.display_state, DisplayState::Collapsed);
+        assert_eq!(bash.state.display_state, FoldState::Collapsed);
 
         let value = serde_json::to_value(bash_output_with_exit(1)).unwrap();
         bash.handle_event(&Event::Answer(AnswerEvent::ToolResult {
@@ -703,9 +695,9 @@ mod tests {
             is_user_cancelled: false,
             output: Final::Json(value),
         }));
-        assert_eq!(bash.state.display_state, DisplayState::Expanded);
+        assert_eq!(bash.state.display_state, FoldState::Expanded);
         bash.update(&Action::Blur);
-        assert_eq!(bash.state.display_state, DisplayState::Expanded);
+        assert_eq!(bash.state.display_state, FoldState::Expanded);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -718,21 +710,21 @@ mod tests {
             .call()
             .unwrap();
 
-        bash.state.write().display_state = DisplayState::Collapsed;
+        bash.state.write().display_state = FoldState::Collapsed;
         bash.handle_key_event(&key(KeyCode::Char('1')));
-        assert_eq!(bash.state.display_state, DisplayState::Collapsed);
+        assert_eq!(bash.state.display_state, FoldState::Collapsed);
 
-        bash.state.write().display_state = DisplayState::Expanded;
+        bash.state.write().display_state = FoldState::Expanded;
         bash.handle_key_event(&key(KeyCode::Char('1')));
-        assert_eq!(bash.state.display_state, DisplayState::Expanded);
+        assert_eq!(bash.state.display_state, FoldState::Expanded);
         assert_eq!(bash.state.view.index(), 0);
 
         bash.handle_key_event(&key(KeyCode::Char('2')));
-        assert_eq!(bash.state.display_state, DisplayState::Expanded);
+        assert_eq!(bash.state.display_state, FoldState::Expanded);
         assert_eq!(bash.state.view.index(), 1);
 
         bash.handle_key_event(&key(KeyCode::Char('3')));
-        assert_eq!(bash.state.display_state, DisplayState::Expanded);
+        assert_eq!(bash.state.display_state, FoldState::Expanded);
         assert_eq!(bash.state.view.index(), 2);
     }
 
@@ -746,9 +738,9 @@ mod tests {
             .call()
             .unwrap();
 
-        assert_eq!(bash.state.display_state, DisplayState::Preview);
+        assert_eq!(bash.state.display_state, FoldState::Preview);
         bash.handle_key_event(&key(KeyCode::Char('z')));
-        assert_eq!(bash.state.display_state, DisplayState::Expanded);
+        assert_eq!(bash.state.display_state, FoldState::Expanded);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -804,7 +796,7 @@ mod tests {
             .call()
             .unwrap();
 
-        bash.state.write().display_state = DisplayState::Collapsed;
+        bash.state.write().display_state = FoldState::Collapsed;
         let height = bash.height(80);
         let input_height = bash.input.height(80);
 
@@ -824,11 +816,11 @@ mod tests {
             is_user_cancelled: false,
             output: Final::Json(value),
         }));
-        assert_eq!(bash.state.display_state, DisplayState::Preview);
+        assert_eq!(bash.state.display_state, FoldState::Preview);
         assert_eq!(bash.height(80), bash.input.height(80));
 
         bash.update(&Action::Blur);
-        assert_eq!(bash.state.display_state, DisplayState::Preview);
+        assert_eq!(bash.state.display_state, FoldState::Preview);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/coco-tui/src/components/messages/tool/list.rs
+++ b/crates/coco-tui/src/components/messages/tool/list.rs
@@ -14,6 +14,7 @@ use ratatui::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::super::fold::FoldState;
 use crate::{
     actions::Action,
     components::{Component, Content, ContentComponent, Persistable},
@@ -28,15 +29,8 @@ use crate::{
 struct Inner {
     input: ListInput,
     output: Option<String>,
-    #[serde(default = "default_display_state")]
-    display_state: DisplayState,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-enum DisplayState {
-    Omitted,
-    Collapsed,
-    Expanded,
+    #[serde(default)]
+    display_state: FoldState,
 }
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -50,10 +44,6 @@ pub struct List<'a> {
 }
 
 const OMITTED_PREVIEW_LINES: usize = 5;
-
-fn default_display_state() -> DisplayState {
-    DisplayState::Omitted
-}
 
 fn generate_input_widget<'a>(input: ListInput) -> Paragraph<'a> {
     let mut lines = vec![];
@@ -87,7 +77,7 @@ impl List<'_> {
             state: State::new(Inner {
                 input,
                 output: None,
-                display_state: DisplayState::Omitted,
+                display_state: FoldState::Preview,
             }),
         }
     }
@@ -105,16 +95,12 @@ impl List<'_> {
 
     fn toggle_display_state(&mut self) {
         let mut state = self.state.write();
-        state.display_state = match state.display_state {
-            DisplayState::Collapsed => DisplayState::Expanded,
-            DisplayState::Expanded => DisplayState::Collapsed,
-            DisplayState::Omitted => DisplayState::Omitted,
-        };
+        state.display_state = state.display_state.toggle();
     }
 
     fn on_blur(&mut self) {
-        if self.state.display_state == DisplayState::Omitted {
-            self.state.write().display_state = DisplayState::Collapsed;
+        if self.state.display_state.is_preview() {
+            self.state.write().display_state.collapse();
         }
     }
 
@@ -136,9 +122,9 @@ impl Content for List<'_> {
             .output_widget
             .as_ref()
             .map(|widget| match self.state.display_state {
-                DisplayState::Collapsed => 0,
-                DisplayState::Expanded => widget.line_count(width),
-                DisplayState::Omitted => {
+                FoldState::Collapsed => 0,
+                FoldState::Expanded => widget.line_count(width),
+                FoldState::Preview => {
                     let height = widget.line_count(width);
                     let indicator = self.omitted_indicator();
                     let indicator_height = indicator.line_count(width);
@@ -157,7 +143,7 @@ impl Content for List<'_> {
         self.output_widget.is_some()
             && matches!(
                 self.state.display_state,
-                DisplayState::Collapsed | DisplayState::Expanded
+                FoldState::Collapsed | FoldState::Expanded
             )
     }
 
@@ -166,15 +152,15 @@ impl Content for List<'_> {
             return block;
         }
         let toggle_text = match self.state.display_state {
-            DisplayState::Collapsed => ("Unfold", "z"),
-            DisplayState::Expanded => ("Fold", "z"),
-            DisplayState::Omitted => return block,
+            FoldState::Collapsed => ("Unfold", "z"),
+            FoldState::Expanded => ("Fold", "z"),
+            FoldState::Preview => return block,
         };
         block.title_bottom(crate::components::shortcuts_desc(&[toggle_text]))
     }
 
     fn reminder_line(&self) -> Option<Line<'static>> {
-        if self.state.display_state == DisplayState::Collapsed {
+        if self.state.display_state.is_collapsed() {
             Some(Line::from(Span::raw(" (folded)").dark_gray()))
         } else {
             None
@@ -238,7 +224,7 @@ impl Component for List<'static> {
             return Ok(());
         };
 
-        if self.state.display_state == DisplayState::Collapsed {
+        if self.state.display_state == FoldState::Collapsed {
             frame.render_widget(&self.input_widget, area);
             return Ok(());
         }
@@ -249,10 +235,10 @@ impl Component for List<'static> {
         frame.render_widget(&self.input_widget, area_input);
 
         match self.state.display_state {
-            DisplayState::Expanded => {
+            FoldState::Expanded => {
                 frame.render_widget(output_widget, area_output);
             }
-            DisplayState::Omitted => {
+            FoldState::Preview => {
                 let height = output_widget.line_count(width);
                 let indicator = self.omitted_indicator();
                 let indicator_height = indicator.line_count(width);
@@ -266,7 +252,7 @@ impl Component for List<'static> {
                     frame.render_widget(output_widget, area_output);
                 }
             }
-            DisplayState::Collapsed => (),
+            FoldState::Collapsed => (),
         }
 
         Ok(())

--- a/crates/coco-tui/src/components/messages/tool/read.rs
+++ b/crates/coco-tui/src/components/messages/tool/read.rs
@@ -14,6 +14,7 @@ use ratatui::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::super::fold::FoldState;
 use crate::{
     actions::Action,
     components::{Component, Content, ContentComponent, Persistable},
@@ -28,15 +29,8 @@ use crate::{
 struct Inner {
     input: ReadInput,
     output: Option<String>,
-    #[serde(default = "default_display_state")]
-    display_state: DisplayState,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-enum DisplayState {
-    Omitted,
-    Collapsed,
-    Expanded,
+    #[serde(default)]
+    display_state: FoldState,
 }
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -50,10 +44,6 @@ pub struct Read<'a> {
 }
 
 const OMITTED_PREVIEW_LINES: usize = 5;
-
-fn default_display_state() -> DisplayState {
-    DisplayState::Omitted
-}
 
 fn generate_input_widget<'a>(input: ReadInput) -> Paragraph<'a> {
     let mut lines = vec![];
@@ -101,7 +91,7 @@ impl Read<'_> {
             state: State::new(Inner {
                 input,
                 output: None,
-                display_state: DisplayState::Omitted,
+                display_state: FoldState::Preview,
             }),
         }
     }
@@ -119,16 +109,12 @@ impl Read<'_> {
 
     fn toggle_display_state(&mut self) {
         let mut state = self.state.write();
-        state.display_state = match state.display_state {
-            DisplayState::Collapsed => DisplayState::Expanded,
-            DisplayState::Expanded => DisplayState::Collapsed,
-            DisplayState::Omitted => DisplayState::Omitted,
-        };
+        state.display_state = state.display_state.toggle();
     }
 
     fn on_blur(&mut self) {
-        if self.state.display_state == DisplayState::Omitted {
-            self.state.write().display_state = DisplayState::Collapsed;
+        if self.state.display_state.is_preview() {
+            self.state.write().display_state.collapse();
         }
     }
 
@@ -150,9 +136,9 @@ impl Content for Read<'_> {
             .output_widget
             .as_ref()
             .map(|widget| match self.state.display_state {
-                DisplayState::Collapsed => 0,
-                DisplayState::Expanded => widget.line_count(width),
-                DisplayState::Omitted => {
+                FoldState::Collapsed => 0,
+                FoldState::Expanded => widget.line_count(width),
+                FoldState::Preview => {
                     let height = widget.line_count(width);
                     let indicator = self.omitted_indicator();
                     let indicator_height = indicator.line_count(width);
@@ -171,7 +157,7 @@ impl Content for Read<'_> {
         self.output_widget.is_some()
             && matches!(
                 self.state.display_state,
-                DisplayState::Collapsed | DisplayState::Expanded
+                FoldState::Collapsed | FoldState::Expanded
             )
     }
 
@@ -180,15 +166,15 @@ impl Content for Read<'_> {
             return block;
         }
         let toggle_text = match self.state.display_state {
-            DisplayState::Collapsed => ("Unfold", "z"),
-            DisplayState::Expanded => ("Fold", "z"),
-            DisplayState::Omitted => return block,
+            FoldState::Collapsed => ("Unfold", "z"),
+            FoldState::Expanded => ("Fold", "z"),
+            FoldState::Preview => return block,
         };
         block.title_bottom(crate::components::shortcuts_desc(&[toggle_text]))
     }
 
     fn reminder_line(&self) -> Option<Line<'static>> {
-        if self.state.display_state == DisplayState::Collapsed {
+        if self.state.display_state.is_collapsed() {
             Some(Line::from(Span::raw(" (folded)").dark_gray()))
         } else {
             None
@@ -252,7 +238,7 @@ impl Component for Read<'static> {
             return Ok(());
         };
 
-        if self.state.display_state == DisplayState::Collapsed {
+        if self.state.display_state == FoldState::Collapsed {
             frame.render_widget(&self.input_widget, area);
             return Ok(());
         }
@@ -265,10 +251,10 @@ impl Component for Read<'static> {
 
         // Draw output area
         match self.state.display_state {
-            DisplayState::Expanded => {
+            FoldState::Expanded => {
                 frame.render_widget(output_widget, area_output);
             }
-            DisplayState::Omitted => {
+            FoldState::Preview => {
                 let height = output_widget.line_count(width);
                 let indicator = self.omitted_indicator();
                 let indicator_height = indicator.line_count(width);
@@ -282,7 +268,7 @@ impl Component for Read<'static> {
                     frame.render_widget(output_widget, area_output);
                 }
             }
-            DisplayState::Collapsed => (),
+            FoldState::Collapsed => (),
         }
 
         Ok(())
@@ -314,15 +300,15 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn read_omitted_then_blur_collapses() {
+    async fn read_preview_then_blur_collapses() {
         let mut read: Read<'static> = Read::new(&make_tool_use());
         read.update_output(make_output());
 
-        assert_eq!(read.state.display_state, DisplayState::Omitted);
+        assert_eq!(read.state.display_state, FoldState::Preview);
         assert!(!read.is_actionable());
 
         read.update(&Action::Blur);
-        assert_eq!(read.state.display_state, DisplayState::Collapsed);
+        assert_eq!(read.state.display_state, FoldState::Collapsed);
         assert!(read.is_actionable());
     }
 
@@ -333,12 +319,12 @@ mod tests {
 
         let key = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE);
         read.handle_key_event(&key);
-        assert_eq!(read.state.display_state, DisplayState::Omitted);
+        assert_eq!(read.state.display_state, FoldState::Preview);
 
         read.update(&Action::Blur);
         read.handle_key_event(&key);
-        assert_eq!(read.state.display_state, DisplayState::Expanded);
+        assert_eq!(read.state.display_state, FoldState::Expanded);
         read.handle_key_event(&key);
-        assert_eq!(read.state.display_state, DisplayState::Collapsed);
+        assert_eq!(read.state.display_state, FoldState::Collapsed);
     }
 }


### PR DESCRIPTION
## Summary
- Extract FoldState enum for unified display state management across UI components
- Extract StreamedLines for centralized streaming output management with line limits
- Remove debug logging from Combo component

## Changes
- **fold.rs**: New `FoldState` enum with `Collapsed`, `Preview`, `Expanded` variants
- **streaming.rs**: `StreamedLine` and `StreamedLines` structs for chunk processing
- **combo.rs**: Replaced boolean `collapsed` with `FoldState` display_state
- **bash.rs**, **list.rs**, **read.rs**: Updated to use shared `FoldState` enum
- **combo.rs**: Removed `tracing::debug` imports and debug statements