### PR TITLE
feat: auto-allow run_task tool execution

### DIFF
--- a/crates/coco-tui/src/components/messages/tool.rs
+++ b/crates/coco-tui/src/components/messages/tool.rs
@@ -247,6 +247,16 @@ impl Component for Tool {
                     handle_component_event!(self, event);
                 }
             }
+            Event::Answer(AnswerEvent::ToolOutput { id, .. })
+            | Event::Answer(AnswerEvent::SubagentEvent { id, .. }) => {
+                if self.tool_use_id() == id {
+                    // Auto-allowed tools skip permission, transition directly to Executing
+                    if self.inner.state == ToolState::Initing {
+                        self.update_state(ToolState::Executing);
+                    }
+                    handle_component_event!(self, event);
+                }
+            }
             Event::Answer(AnswerEvent::ToolResult { id, is_error, .. }) => {
                 if self.tool_use_id() == id {
                     self.update_state(if *is_error {

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -284,7 +284,10 @@ impl Executor {
                 if !bypass_permission
                     && !matches!(
                         name,
-                        STR_REPLACE_TOOL_NAME | READ_TOOL_NAME | LIST_TOOL_NAME
+                        STR_REPLACE_TOOL_NAME
+                            | READ_TOOL_NAME
+                            | LIST_TOOL_NAME
+                            | RUN_TASK_TOOL_NAME
                     )
                 {
                     on_output(Output::AskPermission);


### PR DESCRIPTION
## Summary

Auto-allow run_task tool execution to improve agent workflow efficiency.

## Changes

- Auto-allow run_task tool execution
- Improve agent workflow by reducing manual confirmation for trusted operations

