### PR TITLE
feat: add configurable bash safe commands with layer support

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -50,6 +50,15 @@ impl Agent {
     pub fn new(config: Config) -> Self {
         let mut executor = Executor::default();
         executor.apply_tool_policies(config.allow_tools.as_deref(), config.deny_tools.as_deref());
+        let workspace_dir = config
+            .workspace_config_path
+            .as_deref()
+            .and_then(|path| path.parent());
+        bash_executor::configure_safe_commands(
+            &config.bash_layers,
+            &config.config_dir,
+            workspace_dir,
+        );
         Self {
             config,
             system_prompt: Self::build_system_prompt(None),

--- a/src/agent/bash_executor.rs
+++ b/src/agent/bash_executor.rs
@@ -1,5 +1,8 @@
-use std::collections::HashMap;
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{OnceLock, RwLock},
+};
 
 use lazy_static::lazy_static;
 use serde::Deserialize;
@@ -7,7 +10,10 @@ use toml as serde_toml;
 use tracing::warn;
 use tree_sitter::{Node, Parser};
 
-use crate::tools::BashInput;
+use crate::{
+    config::{BashConfig, BashConfigLayers, SafeCommandsMode},
+    tools::BashInput,
+};
 
 #[derive(Clone)]
 struct SafeCommandRule {
@@ -83,7 +89,7 @@ enum ParseError {
     UnsupportedNode,
 }
 
-const SAFE_COMMANDS_TOML: &str = include_str!("safe_commands.toml");
+const BUILTIN_SAFE_COMMANDS_TOML: &str = include_str!("safe_commands.toml");
 
 #[derive(Deserialize)]
 struct SafeCommandConfig {
@@ -118,15 +124,45 @@ struct SafeFlagConfig {
 }
 
 lazy_static! {
-    static ref SAFE_COMMAND_RULES: Vec<SafeCommandRule> = load_safe_command_rules();
+    static ref BUILTIN_SAFE_COMMAND_RULES: Vec<SafeCommandRule> = load_builtin_safe_command_rules();
+}
+
+static SAFE_COMMAND_RULES: OnceLock<RwLock<Vec<SafeCommandRule>>> = OnceLock::new();
+
+fn safe_command_rules() -> &'static RwLock<Vec<SafeCommandRule>> {
+    SAFE_COMMAND_RULES.get_or_init(|| RwLock::new(BUILTIN_SAFE_COMMAND_RULES.clone()))
 }
 
 pub fn should_bypass_permission(input: &BashInput) -> bool {
     is_safe_command(&input.command)
 }
 
+pub(super) fn configure_safe_commands(
+    layers: &BashConfigLayers,
+    global_config_dir: &Path,
+    workspace_config_dir: Option<&Path>,
+) {
+    let mut rules = BUILTIN_SAFE_COMMAND_RULES.clone();
+    if let Some(global) = layers.global.as_ref()
+        && let Err(err) = apply_safe_command_layer(&mut rules, global, global_config_dir)
+    {
+        warn!("failed to apply global bash safe commands: {err}");
+    }
+    if let Some(workspace) = layers.workspace.as_ref() {
+        let dir = workspace_config_dir.unwrap_or(global_config_dir);
+        if let Err(err) = apply_safe_command_layer(&mut rules, workspace, dir) {
+            warn!("failed to apply workspace bash safe commands: {err}");
+        }
+    }
+
+    let lock = safe_command_rules();
+    let mut guard = lock.write().expect("safe command lock");
+    *guard = rules;
+}
+
 fn is_safe_command(command: &str) -> bool {
-    is_safe_command_with_rules(command, &SAFE_COMMAND_RULES)
+    let rules = safe_command_rules().read().expect("safe command lock");
+    is_safe_command_with_rules(command, &rules)
 }
 
 fn is_safe_command_with_rules(command: &str, rules: &[SafeCommandRule]) -> bool {
@@ -151,6 +187,33 @@ fn is_safe_command_with_rules(command: &str, rules: &[SafeCommandRule]) -> bool 
         let remaining_args = command.args.get(consumed_args..).unwrap_or_default();
         is_safe_args(remaining_args, &rule.args)
     })
+}
+
+fn resolve_safe_commands_path(path: &str, config_dir: &Path) -> PathBuf {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        config_dir.join(path)
+    }
+}
+
+fn apply_safe_command_layer(
+    rules: &mut Vec<SafeCommandRule>,
+    config: &BashConfig,
+    config_dir: &Path,
+) -> Result<(), String> {
+    let Some(path) = config.safe_commands_path.as_deref() else {
+        return Ok(());
+    };
+    let resolved = resolve_safe_commands_path(path, config_dir);
+    let custom_rules = load_safe_command_rules_from_path(&resolved)
+        .map_err(|err| format!("{}: {err}", resolved.display()))?;
+    match config.safe_commands_mode {
+        SafeCommandsMode::Append => rules.extend(custom_rules),
+        SafeCommandsMode::Override => *rules = custom_rules,
+    }
+    Ok(())
 }
 
 fn is_safe_args(args: &[ParsedArg], policy: &ArgPolicy) -> bool {
@@ -684,15 +747,29 @@ fn is_disallowed_token_kind(kind: &str) -> bool {
     matches!(kind, "&" | ";")
 }
 
-fn load_safe_command_rules() -> Vec<SafeCommandRule> {
-    let config: SafeCommandConfig = match serde_toml::from_str(SAFE_COMMANDS_TOML) {
-        Ok(config) => config,
+fn load_builtin_safe_command_rules() -> Vec<SafeCommandRule> {
+    match parse_safe_command_rules(BUILTIN_SAFE_COMMANDS_TOML) {
+        Ok(rules) => rules,
         Err(err) => {
-            warn!("failed to parse safe_commands.toml: {err}");
-            return Vec::new();
+            warn!("failed to parse builtin safe commands: {err}");
+            Vec::new()
         }
-    };
+    }
+}
 
+fn load_safe_command_rules_from_path(path: &Path) -> Result<Vec<SafeCommandRule>, String> {
+    let content =
+        std::fs::read_to_string(path).map_err(|err| format!("failed to read file: {err}"))?;
+    parse_safe_command_rules(&content)
+}
+
+fn parse_safe_command_rules(source: &str) -> Result<Vec<SafeCommandRule>, String> {
+    let config: SafeCommandConfig =
+        serde_toml::from_str(source).map_err(|err| format!("failed to parse config: {err}"))?;
+    Ok(build_safe_command_rules(config))
+}
+
+fn build_safe_command_rules(config: SafeCommandConfig) -> Vec<SafeCommandRule> {
     config
         .commands
         .into_iter()
@@ -768,6 +845,14 @@ fn load_safe_command_rules() -> Vec<SafeCommandRule> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
+
+    fn write_safe_commands_file(dir: &Path, name: &str, command: &str) -> PathBuf {
+        let path = dir.join(name);
+        let content = format!("[[commands]]\nname = \"{command}\"\nallow_any = true\n");
+        std::fs::write(&path, content).expect("write safe commands file");
+        path
+    }
 
     macro_rules! assert_safe_cmd {
         ($cmd:expr) => {
@@ -1000,5 +1085,64 @@ mod tests {
         assert_unsafe_cmd!("   ");
         assert_unsafe_cmd!("bash -c ls");
         assert_unsafe_cmd!("sudo ls");
+    }
+
+    #[test]
+    fn safe_command_layers_apply_in_order() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _global_path = write_safe_commands_file(dir.path(), "global.toml", "global_cmd");
+        let _workspace_path =
+            write_safe_commands_file(dir.path(), "workspace.toml", "workspace_cmd");
+
+        let base_rules =
+            parse_safe_command_rules("[[commands]]\nname = \"base_cmd\"\nallow_any = true\n")
+                .expect("parse base rules");
+        let mut rules = base_rules;
+
+        let global = BashConfig {
+            safe_commands_path: Some("global.toml".to_string()),
+            safe_commands_mode: SafeCommandsMode::Append,
+        };
+        apply_safe_command_layer(&mut rules, &global, dir.path()).expect("apply global");
+        assert_safe_cmd_with_rules!("base_cmd", &rules);
+        assert_safe_cmd_with_rules!("global_cmd", &rules);
+
+        let workspace = BashConfig {
+            safe_commands_path: Some("workspace.toml".to_string()),
+            safe_commands_mode: SafeCommandsMode::Override,
+        };
+        apply_safe_command_layer(&mut rules, &workspace, dir.path()).expect("apply workspace");
+        assert_unsafe_cmd_with_rules!("base_cmd", &rules);
+        assert_unsafe_cmd_with_rules!("global_cmd", &rules);
+        assert_safe_cmd_with_rules!("workspace_cmd", &rules);
+    }
+
+    #[test]
+    fn safe_command_layers_override_then_append() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _global_path = write_safe_commands_file(dir.path(), "global.toml", "global_cmd");
+        let _workspace_path =
+            write_safe_commands_file(dir.path(), "workspace.toml", "workspace_cmd");
+
+        let base_rules =
+            parse_safe_command_rules("[[commands]]\nname = \"base_cmd\"\nallow_any = true\n")
+                .expect("parse base rules");
+        let mut rules = base_rules;
+
+        let global = BashConfig {
+            safe_commands_path: Some("global.toml".to_string()),
+            safe_commands_mode: SafeCommandsMode::Override,
+        };
+        apply_safe_command_layer(&mut rules, &global, dir.path()).expect("apply global");
+        assert_unsafe_cmd_with_rules!("base_cmd", &rules);
+        assert_safe_cmd_with_rules!("global_cmd", &rules);
+
+        let workspace = BashConfig {
+            safe_commands_path: Some("workspace.toml".to_string()),
+            safe_commands_mode: SafeCommandsMode::Append,
+        };
+        apply_safe_command_layer(&mut rules, &workspace, dir.path()).expect("apply workspace");
+        assert_safe_cmd_with_rules!("global_cmd", &rules);
+        assert_safe_cmd_with_rules!("workspace_cmd", &rules);
     }
 }

--- a/src/config/bash.rs
+++ b/src/config/bash.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum SafeCommandsMode {
+    #[default]
+    Append,
+    Override,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BashConfig {
+    #[serde(default)]
+    pub safe_commands_path: Option<String>,
+    #[serde(default)]
+    pub safe_commands_mode: SafeCommandsMode,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BashConfigLayers {
+    pub global: Option<BashConfig>,
+    pub workspace: Option<BashConfig>,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+mod bash;
 mod env;
 mod mcp;
 mod provider;
@@ -10,6 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+pub use bash::{BashConfig, BashConfigLayers, SafeCommandsMode};
 pub use env::EnvString;
 pub use mcp::{
     McpConfig, McpServerCommandConfig, McpServerConfig, McpServerConnection, McpServerHttpConfig,
@@ -44,9 +46,15 @@ pub struct Config {
     pub deny_tools: Option<Vec<String>>,
     #[serde(default)]
     pub mcp: Option<McpConfig>,
+    #[serde(default)]
+    pub bash: Option<BashConfig>,
 
     #[serde(skip)]
     pub config_dir: PathBuf,
+    #[serde(skip)]
+    pub workspace_config_path: Option<PathBuf>,
+    #[serde(skip)]
+    pub bash_layers: BashConfigLayers,
 }
 
 impl Config {
@@ -100,15 +108,25 @@ pub fn load_config_with_overrides(
     workspace_override_path: Option<&Path>,
 ) -> Result<Config, BoxError> {
     let mut base_value = parse_toml_value(config_path)?;
+    let base_bash = extract_bash_config(&base_value)?;
+    let mut workspace_bash = None;
+    let mut workspace_path = None;
     if let Some(path) = workspace_override_path
         && path.exists()
     {
         let override_value = parse_toml_value(path)?;
+        workspace_bash = extract_bash_config(&override_value)?;
         merge_config_values(&mut base_value, override_value)?;
+        workspace_path = Some(path.to_path_buf());
     }
     let merged = toml::to_string(&base_value)?;
     let mut config: Config = toml::from_str(&merged)?;
     config.config_dir = config_dir.to_path_buf();
+    config.workspace_config_path = workspace_path;
+    config.bash_layers = BashConfigLayers {
+        global: base_bash,
+        workspace: workspace_bash,
+    };
     Ok(config)
 }
 
@@ -118,6 +136,20 @@ fn parse_toml_value(path: &Path) -> Result<toml::Value, BoxError> {
         Some("toml") => Ok(toml::from_str(&content)?),
         _ => Err("Unsupported config file format".into()),
     }
+}
+
+fn extract_bash_config(value: &toml::Value) -> Result<Option<BashConfig>, BoxError> {
+    let table = value
+        .as_table()
+        .ok_or_else(|| override_error("config must be a table"))?;
+    let Some(bash_value) = table.get("bash") else {
+        return Ok(None);
+    };
+    let bash: BashConfig = bash_value
+        .clone()
+        .try_into()
+        .map_err(|err| override_error(format!("bash config invalid: {err}")))?;
+    Ok(Some(bash))
 }
 
 fn merge_config_values(
@@ -319,7 +351,9 @@ fn table_name_from_table(table: &toml::value::Table, path: &str) -> Result<Strin
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, MarkdownRenderEngine, McpServerConnection, merge_config_values};
+    use super::{
+        Config, MarkdownRenderEngine, McpServerConnection, SafeCommandsMode, merge_config_values,
+    };
 
     fn base_config() -> String {
         [
@@ -342,6 +376,7 @@ mod tests {
         assert!(config.allow_tools.is_none());
         assert!(config.deny_tools.is_none());
         assert!(config.mcp.is_none());
+        assert!(config.bash.is_none());
     }
 
     #[test]
@@ -356,6 +391,24 @@ mod tests {
         let config_str = format!("deny_tools = []\n{}", base_config());
         let config: Config = toml::from_str(&config_str).expect("parse config");
         assert_eq!(config.deny_tools, Some(Vec::new()));
+    }
+
+    #[test]
+    fn parse_config_with_bash_safe_commands() {
+        let config_str = format!(
+            "[bash]\n\
+safe_commands_path = \"safe_commands.toml\"\n\
+safe_commands_mode = \"override\"\n\
+{}",
+            base_config()
+        );
+        let config: Config = toml::from_str(&config_str).expect("parse config");
+        let bash = config.bash.expect("bash config");
+        assert_eq!(
+            bash.safe_commands_path.as_deref(),
+            Some("safe_commands.toml")
+        );
+        assert_eq!(bash.safe_commands_mode, SafeCommandsMode::Override);
     }
 
     #[test]


### PR DESCRIPTION
- Add `BashConfig` struct with `safe_commands_path` and `safe_commands_mode` (append/override)
- Implement `BashConfigLayers` to support global and workspace-specific safe command configurations
- Add `configure_safe_commands()` function to apply safe command layers in order (global → workspace)
- Update `bash_executor.rs` to use dynamic safe command rules with thread-safe `OnceLock<RwLock>`
- Support relative and absolute paths for safe command configuration files
- Add comprehensive tests for layer application order and mode combinations
- Integrate bash configuration loading into main config system with proper error handling