### PR TITLE
fix: prevent COCO_ environment variable leakage in shell commands

### DIFF
--- a/crates/coco-tui/src/app.rs
+++ b/crates/coco-tui/src/app.rs
@@ -273,7 +273,11 @@ impl App {
         let _ = crossterm::execute!(out, Clear(ClearType::All), cursor::MoveTo(0, 0));
         println!("Entering shell. Type 'exit' to return.");
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
-        let status = Command::new(&shell)
+        let mut cmd = Command::new(&shell);
+        for key in code_combo::env_keys_with_prefix("COCO_") {
+            cmd.env_remove(key);
+        }
+        let status = cmd
             .envs(envs)
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     io,
     pin::Pin,
     process::Stdio,
@@ -108,6 +109,7 @@ impl RunningProcess {
 pub struct ExecCommand {
     argv: Vec<String>,
     envs: Vec<(String, String)>,
+    env_remove: Vec<OsString>,
     stdin: Stdio,
 }
 
@@ -116,6 +118,7 @@ impl ExecCommand {
         Self {
             argv,
             envs: Vec::new(),
+            env_remove: Vec::new(),
             stdin: Stdio::null(),
         }
     }
@@ -130,6 +133,11 @@ impl ExecCommand {
             .into_iter()
             .map(|(k, v)| (k.into(), v.into()))
             .collect();
+        self
+    }
+
+    pub fn remove_env_prefix(mut self, prefix: &str) -> Self {
+        self.env_remove.extend(env_keys_with_prefix(prefix));
         self
     }
 
@@ -153,8 +161,11 @@ impl ExecCommand {
         cmd.stdin(self.stdin)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .envs(self.envs.iter().map(|(k, v)| (k, v)));
+            .kill_on_drop(true);
+        for key in &self.env_remove {
+            cmd.env_remove(key);
+        }
+        cmd.envs(self.envs.iter().map(|(k, v)| (k, v)));
 
         let mut child = cmd.spawn()?;
         let _ = child.stdin.take();
@@ -310,6 +321,13 @@ impl ExecCommand {
             handle,
         })
     }
+}
+
+pub fn env_keys_with_prefix(prefix: &str) -> Vec<OsString> {
+    std::env::vars_os()
+        .map(|(key, _)| key)
+        .filter(|key| key.to_string_lossy().starts_with(prefix))
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -118,6 +118,7 @@ where
         }
     };
     let mut proc = ExecCommand::from_argv(argv)
+        .remove_env_prefix("COCO_")
         .envs(envs)
         .spawn_chunked(ChunkConfig {
             interval: Duration::ZERO,


### PR DESCRIPTION
- Add env_keys_with_prefix() utility to identify environment variables with specific prefix
- Extend ExecCommand with remove_env_prefix() method to strip matching environment variables
- Apply COCO_ environment removal to bash tool execution to prevent variable leakage
- Clean up COCO_ environment variables in TUI shell command for isolated shell sessions
- Maintain existing environment variable functionality while preventing unintended variable inheritance