### PR TITLE
feat: add CLI prompt argument for auto-submission

### DIFF
--- a/crates/coco-tui/src/actions.rs
+++ b/crates/coco-tui/src/actions.rs
@@ -12,6 +12,7 @@ pub enum Action {
     Tool(ToolAction),
     Session(SessionAction),
     Command(String),
+    SubmitPrompt(String),
 
     Blur,
     Focus,

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -418,18 +418,22 @@ impl Chat<'static> {
         }
     }
 
+    fn submit_value(&mut self, value: String) {
+        if value.is_empty() {
+            debug!("submitting with empty value, skipping");
+            return;
+        }
+        debug!(?value, "submiting");
+        self.messages
+            .push(Message::user(Plain::new(value.clone()).into()));
+        let content = self.build_user_content(ChatContent::Text(value));
+        self.spawn_chat_task(content);
+    }
+
     fn on_submit(&mut self) {
         if self.state.state == ChatState::Ready {
             let value = self.input.clear();
-            if value.is_empty() {
-                debug!("submitting with empty value, skipping");
-                return;
-            }
-            debug!(?value, "submiting");
-            self.messages
-                .push(Message::user(Plain::new(value.clone()).into()));
-            let content = self.build_user_content(ChatContent::Text(value));
-            self.spawn_chat_task(content);
+            self.submit_value(value);
         } else {
             // TODO: Display an alert when input submission is not available
         }
@@ -911,6 +915,17 @@ impl Component for Chat<'static> {
                     unknown => {
                         warn!(?unknown, "unknown command");
                     }
+                }
+            }
+            Action::SubmitPrompt(prompt) => {
+                if self.state.state == ChatState::Ready {
+                    self.submit_value(prompt.to_owned());
+                } else {
+                    warn!(
+                        ?prompt,
+                        state = %self.state.state,
+                        "auto submit skipped while busy"
+                    );
                 }
             }
             _ => (),

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -33,6 +33,10 @@ struct Args {
     #[arg(short = 'r', long)]
     restore: bool,
 
+    /// Prompt text to submit after TUI starts
+    #[arg(trailing_var_arg = true, value_name = "prompt")]
+    prompt: Vec<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -90,6 +94,20 @@ impl TryFrom<Commands> for ClientCommand {
 #[tokio::main]
 async fn main() -> Result<()> {
     let mut args = Args::parse();
+    if !args.prompt.is_empty() {
+        ensure_whatever!(
+            args.command.is_none(),
+            "prompt cannot be used with subcommands"
+        );
+        ensure_whatever!(!args.restore, "prompt cannot be used with --restore");
+    }
+    let startup_prompt = if args.prompt.is_empty() {
+        None
+    } else {
+        let prompt = args.prompt.join(" ");
+        ensure_whatever!(!prompt.trim().is_empty(), "prompt is required");
+        Some(prompt)
+    };
     if let Some(command) = args.command.take() {
         match ClientCommand::try_from(command) {
             Ok(command) => {
@@ -120,6 +138,9 @@ async fn main() -> Result<()> {
     let mut root_view = Chat::new(config);
     root_view.setup().await;
     let mut app = app::App::new(Box::new(root_view))?;
+    if let Some(prompt) = startup_prompt {
+        app.send_action(Action::SubmitPrompt(prompt));
+    }
     match args.command {
         Some(Commands::Combo(combo_cmd)) => match combo_cmd {
             ComboCommands::Run { name } => {


### PR DESCRIPTION
## Description

Adds CLI prompt argument support for auto-submission functionality.

## Changes

- Added positional argument handling for CLI prompts
- Implemented auto-submission logic when prompt is provided via command line
- Updated documentation and usage examples
