### PR TITLE
feat: add git commit --dry-run to safe commands

### DIFF
--- a/src/agent/safe_commands.toml
+++ b/src/agent/safe_commands.toml
@@ -120,5 +120,9 @@ allow_positional = true
 positional_path_from = 0
 
 [[commands]]
+command = ["git", "commit"]
+flags = [{ name = "--dry-run", arg = "none" }]
+
+[[commands]]
 command = ["cargo", "check"]
 allow_any = true


### PR DESCRIPTION
- Add git commit --dry-run command to safe_commands.toml
- Allow safe execution of commit dry-run operations
- Maintain existing cargo check command configuration