### PR TITLE
feat: show prompt reply parameters in combo UI

### DIFF
--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -366,7 +366,8 @@ impl Chat<'static> {
             | ComboEvent::RecordStart { .. }
             | ComboEvent::RecordOutput { .. }
             | ComboEvent::RecordEnd { .. }
-            | ComboEvent::Prompt { .. } => {
+            | ComboEvent::Prompt { .. }
+            | ComboEvent::PromptReply { .. } => {
                 self.set_processing();
             }
             ComboEvent::Executed { starter, .. } => {
@@ -1488,16 +1489,25 @@ async fn task_combo_execute(
                             .into(),
                         )
                         .unwrap();
-
-                        let response = if cancel_token.is_cancelled() {
+                        let reply = if cancel_token.is_cancelled() {
                             Err("prompt reply cancelled".to_string())
                         } else {
                             agent
                                 .reply_prompt(&system_prompt, schemas)
                                 .await
-                                .map(|reply| reply.response)
                                 .map_err(|err| err.to_string())
                         };
+                        if let Ok(reply) = &reply {
+                            tx.send(
+                                ComboEvent::PromptReply {
+                                    name: name.clone(),
+                                    tool_use: reply.tool_use.clone(),
+                                }
+                                .into(),
+                            )
+                            .ok();
+                        }
+                        let response = reply.map(|reply| reply.response);
                         if let Err(err) = &response {
                             tx.send(
                                 ComboEvent::ReplyToolError {

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -32,6 +32,9 @@ use crate::{
     widgets::Paragraph,
 };
 
+mod prompt_reply;
+use prompt_reply::PromptReply;
+
 #[derive(Serialize, Deserialize, Default)]
 enum StarterState {
     #[default]
@@ -204,6 +207,13 @@ impl Combo {
             .push(Message::user(Plain::new(prompt.to_string()).into()).with_role_prefix(false));
     }
 
+    fn push_prompt_reply(&mut self, tool_use: &ToolUse) {
+        self.state.write().view = ComboView::Messages;
+        let params = PromptReply::new(tool_use);
+        self.messages
+            .push(Message::bot(params.into()).with_role_prefix(false));
+    }
+
     fn forward_output_to_child(&mut self, tool_use_id: &str, chunk: &OutputChunk) -> bool {
         let event = Event::Answer(AnswerEvent::ToolOutput {
             id: tool_use_id.to_string(),
@@ -316,6 +326,11 @@ impl Combo {
             ComboEvent::Prompt { name, prompt } => {
                 if &self.state.name == name {
                     self.push_prompt(prompt);
+                }
+            }
+            ComboEvent::PromptReply { name, tool_use } => {
+                if &self.state.name == name {
+                    self.push_prompt_reply(tool_use);
                 }
             }
             ComboEvent::Executing { name, command_line } => {

--- a/crates/coco-tui/src/components/messages/combo/prompt_reply.rs
+++ b/crates/coco-tui/src/components/messages/combo/prompt_reply.rs
@@ -1,0 +1,120 @@
+use coco_macro::{ComponentExt, ContentComponentExt};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    prelude::Rect,
+    text::{Line, Span},
+};
+use serde::{Deserialize, Serialize};
+
+use code_combo::ToolUse;
+use code_highlight::Lang;
+
+use crate::{
+    components::{CodeHighlight, Component, Content, ContentComponent, Persistable},
+    error::*,
+    global,
+    session::{self, Session},
+    widgets::Paragraph,
+};
+
+const PROMPT_REPLY_LABEL: &str = "Reply Params";
+
+#[derive(Serialize, Deserialize)]
+struct Inner {
+    params_json: String,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "combo_prompt_params")]
+pub struct PromptReply {
+    state: Inner,
+    label: Paragraph<'static>,
+    params: CodeHighlight<'static>,
+    theme_dirty: bool,
+}
+
+impl PromptReply {
+    pub fn new(tool_use: &ToolUse) -> Self {
+        let params_json = build_params_json(tool_use);
+        Self::from_json(params_json)
+    }
+
+    fn from_json(params_json: String) -> Self {
+        let label = build_prompt_params_label();
+        let params =
+            CodeHighlight::try_new(&params_json, Lang::Json).expect("failed to new CodeHighlight");
+        Self {
+            state: Inner { params_json },
+            label,
+            params,
+            theme_dirty: false,
+        }
+    }
+}
+
+fn build_prompt_params_label() -> Paragraph<'static> {
+    let theme = global::theme();
+    Paragraph::new(Line::from(Span::styled(
+        PROMPT_REPLY_LABEL.to_string(),
+        theme.ui.tool_label,
+    )))
+}
+
+fn build_params_json(tool_use: &ToolUse) -> String {
+    serde_json::to_string_pretty(&tool_use.input).unwrap_or_else(|_| tool_use.input.to_string())
+}
+
+impl Persistable for PromptReply {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: Inner = session::load(session)?;
+        Ok(Self::from_json(state.params_json))
+    }
+}
+
+impl Component for PromptReply {
+    fn children(&'_ mut self) -> Box<dyn Iterator<Item = &'_ mut dyn Component> + '_> {
+        Box::new(vec![&mut self.params as &mut dyn Component].into_iter())
+    }
+
+    fn on_cache_invalidation(&mut self, reason: crate::components::CacheInvalidation) {
+        if matches!(reason, crate::components::CacheInvalidation::Theme) {
+            self.theme_dirty = true;
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        if area.height == 0 {
+            return Ok(());
+        }
+        if self.theme_dirty {
+            self.label = build_prompt_params_label();
+            self.theme_dirty = false;
+        }
+
+        let width = area.width.max(1);
+        let label_height: u16 = 1;
+        let params_height = u16::try_from(self.params.height(width)).unwrap_or(u16::MAX);
+        let [area_label, area_params] = Layout::vertical([
+            Constraint::Length(label_height),
+            Constraint::Length(params_height),
+        ])
+        .areas(area);
+        frame.render_widget(&self.label, area_label);
+        self.params.draw(frame, area_params)?;
+        Ok(())
+    }
+}
+
+impl Content for PromptReply {
+    fn height(&self, width: u16) -> usize {
+        let width = width.max(1);
+        1 + self.params.height(width)
+    }
+}
+
+impl ContentComponent for PromptReply {}

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -91,6 +91,10 @@ pub enum ComboEvent {
         name: String,
         prompt: String,
     },
+    PromptReply {
+        name: String,
+        tool_use: ToolUse,
+    },
     Executed {
         name: String,
         starter: Starter,


### PR DESCRIPTION
- Add ComboEvent::PromptReply variant to notify UI of prompt reply parameters
- Create PromptReply component to display tool use parameters as formatted JSON
- Render reply parameters with syntax highlighting in combo message view
- Update chat component to handle prompt reply events and display parameters
- Maintain existing prompt flow while adding parameter visibility for debugging