### PR TITLE
fix(bash): prevent visual flicker when toggling confirmation mode

### DIFF
--- a/crates/coco-tui/src/components/code_highlight.rs
+++ b/crates/coco-tui/src/components/code_highlight.rs
@@ -178,6 +178,22 @@ impl<'a> CodeHighlight<'a> {
         }
     }
 
+    /// Clears all overlays without rebuilding the widget from scratch.
+    /// The existing highlighted widget is preserved until the next async rebuild completes.
+    /// This prevents the visual flicker that would occur if we created a new placeholder widget.
+    pub fn clear_overlays(&mut self) {
+        if self.state.overlays.is_empty() {
+            return;
+        }
+        self.state.overlays.clear();
+        self.source_dirty = true;
+        if let Some(width) = self.last_width
+            && self.pending_rx.is_none()
+        {
+            self.spawn_build(width);
+        }
+    }
+
     fn build_placeholder_widget(source: &str, base_style: Option<Style>) -> Paragraph<'static> {
         let base_style = base_style.unwrap_or_default();
         let lines = source

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -346,7 +346,15 @@ impl<'a> Bash<'a> {
                 *requiring_confirmation = value;
             }
         }
-        self.rebuild_input();
+        if value {
+            // Need to rebuild input to add overlays for unsafe ranges
+            self.rebuild_input();
+        } else {
+            // Just clear overlays without rebuilding the entire widget.
+            // This preserves the existing syntax highlighting and prevents
+            // the visual flicker that would occur if we created a new placeholder.
+            self.input.clear_overlays();
+        }
     }
 
     fn push_chunk(&mut self, chunk: OutputChunk) {


### PR DESCRIPTION
## Summary

This PR fixes the visual flicker issue in the Bash UI code highlighting when toggling AskPermission confirmation mode, as reported in #113.

## Problem

When a Bash tool UI component execution was cancelled or confirmed during the AskPermission phase, the code highlighting would disappear and reappear, causing visual flickering.

## Root Cause

The issue occurred because when toggling off confirmation mode, `rebuild_input()` was being called, which would create a new placeholder widget and lose the existing syntax-highlighted content until the async rebuild completed.

## Solution

- Introduced a new `clear_overlays()` method in `CodeHighlight` that clears overlays without rebuilding the widget from scratch
- When toggling confirmation mode **off**, we now call `clear_overlays()` instead of `rebuild_input()`
- This preserves the existing highlighted widget until the next async rebuild completes, preventing the visual flicker

## Changes

- **crates/coco-tui/src/components/code_highlight.rs**: Added `clear_overlays()` method
- **crates/coco-tui/src/components/messages/tool/bash.rs**: Updated `set_confirmation_mode()` to use `clear_overlays()` when disabling confirmation

## Testing

Manual testing confirms that toggling confirmation mode (pressing 'c') no longer causes the code highlighting to flicker.

## Related Issue

Fixes #113