### PR TITLE
refactor: improve commit combo error handling and message clarity

### DIFF
--- a/.coco/combos/commit.sh
+++ b/.coco/combos/commit.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 
-set -e
+set -Ee
 
 coco metadata name=commit description="Git Commit with Proper Message" || exit 0
 
 if [ -f .pre-commit-config.yaml ]; then
+	on_err() {
+		coco tell <<EOF
+If formatting-type checks fail, they have likely been automatically fixed.
+You only need to re-add the fixed files and re-run the checks.
+EOF
+	}
+	trap on_err ERR
 	if command -v prek &>/dev/null; then
 		coco record prek run
 	elif command -v pre-commit &>/dev/null; then
 		coco record pre-commit run
 	fi
+	trap - ERR
 fi
 
 coco record git status
@@ -21,14 +29,12 @@ coco record git diff --staged --stat
 coco record git diff --staged
 
 resp=$(
-	coco ask --schemas 'message:git commit message' <<-EOF
-		# Apply Git Commit with Proper Message
+	coco ask --schemas 'message:git commit message' <<EOF
+# Summarize the staged changes and commit an appropriate message using git
 
-		Check the output of the commands provided before and
-		create a well-structured commit message adhering to the established format.
-		Summarize the staged changes concisely and clearly, ensuring the message is formatted professionally.
-		Commit these changes as a single commit. Keep the commit message clean and tidy.
-	EOF
+- Use the language and message format consistent with previous commits
+- The summarized git commit message should be concise, clear, and professional
+EOF
 )
 
 message=$(jq -r '.message' <<<"$resp")


### PR DESCRIPTION
- Apply -E flag to bash for better error trap handling
- Add pre-commit failure message handler with automatic fix guidance
- Simplify git commit message prompt for more focused AI responses
- Use consistent heredoc format (<<EOF instead of <<-EOF)
- Improve error handling flow with ERR trap setup and cleanup