### PR TITLE
fix(tools): use 'path' instead of 'file_path' in read/str_replace input summaries

### DIFF
--- a/src/tools/run_task.rs
+++ b/src/tools/run_task.rs
@@ -742,7 +742,7 @@ fn summarize_tool_input(tool_name: &str, input: &Value) -> String {
             }
         }
         "read" => {
-            if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+            if let Some(path) = input.get("path").and_then(|v| v.as_str()) {
                 truncate_str(path, MAX_LEN)
             } else {
                 "(no path)".to_string()
@@ -756,7 +756,7 @@ fn summarize_tool_input(tool_name: &str, input: &Value) -> String {
             }
         }
         "str_replace" => {
-            if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+            if let Some(path) = input.get("path").and_then(|v| v.as_str()) {
                 truncate_str(path, MAX_LEN)
             } else {
                 "(no path)".to_string()


### PR DESCRIPTION
This PR fixes #118 by updating the input summaries for read and str_replace tools to use 'path' instead of 'file_path', making them consistent with the actual parameter names.

**Problem:**
The Read component in the RunTask UI was showing "(no path)" instead of the actual file path that was read.

**Root Cause:**
The input summaries were using 'file_path' while the actual parameter name was 'path', causing a mismatch.

**Solution:**
Updated the input summaries to use 'path' to match the actual parameter names.