### PR TITLE
fix: reset processing state when saving chat snapshot

### DIFF
--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -275,6 +275,10 @@ impl Chat<'static> {
         if state.focus == Focus::ShortcutHints {
             state.focus = self.prev_focus.clone().unwrap_or_default();
         }
+        if state.state == ChatState::Procesing {
+            // Persist Ready to avoid restoring a stale processing state.
+            state.state = ChatState::Ready;
+        }
         let messages = self.messages.save();
         let agent = self.agent.clone();
 


### PR DESCRIPTION
Ensure chat state is set to Ready when saving a snapshot to avoid restoring stale processing state on session reload.