### PR TITLE
feat: add transcript view with message history and navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-diff",
  "tree-sitter-highlight",
+ "tree-sitter-json",
  "tree-sitter-md",
 ]
 
@@ -1334,7 +1335,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2217,6 +2218,16 @@ dependencies = [
  "streaming-iterator",
  "thiserror 2.0.17",
  "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/crates/coco-tui/src/components.rs
+++ b/crates/coco-tui/src/components.rs
@@ -53,6 +53,7 @@ mod command_palette;
 mod input;
 mod message;
 mod messages;
+mod transcript;
 
 pub use chat::Chat;
 pub use code_highlight::CodeHighlight;
@@ -60,6 +61,7 @@ pub use command_palette::*;
 pub use input::Input;
 pub use message::*;
 pub use messages::*;
+pub use transcript::*;
 
 /// Provides a unique identifier string for struct registry.
 ///

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -43,6 +43,8 @@ pub struct Chat<'a> {
     command_palette: CommandPalette,
     input: Input<'a>,
     messages: Messages,
+    transcript: Messages,
+    view: ViewMode,
     indicator: ThrobberState,
 
     token_schedule_session_save: Option<CancellationToken>,
@@ -113,6 +115,12 @@ enum Focus {
     CommandPalette,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ViewMode {
+    Chat,
+    Transcript,
+}
+
 const CTRL_C_WINDOW: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Default)]
@@ -178,6 +186,7 @@ impl CancellationGuard {
 }
 
 const COMMAND_NEW_SESSION: &str = "New Session";
+const COMMAND_TRANSCRIPT: &str = "Transcript";
 
 const AGENTS_MD_FILENAME: &str = "AGENTS.md";
 
@@ -193,10 +202,16 @@ impl Chat<'static> {
                     name: COMMAND_NEW_SESSION.to_string(),
                     shortcut: Some("<C-n>".to_string()),
                 },
+                Command {
+                    name: COMMAND_TRANSCRIPT.to_string(),
+                    shortcut: Some("<C-t>".to_string()),
+                },
                 // TODO: Switch Session
             ]),
             input: Input::default(),
             messages: Messages::default(),
+            transcript: Messages::default(),
+            view: ViewMode::Chat,
             indicator: ThrobberState::default(),
             token_schedule_session_save: None,
             cancellation_guard: CancellationGuard::default(),
@@ -563,6 +578,28 @@ impl Chat<'static> {
         }
     }
 
+    fn open_transcript(&mut self) {
+        self.update_focus(Focus::InputBlur);
+        let agent_messages = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(self.agent.dump_messages())
+        });
+
+        self.transcript.clear();
+        let iter = agent_messages.iter().map(|message| {
+            let text = format_transcript_message(message);
+            Message::system(Plain::new(text).into())
+        });
+        self.transcript.extend(iter);
+        self.view = ViewMode::Transcript;
+        global::signal_dirty();
+    }
+
+    fn close_transcript(&mut self) {
+        self.view = ViewMode::Chat;
+        self.update_focus(Focus::InputBlur);
+        global::signal_dirty();
+    }
+
     /// Handle the "New Session" command
     /// Optionally saves the current session before clearing
     fn new_session(&mut self) {
@@ -626,7 +663,8 @@ impl Persistable for Chat<'static> {
 
 impl Component for Chat<'static> {
     fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
-        let children: Vec<&mut dyn Component> = vec![&mut self.input, &mut self.messages];
+        let children: Vec<&mut dyn Component> =
+            vec![&mut self.input, &mut self.messages, &mut self.transcript];
         Box::new(children.into_iter())
     }
 
@@ -735,7 +773,9 @@ impl Component for Chat<'static> {
         use KeyModifiers as KM;
 
         if matches!(key.code, BackTab) {
-            self.toggle_auto_accept_edits();
+            if self.view == ViewMode::Chat {
+                self.toggle_auto_accept_edits();
+            }
             return;
         }
 
@@ -749,6 +789,31 @@ impl Component for Chat<'static> {
             }
         ) {
             self.handle_ctrl_c();
+            return;
+        }
+        if self.view == ViewMode::Transcript {
+            match (key.modifiers, key.code) {
+                (KM::NONE, Esc) => self.close_transcript(),
+                (KM::NONE, Char('k')) => {
+                    self.transcript.scroll_up(1);
+                }
+                (KM::NONE, Char('j')) => {
+                    self.transcript.scroll_down(1);
+                }
+                (KM::CONTROL, Char('y')) => {
+                    self.transcript.scroll_up(1);
+                }
+                (KM::CONTROL, Char('e')) => {
+                    self.transcript.scroll_down(1);
+                }
+                (KM::CONTROL, Char('u')) => {
+                    self.transcript.scroll_half_up();
+                }
+                (KM::CONTROL, Char('d')) => {
+                    self.transcript.scroll_half_down();
+                }
+                _ => (),
+            }
             return;
         }
         match (focus, key.modifiers, key.code) {
@@ -911,6 +976,9 @@ impl Component for Chat<'static> {
                     COMMAND_NEW_SESSION => {
                         self.new_session();
                     }
+                    COMMAND_TRANSCRIPT => {
+                        self.open_transcript();
+                    }
                     unknown => {
                         warn!(?unknown, "unknown command");
                     }
@@ -934,36 +1002,63 @@ impl Component for Chat<'static> {
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         use Constraint::{Length, Min};
 
-        let vertical = Layout::vertical([Min(0), Length(1), Length(1), Length(1)]);
-        let [area_messages, divider, area_input, bottom] = vertical.areas(area);
+        match self.view {
+            ViewMode::Chat => {
+                let vertical = Layout::vertical([Min(0), Length(1), Length(1), Length(1)]);
+                let [area_messages, divider, area_input, bottom] = vertical.areas(area);
 
-        self.messages.draw(frame, area_messages)?;
+                self.messages.draw(frame, area_messages)?;
 
-        let block = Block::new()
-            .borders(Borders::BOTTOM)
-            .border_set(border::THICK);
-        frame.render_widget(self.block_bottom_with_shortcuts_desc(block), divider);
+                let block = Block::new()
+                    .borders(Borders::BOTTOM)
+                    .border_set(border::THICK);
+                frame.render_widget(self.block_bottom_with_shortcuts_desc(block), divider);
 
-        let theme = global::theme();
-        let mut bottom_block = Block::new().borders(Borders::BOTTOM);
-        bottom_block = if !matches!(self.state.focus, Focus::Messages) {
-            bottom_block
-                .border_set(border::THICK)
-                .border_style(theme.ui.block_border_active)
-        } else {
-            bottom_block
-                .border_set(border::PLAIN)
-                .border_style(theme.ui.block_border_inactive)
-        };
-        bottom_block = bottom_block
-            .title_bottom(Line::from(""))
-            .title_bottom(self.widget_state_indicator());
-        bottom_block = bottom_block.title_bottom(self.auto_accept_indicator());
-        if let Some(line) = self.ctrl_c_reminder_line() {
-            bottom_block = bottom_block.title_bottom(line);
+                let theme = global::theme();
+                let mut bottom_block = Block::new().borders(Borders::BOTTOM);
+                bottom_block = if !matches!(self.state.focus, Focus::Messages) {
+                    bottom_block
+                        .border_set(border::THICK)
+                        .border_style(theme.ui.block_border_active)
+                } else {
+                    bottom_block
+                        .border_set(border::PLAIN)
+                        .border_style(theme.ui.block_border_inactive)
+                };
+                bottom_block = bottom_block
+                    .title_bottom(Line::from(""))
+                    .title_bottom(self.widget_state_indicator());
+                bottom_block = bottom_block.title_bottom(self.auto_accept_indicator());
+                if let Some(line) = self.ctrl_c_reminder_line() {
+                    bottom_block = bottom_block.title_bottom(line);
+                }
+                frame.render_widget(bottom_block, bottom);
+                self.input.draw(frame, area_input)?;
+            }
+            ViewMode::Transcript => {
+                let vertical = Layout::vertical([Min(0), Length(1)]);
+                let [area_messages, bottom] = vertical.areas(area);
+                self.transcript.draw(frame, area_messages)?;
+
+                let theme = global::theme();
+                let mut bottom_block = Block::new()
+                    .borders(Borders::BOTTOM)
+                    .border_set(border::THICK)
+                    .border_style(theme.ui.block_border_active);
+                bottom_block = bottom_block
+                    .title_bottom(Line::from(""))
+                    .title_bottom(Line::from(" Transcript ").bold());
+                bottom_block = bottom_block
+                    .title_bottom(shortcuts_desc(&[("Back", "Esc")]))
+                    .title_bottom(shortcuts_desc(&[("Up", "k"), ("Down", "j")]))
+                    .title_bottom(shortcuts_desc(&[("Scroll Up", "C-y"), ("Down", "C-e")]))
+                    .title_bottom(shortcuts_desc(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]));
+                if let Some(line) = self.ctrl_c_reminder_line() {
+                    bottom_block = bottom_block.title_bottom(line);
+                }
+                frame.render_widget(bottom_block, bottom);
+            }
         }
-        frame.render_widget(bottom_block, bottom);
-        self.input.draw(frame, area_input)?;
 
         if self.state.focus == Focus::CommandPalette {
             // popup floating window
@@ -971,6 +1066,99 @@ impl Component for Chat<'static> {
         }
 
         Ok(())
+    }
+}
+
+fn format_transcript_message(message: &ChatMessage) -> String {
+    let mut out = String::new();
+    let role = match message.role {
+        code_combo::Role::User => "user",
+        code_combo::Role::Assistant => "assistant",
+    };
+    push_line(&mut out, 0, &format!("role: {role}"));
+    push_line(&mut out, 0, "blocks:");
+    match &message.content {
+        ChatContent::Text(text) => {
+            format_text_block(&mut out, 2, text);
+        }
+        ChatContent::Multiple(blocks) => {
+            for block in blocks {
+                format_block(&mut out, 2, block);
+            }
+        }
+    }
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+fn format_text_block(out: &mut String, indent: usize, text: &str) {
+    push_line(out, indent, "- type: text");
+    push_line(out, indent + 2, "text:");
+    push_multiline(out, indent + 4, text);
+}
+
+fn format_block(out: &mut String, indent: usize, block: &ChatBlock) {
+    match block {
+        ChatBlock::Text { text } => {
+            format_text_block(out, indent, text);
+        }
+        ChatBlock::ToolUse(tool_use) => {
+            push_line(out, indent, "- type: tool_use");
+            push_line(out, indent + 2, &format!("id: {}", tool_use.id));
+            push_line(out, indent + 2, &format!("name: {}", tool_use.name));
+            push_line(out, indent + 2, "input:");
+            let input = serde_json::to_string_pretty(&tool_use.input)
+                .unwrap_or_else(|_| "[Invalid JSON]".to_string());
+            push_multiline(out, indent + 4, &input);
+        }
+        ChatBlock::ToolResult {
+            tool_use_id,
+            is_error,
+            content,
+        } => {
+            push_line(out, indent, "- type: tool_result");
+            push_line(out, indent + 2, &format!("tool_use_id: {tool_use_id}"));
+            if let Some(is_error) = is_error {
+                push_line(out, indent + 2, &format!("is_error: {is_error}"));
+            }
+            push_line(out, indent + 2, "content:");
+            format_content(out, indent + 4, content);
+        }
+    }
+}
+
+fn format_content(out: &mut String, indent: usize, content: &ChatContent) {
+    match content {
+        ChatContent::Text(text) => {
+            push_line(out, indent, "text:");
+            push_multiline(out, indent + 2, text);
+        }
+        ChatContent::Multiple(blocks) => {
+            push_line(out, indent, "blocks:");
+            for block in blocks {
+                format_block(out, indent + 2, block);
+            }
+        }
+    }
+}
+
+fn push_line(out: &mut String, indent: usize, line: &str) {
+    for _ in 0..indent {
+        out.push(' ');
+    }
+    out.push_str(line);
+    out.push('\n');
+}
+
+fn push_multiline(out: &mut String, indent: usize, text: &str) {
+    if text.is_empty() {
+        push_line(out, indent, "");
+        return;
+    }
+    for line in text.lines() {
+        push_line(out, indent, line);
     }
 }
 

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1000,70 +1000,82 @@ impl Component for Chat<'static> {
     }
 
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        use Constraint::{Length, Min};
-
         match self.view {
-            ViewMode::Chat => {
-                let vertical = Layout::vertical([Min(0), Length(1), Length(1), Length(1)]);
-                let [area_messages, divider, area_input, bottom] = vertical.areas(area);
-
-                self.messages.draw(frame, area_messages)?;
-
-                let block = Block::new()
-                    .borders(Borders::BOTTOM)
-                    .border_set(border::THICK);
-                frame.render_widget(self.block_bottom_with_shortcuts_desc(block), divider);
-
-                let theme = global::theme();
-                let mut bottom_block = Block::new().borders(Borders::BOTTOM);
-                bottom_block = if !matches!(self.state.focus, Focus::Messages) {
-                    bottom_block
-                        .border_set(border::THICK)
-                        .border_style(theme.ui.block_border_active)
-                } else {
-                    bottom_block
-                        .border_set(border::PLAIN)
-                        .border_style(theme.ui.block_border_inactive)
-                };
-                bottom_block = bottom_block
-                    .title_bottom(Line::from(""))
-                    .title_bottom(self.widget_state_indicator());
-                bottom_block = bottom_block.title_bottom(self.auto_accept_indicator());
-                if let Some(line) = self.ctrl_c_reminder_line() {
-                    bottom_block = bottom_block.title_bottom(line);
-                }
-                frame.render_widget(bottom_block, bottom);
-                self.input.draw(frame, area_input)?;
-            }
-            ViewMode::Transcript => {
-                let vertical = Layout::vertical([Min(0), Length(1)]);
-                let [area_messages, bottom] = vertical.areas(area);
-                self.transcript.draw(frame, area_messages)?;
-
-                let theme = global::theme();
-                let mut bottom_block = Block::new()
-                    .borders(Borders::BOTTOM)
-                    .border_set(border::THICK)
-                    .border_style(theme.ui.block_border_active);
-                bottom_block = bottom_block
-                    .title_bottom(Line::from(""))
-                    .title_bottom(Line::from(" Transcript ").bold());
-                bottom_block = bottom_block
-                    .title_bottom(shortcuts_desc(&[("Back", "Esc")]))
-                    .title_bottom(shortcuts_desc(&[("Up", "k"), ("Down", "j")]))
-                    .title_bottom(shortcuts_desc(&[("Scroll Up", "C-y"), ("Down", "C-e")]))
-                    .title_bottom(shortcuts_desc(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]));
-                if let Some(line) = self.ctrl_c_reminder_line() {
-                    bottom_block = bottom_block.title_bottom(line);
-                }
-                frame.render_widget(bottom_block, bottom);
-            }
+            ViewMode::Chat => self.draw_chat(frame, area)?,
+            ViewMode::Transcript => self.draw_transcript(frame, area)?,
         }
 
         if self.state.focus == Focus::CommandPalette {
             // popup floating window
             self.command_palette.draw(frame, area)?;
         }
+
+        Ok(())
+    }
+}
+
+impl Chat<'static> {
+    fn draw_chat(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        use Constraint::{Length, Min};
+
+        let vertical = Layout::vertical([Min(0), Length(1), Length(1), Length(1)]);
+        let [area_messages, divider, area_input, bottom] = vertical.areas(area);
+
+        self.messages.draw(frame, area_messages)?;
+
+        let block = Block::new()
+            .borders(Borders::BOTTOM)
+            .border_set(border::THICK);
+        frame.render_widget(self.block_bottom_with_shortcuts_desc(block), divider);
+
+        let theme = global::theme();
+        let mut bottom_block = Block::new().borders(Borders::BOTTOM);
+        bottom_block = if !matches!(self.state.focus, Focus::Messages) {
+            bottom_block
+                .border_set(border::THICK)
+                .border_style(theme.ui.block_border_active)
+        } else {
+            bottom_block
+                .border_set(border::PLAIN)
+                .border_style(theme.ui.block_border_inactive)
+        };
+        bottom_block = bottom_block
+            .title_bottom(Line::from(""))
+            .title_bottom(self.widget_state_indicator());
+        bottom_block = bottom_block.title_bottom(self.auto_accept_indicator());
+        if let Some(line) = self.ctrl_c_reminder_line() {
+            bottom_block = bottom_block.title_bottom(line);
+        }
+        frame.render_widget(bottom_block, bottom);
+        self.input.draw(frame, area_input)?;
+
+        Ok(())
+    }
+
+    fn draw_transcript(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        use Constraint::{Length, Min};
+
+        let vertical = Layout::vertical([Min(0), Length(1)]);
+        let [area_messages, bottom] = vertical.areas(area);
+        self.transcript.draw(frame, area_messages)?;
+
+        let theme = global::theme();
+        let mut bottom_block = Block::new()
+            .borders(Borders::BOTTOM)
+            .border_set(border::THICK)
+            .border_style(theme.ui.block_border_active);
+        bottom_block = bottom_block
+            .title_bottom(Line::from(""))
+            .title_bottom(Line::from(" Transcript ").bold());
+        bottom_block = bottom_block
+            .title_bottom(shortcuts_desc(&[("Back", "Esc")]))
+            .title_bottom(shortcuts_desc(&[("Up", "k"), ("Down", "j")]))
+            .title_bottom(shortcuts_desc(&[("Scroll Up", "C-y"), ("Down", "C-e")]))
+            .title_bottom(shortcuts_desc(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]));
+        if let Some(line) = self.ctrl_c_reminder_line() {
+            bottom_block = bottom_block.title_bottom(line);
+        }
+        frame.render_widget(bottom_block, bottom);
 
         Ok(())
     }

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -23,7 +23,8 @@ use tracing::{debug, warn};
 
 use super::{
     Action, AnswerEvent, AskEvent, BotMessage, Combo, ComboAction, ComboEvent, Component, Content,
-    Event, Input, Message, Messages, Plain, SessionAction, Tool, ToolAction, shortcuts_desc,
+    Event, Input, Message, Messages, Plain, SessionAction, Tool, ToolAction, TranscriptMessage,
+    shortcuts_desc,
 };
 use crate::{
     components::{Command, CommandPalette, Persistable},
@@ -585,10 +586,9 @@ impl Chat<'static> {
         });
 
         self.transcript.clear();
-        let iter = agent_messages.iter().map(|message| {
-            let text = format_transcript_message(message);
-            Message::system(Plain::new(text).into())
-        });
+        let iter = agent_messages
+            .into_iter()
+            .map(|message| Message::system(TranscriptMessage::new(message).into()));
         self.transcript.extend(iter);
         self.view = ViewMode::Transcript;
         global::signal_dirty();
@@ -1078,99 +1078,6 @@ impl Chat<'static> {
         frame.render_widget(bottom_block, bottom);
 
         Ok(())
-    }
-}
-
-fn format_transcript_message(message: &ChatMessage) -> String {
-    let mut out = String::new();
-    let role = match message.role {
-        code_combo::Role::User => "user",
-        code_combo::Role::Assistant => "assistant",
-    };
-    push_line(&mut out, 0, &format!("role: {role}"));
-    push_line(&mut out, 0, "blocks:");
-    match &message.content {
-        ChatContent::Text(text) => {
-            format_text_block(&mut out, 2, text);
-        }
-        ChatContent::Multiple(blocks) => {
-            for block in blocks {
-                format_block(&mut out, 2, block);
-            }
-        }
-    }
-    if out.ends_with('\n') {
-        out.pop();
-    }
-    out
-}
-
-fn format_text_block(out: &mut String, indent: usize, text: &str) {
-    push_line(out, indent, "- type: text");
-    push_line(out, indent + 2, "text:");
-    push_multiline(out, indent + 4, text);
-}
-
-fn format_block(out: &mut String, indent: usize, block: &ChatBlock) {
-    match block {
-        ChatBlock::Text { text } => {
-            format_text_block(out, indent, text);
-        }
-        ChatBlock::ToolUse(tool_use) => {
-            push_line(out, indent, "- type: tool_use");
-            push_line(out, indent + 2, &format!("id: {}", tool_use.id));
-            push_line(out, indent + 2, &format!("name: {}", tool_use.name));
-            push_line(out, indent + 2, "input:");
-            let input = serde_json::to_string_pretty(&tool_use.input)
-                .unwrap_or_else(|_| "[Invalid JSON]".to_string());
-            push_multiline(out, indent + 4, &input);
-        }
-        ChatBlock::ToolResult {
-            tool_use_id,
-            is_error,
-            content,
-        } => {
-            push_line(out, indent, "- type: tool_result");
-            push_line(out, indent + 2, &format!("tool_use_id: {tool_use_id}"));
-            if let Some(is_error) = is_error {
-                push_line(out, indent + 2, &format!("is_error: {is_error}"));
-            }
-            push_line(out, indent + 2, "content:");
-            format_content(out, indent + 4, content);
-        }
-    }
-}
-
-fn format_content(out: &mut String, indent: usize, content: &ChatContent) {
-    match content {
-        ChatContent::Text(text) => {
-            push_line(out, indent, "text:");
-            push_multiline(out, indent + 2, text);
-        }
-        ChatContent::Multiple(blocks) => {
-            push_line(out, indent, "blocks:");
-            for block in blocks {
-                format_block(out, indent + 2, block);
-            }
-        }
-    }
-}
-
-fn push_line(out: &mut String, indent: usize, line: &str) {
-    for _ in 0..indent {
-        out.push(' ');
-    }
-    out.push_str(line);
-    out.push('\n');
-}
-
-fn push_multiline(out: &mut String, indent: usize, text: &str) {
-    if text.is_empty() {
-        push_line(out, indent, "");
-        return;
-    }
-    for line in text.lines() {
-        push_line(out, indent, line);
     }
 }
 

--- a/crates/coco-tui/src/components/transcript.rs
+++ b/crates/coco-tui/src/components/transcript.rs
@@ -1,0 +1,747 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
+use code_combo::{Block as ChatBlock, Content as ChatContent, Message as ChatMessage};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    prelude::Rect,
+    widgets::Wrap,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    components::{CodeHighlight, Component, Content, ContentComponent, Persistable},
+    error::Result,
+    session::{self, Session},
+    widgets::Paragraph,
+};
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptState {
+    message: ChatMessage,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_message")]
+pub struct TranscriptMessage {
+    state: TranscriptState,
+    segments: Vec<Box<dyn ContentComponent>>,
+}
+
+const INDENT_STEP: u16 = 2;
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_plain")]
+struct TranscriptPlain {
+    text: String,
+    widget: Paragraph<'static>,
+}
+
+impl TranscriptPlain {
+    fn new(text: impl Into<String>) -> Self {
+        let text = text.into();
+        let widget = Paragraph::new_wrap(text.clone(), Wrap { trim: false });
+        Self { text, widget }
+    }
+}
+
+impl Persistable for TranscriptPlain {
+    fn save(&self) -> Session {
+        session::save(&self.text)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let text: String = session::load(session)?;
+        Ok(Self::new(text))
+    }
+}
+
+impl Component for TranscriptPlain {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        frame.render_widget(&self.widget, area);
+        Ok(())
+    }
+}
+
+impl Content for TranscriptPlain {
+    fn height(&self, width: u16) -> usize {
+        self.widget.line_count(width)
+    }
+}
+
+impl ContentComponent for TranscriptPlain {}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptTextState {
+    text: String,
+    detect_json: bool,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_text")]
+struct TranscriptText {
+    state: TranscriptTextState,
+    content: Box<dyn ContentComponent>,
+}
+
+impl TranscriptText {
+    fn new(text: &str, detect_json: bool) -> Self {
+        let content = text_component(text, detect_json);
+        Self {
+            state: TranscriptTextState {
+                text: text.to_string(),
+                detect_json,
+            },
+            content,
+        }
+    }
+}
+
+impl Persistable for TranscriptText {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptTextState = session::load(session)?;
+        Ok(Self::new(&state.text, state.detect_json))
+    }
+}
+
+impl Component for TranscriptText {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(vec![self.content.as_mut() as &mut dyn Component].into_iter())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        let header = "- type: text";
+        let key = "text:";
+        let header_height = line_height(header, area.width);
+        let key_height = line_height(key, area.width.saturating_sub(INDENT_STEP));
+        let content_height = child_height(self.content.as_ref(), area.width, INDENT_STEP * 2);
+        let chunks = vertical_chunks(area, &[header_height, key_height, content_height]);
+        if !chunks.is_empty() {
+            draw_line(frame, chunks[0], header);
+        }
+        if chunks.len() >= 2 {
+            draw_line(frame, indented_area(chunks[1], INDENT_STEP), key);
+        }
+        if chunks.len() >= 3 {
+            draw_child(self.content.as_mut(), frame, chunks[2], INDENT_STEP * 2)?;
+        }
+        Ok(())
+    }
+}
+
+impl Content for TranscriptText {
+    fn height(&self, width: u16) -> usize {
+        let header = "- type: text";
+        let key = "text:";
+        let header_height = line_height(header, width);
+        let key_height = line_height(key, width.saturating_sub(INDENT_STEP));
+        let content_height = child_height(self.content.as_ref(), width, INDENT_STEP * 2);
+        header_height + key_height + content_height
+    }
+}
+
+impl ContentComponent for TranscriptText {}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptToolUseState {
+    tool_use: code_combo::ToolUse,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_tool_use")]
+struct TranscriptToolUse {
+    state: TranscriptToolUseState,
+    input: Box<dyn ContentComponent>,
+}
+
+impl TranscriptToolUse {
+    fn new(tool_use: &code_combo::ToolUse) -> Self {
+        let input = json_component(&tool_use.input);
+        Self {
+            state: TranscriptToolUseState {
+                tool_use: tool_use.clone(),
+            },
+            input,
+        }
+    }
+}
+
+impl Persistable for TranscriptToolUse {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptToolUseState = session::load(session)?;
+        Ok(Self::new(&state.tool_use))
+    }
+}
+
+impl Component for TranscriptToolUse {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(vec![self.input.as_mut() as &mut dyn Component].into_iter())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        let header = "- type: tool_use";
+        let id = format!("id: {}", self.state.tool_use.id);
+        let name = format!("name: {}", self.state.tool_use.name);
+        let input_key = "input:";
+
+        let header_height = line_height(header, area.width);
+        let id_height = line_height(&id, area.width.saturating_sub(INDENT_STEP));
+        let name_height = line_height(&name, area.width.saturating_sub(INDENT_STEP));
+        let input_height = line_height(input_key, area.width.saturating_sub(INDENT_STEP));
+        let body_height = child_height(self.input.as_ref(), area.width, INDENT_STEP * 2);
+        let chunks = vertical_chunks(
+            area,
+            &[
+                header_height,
+                id_height,
+                name_height,
+                input_height,
+                body_height,
+            ],
+        );
+
+        if !chunks.is_empty() {
+            draw_line(frame, chunks[0], header);
+        }
+        if chunks.len() >= 2 {
+            draw_line(frame, indented_area(chunks[1], INDENT_STEP), &id);
+        }
+        if chunks.len() >= 3 {
+            draw_line(frame, indented_area(chunks[2], INDENT_STEP), &name);
+        }
+        if chunks.len() >= 4 {
+            draw_line(frame, indented_area(chunks[3], INDENT_STEP), input_key);
+        }
+        if chunks.len() >= 5 {
+            draw_child(self.input.as_mut(), frame, chunks[4], INDENT_STEP * 2)?;
+        }
+        Ok(())
+    }
+}
+
+impl Content for TranscriptToolUse {
+    fn height(&self, width: u16) -> usize {
+        let header = "- type: tool_use";
+        let id = format!("id: {}", self.state.tool_use.id);
+        let name = format!("name: {}", self.state.tool_use.name);
+        let input_key = "input:";
+        let header_height = line_height(header, width);
+        let id_height = line_height(&id, width.saturating_sub(INDENT_STEP));
+        let name_height = line_height(&name, width.saturating_sub(INDENT_STEP));
+        let input_height = line_height(input_key, width.saturating_sub(INDENT_STEP));
+        let body_height = child_height(self.input.as_ref(), width, INDENT_STEP * 2);
+        header_height + id_height + name_height + input_height + body_height
+    }
+}
+
+impl ContentComponent for TranscriptToolUse {}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptToolResultState {
+    tool_use_id: String,
+    is_error: Option<bool>,
+    content: ChatContent,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_tool_result")]
+struct TranscriptToolResult {
+    state: TranscriptToolResultState,
+    content: TranscriptContentSection,
+}
+
+impl TranscriptToolResult {
+    fn new(tool_use_id: &str, is_error: Option<bool>, content: &ChatContent) -> Self {
+        let content_section = TranscriptContentSection::new(content, true);
+        Self {
+            state: TranscriptToolResultState {
+                tool_use_id: tool_use_id.to_string(),
+                is_error,
+                content: content.clone(),
+            },
+            content: content_section,
+        }
+    }
+}
+
+impl Persistable for TranscriptToolResult {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptToolResultState = session::load(session)?;
+        Ok(Self::new(
+            &state.tool_use_id,
+            state.is_error,
+            &state.content,
+        ))
+    }
+}
+
+impl Component for TranscriptToolResult {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(vec![&mut self.content as &mut dyn Component].into_iter())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        let header = "- type: tool_result";
+        let tool_use_id = format!("tool_use_id: {}", self.state.tool_use_id);
+        let mut heights = Vec::with_capacity(5);
+        heights.push(line_height(header, area.width));
+        heights.push(line_height(
+            &tool_use_id,
+            area.width.saturating_sub(INDENT_STEP),
+        ));
+        if let Some(is_error) = self.state.is_error {
+            let is_error = format!("is_error: {is_error}");
+            heights.push(line_height(
+                &is_error,
+                area.width.saturating_sub(INDENT_STEP),
+            ));
+        }
+        let content_key = "content:";
+        heights.push(line_height(
+            content_key,
+            area.width.saturating_sub(INDENT_STEP),
+        ));
+        heights.push(child_height(&self.content, area.width, INDENT_STEP * 2));
+
+        let chunks = vertical_chunks(area, &heights);
+        let mut idx = 0;
+        if let Some(chunk) = chunks.get(idx) {
+            draw_line(frame, *chunk, header);
+        }
+        idx += 1;
+        if let Some(chunk) = chunks.get(idx) {
+            draw_line(frame, indented_area(*chunk, INDENT_STEP), &tool_use_id);
+        }
+        idx += 1;
+        if let Some(is_error) = self.state.is_error {
+            if let Some(chunk) = chunks.get(idx) {
+                draw_line(
+                    frame,
+                    indented_area(*chunk, INDENT_STEP),
+                    &format!("is_error: {is_error}"),
+                );
+            }
+            idx += 1;
+        }
+        if let Some(chunk) = chunks.get(idx) {
+            draw_line(frame, indented_area(*chunk, INDENT_STEP), content_key);
+        }
+        idx += 1;
+        if let Some(chunk) = chunks.get(idx) {
+            draw_child(&mut self.content, frame, *chunk, INDENT_STEP * 2)?;
+        }
+        Ok(())
+    }
+}
+
+impl Content for TranscriptToolResult {
+    fn height(&self, width: u16) -> usize {
+        let header = "- type: tool_result";
+        let tool_use_id = format!("tool_use_id: {}", self.state.tool_use_id);
+        let mut total = 0;
+        total += line_height(header, width);
+        total += line_height(&tool_use_id, width.saturating_sub(INDENT_STEP));
+        if let Some(is_error) = self.state.is_error {
+            total += line_height(
+                &format!("is_error: {is_error}"),
+                width.saturating_sub(INDENT_STEP),
+            );
+        }
+        total += line_height("content:", width.saturating_sub(INDENT_STEP));
+        total += child_height(&self.content, width, INDENT_STEP * 2);
+        total
+    }
+}
+
+impl ContentComponent for TranscriptToolResult {}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptBlocksState {
+    blocks: Vec<ChatBlock>,
+    detect_json: bool,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_blocks")]
+struct TranscriptBlocks {
+    state: TranscriptBlocksState,
+    items: Vec<Box<dyn ContentComponent>>,
+}
+
+impl TranscriptBlocks {
+    fn new(blocks: &[ChatBlock], detect_json: bool) -> Self {
+        let items = build_block_items(blocks, detect_json);
+        Self {
+            state: TranscriptBlocksState {
+                blocks: blocks.to_vec(),
+                detect_json,
+            },
+            items,
+        }
+    }
+}
+
+impl Persistable for TranscriptBlocks {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptBlocksState = session::load(session)?;
+        Ok(Self::new(&state.blocks, state.detect_json))
+    }
+}
+
+impl Component for TranscriptBlocks {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(
+            self.items
+                .iter_mut()
+                .map(|item| item.as_mut() as &mut dyn Component),
+        )
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        if self.items.is_empty() {
+            return Ok(());
+        }
+        let heights = self
+            .items
+            .iter()
+            .map(|item| item.height(area.width))
+            .collect::<Vec<_>>();
+        let chunks = vertical_chunks(area, &heights);
+        for (item, chunk) in self.items.iter_mut().zip(chunks.iter()) {
+            item.draw(frame, *chunk)?;
+        }
+        Ok(())
+    }
+}
+
+impl Content for TranscriptBlocks {
+    fn height(&self, width: u16) -> usize {
+        self.items.iter().map(|item| item.height(width)).sum()
+    }
+}
+
+impl ContentComponent for TranscriptBlocks {}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptBlocksSectionState {
+    content: ChatContent,
+    detect_json: bool,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_blocks_section")]
+struct TranscriptBlocksSection {
+    state: TranscriptBlocksSectionState,
+    blocks: TranscriptBlocks,
+}
+
+impl TranscriptBlocksSection {
+    fn new(content: &ChatContent, detect_json: bool) -> Self {
+        let blocks = blocks_from_content(content);
+        let blocks = TranscriptBlocks::new(&blocks, detect_json);
+        Self {
+            state: TranscriptBlocksSectionState {
+                content: content.clone(),
+                detect_json,
+            },
+            blocks,
+        }
+    }
+}
+
+impl Persistable for TranscriptBlocksSection {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptBlocksSectionState = session::load(session)?;
+        Ok(Self::new(&state.content, state.detect_json))
+    }
+}
+
+impl Component for TranscriptBlocksSection {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(vec![&mut self.blocks as &mut dyn Component].into_iter())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        let label = "blocks:";
+        let label_height = line_height(label, area.width);
+        let blocks_height = child_height(&self.blocks, area.width, INDENT_STEP);
+        let chunks = vertical_chunks(area, &[label_height, blocks_height]);
+        if !chunks.is_empty() {
+            draw_line(frame, chunks[0], label);
+        }
+        if chunks.len() >= 2 {
+            draw_child(&mut self.blocks, frame, chunks[1], INDENT_STEP)?;
+        }
+        Ok(())
+    }
+}
+
+impl Content for TranscriptBlocksSection {
+    fn height(&self, width: u16) -> usize {
+        let label_height = line_height("blocks:", width);
+        let blocks_height = child_height(&self.blocks, width, INDENT_STEP);
+        label_height + blocks_height
+    }
+}
+
+impl ContentComponent for TranscriptBlocksSection {}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptContentSectionState {
+    content: ChatContent,
+    detect_json: bool,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_content_section")]
+struct TranscriptContentSection {
+    state: TranscriptContentSectionState,
+    label: String,
+    content: Box<dyn ContentComponent>,
+}
+
+impl TranscriptContentSection {
+    fn new(chat_content: &ChatContent, detect_json: bool) -> Self {
+        let (label, content_component) = match chat_content {
+            ChatContent::Text(text) => ("text".to_string(), text_component(text, detect_json)),
+            ChatContent::Multiple(blocks) => (
+                "blocks".to_string(),
+                TranscriptBlocks::new(blocks, detect_json).into(),
+            ),
+        };
+        Self {
+            state: TranscriptContentSectionState {
+                content: chat_content.clone(),
+                detect_json,
+            },
+            label,
+            content: content_component,
+        }
+    }
+}
+
+impl Persistable for TranscriptContentSection {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptContentSectionState = session::load(session)?;
+        Ok(Self::new(&state.content, state.detect_json))
+    }
+}
+
+impl Component for TranscriptContentSection {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(vec![self.content.as_mut() as &mut dyn Component].into_iter())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        let label = format!("{}:", self.label);
+        let label_height = line_height(&label, area.width);
+        let content_height = child_height(self.content.as_ref(), area.width, INDENT_STEP);
+        let chunks = vertical_chunks(area, &[label_height, content_height]);
+        if !chunks.is_empty() {
+            draw_line(frame, chunks[0], &label);
+        }
+        if chunks.len() >= 2 {
+            draw_child(self.content.as_mut(), frame, chunks[1], INDENT_STEP)?;
+        }
+        Ok(())
+    }
+}
+
+impl Content for TranscriptContentSection {
+    fn height(&self, width: u16) -> usize {
+        let label = format!("{}:", self.label);
+        let label_height = line_height(&label, width);
+        let content_height = child_height(self.content.as_ref(), width, INDENT_STEP);
+        label_height + content_height
+    }
+}
+
+impl ContentComponent for TranscriptContentSection {}
+
+impl TranscriptMessage {
+    pub fn new(message: ChatMessage) -> Self {
+        let segments = build_segments(&message);
+        Self {
+            state: TranscriptState { message },
+            segments,
+        }
+    }
+}
+
+fn build_segments(message: &ChatMessage) -> Vec<Box<dyn ContentComponent>> {
+    let role = match message.role {
+        code_combo::Role::User => "user",
+        code_combo::Role::Assistant => "assistant",
+    };
+    vec![
+        TranscriptPlain::new(format!("role: {role}")).into(),
+        TranscriptBlocksSection::new(&message.content, false).into(),
+    ]
+}
+
+fn blocks_from_content(content: &ChatContent) -> Vec<ChatBlock> {
+    match content {
+        ChatContent::Text(text) => vec![ChatBlock::Text { text: text.clone() }],
+        ChatContent::Multiple(blocks) => blocks.clone(),
+    }
+}
+
+fn build_block_items(blocks: &[ChatBlock], detect_json: bool) -> Vec<Box<dyn ContentComponent>> {
+    blocks
+        .iter()
+        .map(|block| block_component(block, detect_json))
+        .collect()
+}
+
+fn block_component(block: &ChatBlock, detect_json: bool) -> Box<dyn ContentComponent> {
+    match block {
+        ChatBlock::Text { text } => TranscriptText::new(text, detect_json).into(),
+        ChatBlock::ToolUse(tool_use) => TranscriptToolUse::new(tool_use).into(),
+        ChatBlock::ToolResult {
+            tool_use_id,
+            is_error,
+            content,
+        } => TranscriptToolResult::new(tool_use_id, *is_error, content).into(),
+    }
+}
+
+fn line_height(text: &str, width: u16) -> usize {
+    if width == 0 {
+        return 0;
+    }
+    Paragraph::new_wrap(text.to_string(), Wrap { trim: false }).line_count(width)
+}
+
+fn draw_line(frame: &mut Frame, area: Rect, text: &str) {
+    if area.width == 0 {
+        return;
+    }
+    let widget = Paragraph::new_wrap(text.to_string(), Wrap { trim: false });
+    frame.render_widget(widget, area);
+}
+
+fn indented_area(area: Rect, indent: u16) -> Rect {
+    if area.width <= indent {
+        return Rect::new(area.x + area.width, area.y, 0, area.height);
+    }
+    Rect::new(area.x + indent, area.y, area.width - indent, area.height)
+}
+
+fn child_height(child: &dyn ContentComponent, width: u16, indent: u16) -> usize {
+    let width = width.saturating_sub(indent);
+    if width == 0 { 0 } else { child.height(width) }
+}
+
+fn draw_child(
+    child: &mut dyn ContentComponent,
+    frame: &mut Frame,
+    area: Rect,
+    indent: u16,
+) -> Result<()> {
+    let area = indented_area(area, indent);
+    if area.width == 0 {
+        return Ok(());
+    }
+    child.draw(frame, area)
+}
+
+fn vertical_chunks(area: Rect, heights: &[usize]) -> Vec<Rect> {
+    if heights.is_empty() {
+        return Vec::new();
+    }
+    let constraints = heights
+        .iter()
+        .map(|height| Constraint::Length(*height as u16))
+        .collect::<Vec<_>>();
+    Layout::vertical(constraints).split(area).to_vec()
+}
+
+fn text_component(text: &str, detect_json: bool) -> Box<dyn ContentComponent> {
+    if detect_json && let Ok(value) = serde_json::from_str::<Value>(text) {
+        return json_component(&value);
+    }
+    markdown_component(text)
+}
+
+fn markdown_component(text: &str) -> Box<dyn ContentComponent> {
+    if text.is_empty() {
+        return TranscriptPlain::new(String::new()).into();
+    }
+    match CodeHighlight::try_new(text, code_highlight::Lang::Markdown) {
+        Ok(widget) => widget.into(),
+        Err(_) => TranscriptPlain::new(text).into(),
+    }
+}
+
+fn json_component(value: &Value) -> Box<dyn ContentComponent> {
+    let json = serde_json::to_string_pretty(value).unwrap_or_else(|_| "[Invalid JSON]".into());
+    match CodeHighlight::try_new(&json, code_highlight::Lang::Json) {
+        Ok(widget) => widget.into(),
+        Err(_) => TranscriptPlain::new(json).into(),
+    }
+}
+
+impl Persistable for TranscriptMessage {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptState = session::load(session)?;
+        Ok(Self::new(state.message))
+    }
+}
+
+impl Component for TranscriptMessage {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        if self.segments.is_empty() {
+            return Ok(());
+        }
+
+        let heights = self
+            .segments
+            .iter()
+            .map(|segment| segment.height(area.width))
+            .collect::<Vec<_>>();
+        let chunks = vertical_chunks(area, &heights);
+        for (segment, chunk) in self.segments.iter_mut().zip(chunks.iter()) {
+            segment.draw(frame, chunk.to_owned())?;
+        }
+        Ok(())
+    }
+}
+
+impl Content for TranscriptMessage {
+    fn height(&self, width: u16) -> usize {
+        self.segments
+            .iter()
+            .map(|segment| segment.height(width))
+            .sum()
+    }
+}
+
+impl ContentComponent for TranscriptMessage {}

--- a/crates/code-highlight/Cargo.toml
+++ b/crates/code-highlight/Cargo.toml
@@ -11,6 +11,7 @@ tree-sitter-highlight = "0.25.10"
 # Support Languages
 tree-sitter-bash = "0.25.0"
 tree-sitter-diff = "0.1.0"
+tree-sitter-json = "0.24"
 tree-sitter-md.workspace = true
 
 # Serialization and data handling

--- a/crates/code-highlight/src/lang.rs
+++ b/crates/code-highlight/src/lang.rs
@@ -8,6 +8,7 @@ use super::Result;
 pub enum Lang {
     Bash,
     Diff,
+    Json,
     Markdown,
     MarkdownInline,
 }
@@ -18,6 +19,7 @@ impl Lang {
         match self {
             Bash => "bash",
             Diff => "diff",
+            Json => "json",
             Markdown => "markdown",
             MarkdownInline => "markdown_inline",
         }
@@ -35,8 +37,9 @@ pub fn new_config(lang: &Lang, names: &[&str]) -> Result<HighlightConfiguration>
     match lang {
         Bash => bash_config(names),
         Diff => diff_config(names),
+        Json => json_config(names),
         Markdown => markdown_config(names),
-        _ => unimplemented!(),
+        MarkdownInline => markdown_inline_config(names),
     }
 }
 
@@ -70,6 +73,30 @@ fn diff_config(names: &[&str]) -> Result<HighlightConfiguration> {
     Ok(config)
 }
 
+const JSON_HIGHLIGHTS_QUERY: &str = r#"
+(string) @string
+(number) @number
+(true) @keyword
+(false) @keyword
+(null) @keyword
+(pair key: (string) @property)
+"#;
+
+fn json_config(names: &[&str]) -> Result<HighlightConfiguration> {
+    let mut config = HighlightConfiguration::new(
+        tree_sitter_json::LANGUAGE.into(),
+        "json",
+        JSON_HIGHLIGHTS_QUERY,
+        "",
+        "",
+    )
+    .whatever_context("failed to create json highlight configuration")?;
+
+    config.configure(names);
+
+    Ok(config)
+}
+
 fn markdown_config(names: &[&str]) -> Result<HighlightConfiguration> {
     let mut config = HighlightConfiguration::new(
         tree_sitter_md::LANGUAGE.into(),
@@ -79,6 +106,21 @@ fn markdown_config(names: &[&str]) -> Result<HighlightConfiguration> {
         "",
     )
     .whatever_context("failed to create markdown highlight configuration")?;
+
+    config.configure(names);
+
+    Ok(config)
+}
+
+fn markdown_inline_config(names: &[&str]) -> Result<HighlightConfiguration> {
+    let mut config = HighlightConfiguration::new(
+        tree_sitter_md::INLINE_LANGUAGE.into(),
+        "markdown_inline",
+        tree_sitter_md::HIGHLIGHT_QUERY_INLINE,
+        tree_sitter_md::INJECTION_QUERY_INLINE,
+        "",
+    )
+    .whatever_context("failed to create markdown inline highlight configuration")?;
 
     config.configure(names);
 

--- a/crates/code-highlight/src/lang.rs
+++ b/crates/code-highlight/src/lang.rs
@@ -73,20 +73,11 @@ fn diff_config(names: &[&str]) -> Result<HighlightConfiguration> {
     Ok(config)
 }
 
-const JSON_HIGHLIGHTS_QUERY: &str = r#"
-(string) @string
-(number) @number
-(true) @keyword
-(false) @keyword
-(null) @keyword
-(pair key: (string) @property)
-"#;
-
 fn json_config(names: &[&str]) -> Result<HighlightConfiguration> {
     let mut config = HighlightConfiguration::new(
         tree_sitter_json::LANGUAGE.into(),
         "json",
-        JSON_HIGHLIGHTS_QUERY,
+        tree_sitter_json::HIGHLIGHTS_QUERY,
         "",
         "",
     )

--- a/crates/code-highlight/src/tests.rs
+++ b/crates/code-highlight/src/tests.rs
@@ -1,2 +1,3 @@
 mod bash;
 mod diff;
+mod json;

--- a/crates/code-highlight/src/tests/json.rs
+++ b/crates/code-highlight/src/tests/json.rs
@@ -1,0 +1,33 @@
+use crate::{Event::Source, Lang, Result, highlight};
+use indoc::indoc;
+
+#[test]
+#[snafu::report]
+fn parse_json_roundtrip() -> Result<()> {
+    let source = indoc! {r#"
+        {
+          "name": "alice",
+          "age": 30,
+          "active": true,
+          "tags": ["a", "b"],
+          "meta": {"score": 4.5, "note": null}
+        }
+    "#}
+    .trim();
+
+    let events = highlight(
+        &Lang::Json,
+        &["string", "number", "keyword", "property"],
+        source,
+    )?;
+    let merged = events
+        .iter()
+        .filter_map(|event| match event {
+            Source(text) => Some(*text),
+            _ => None,
+        })
+        .collect::<String>();
+    assert_eq!(merged, source);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds a transcript view that displays the full message history of the current session
- Implements navigation shortcuts (Esc to exit, j/k for line navigation, C-y/C-e for scrolling)
- Extracts transcript formatting into dedicated component system for maintainability
- Refactors chat and transcript drawing logic into separate methods for clarity