### PR TITLE
chore: add --all flag to cargo test configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
                 bash
               ];
               cargoTestFlags = [
+                "--all"
                 "--no-capture"
               ];
               useNextest = true;


### PR DESCRIPTION
- Add '--all' flag to cargoTestFlags in flake.nix
- Ensures all tests are run in Nix build environment
- Maintains existing '--no-capture' flag for test output visibility