### PR TITLE
fix: Subagents now inherit parent agent's model configuration

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -37,8 +37,9 @@ pub use executor::{ExecuteStatus, Executor, Input, Output};
 
 const DEFAULT_THINKING_BUDGET_TOKENS: usize = 1024;
 pub use config::{
-    AGENT_CONFIG_FILENAME, AgentConfig, AgentConfigError, SubagentConfig, SystemPromptConfig,
-    ToolsConfig, load_agent_config, load_agent_config_for_combo, load_agent_config_with_layers,
+    AGENT_CONFIG_FILENAME, AgentConfig, AgentConfigError, SubagentConfig, SubagentModelConfig,
+    SystemPromptConfig, ToolsConfig, load_agent_config, load_agent_config_for_combo,
+    load_agent_config_with_layers,
 };
 
 const PROMPT_REPLY_TOOL_NAME: &str = "combo_reply";
@@ -61,6 +62,9 @@ pub struct Agent {
 
     /// Shared context for run_combo tool.
     combo_context: Arc<Mutex<RunComboContext>>,
+
+    /// Shared context for run_task tool (if subagents are configured).
+    run_task_context: Option<Arc<Mutex<RunTaskContext>>>,
 }
 
 pub struct ChatResponse {
@@ -323,17 +327,23 @@ impl Agent {
 
         // Register run_task tool only if subagents are configured
         // Must be done before apply_tool_policies so it can be retained
-        if let Some(ref subagents) = agent_config.subagents
+        // Note: model_override is initially None, will be updated via set_model_override()
+        let run_task_context = if let Some(ref subagents) = agent_config.subagents
             && !subagents.is_empty()
         {
-            let run_task_context = RunTaskContext {
+            let context = Arc::new(Mutex::new(RunTaskContext {
                 subagents: subagents.clone(),
                 config: config.clone(),
                 executor: executor.clone(),
-            };
-            let run_task_tool = RunTaskTool::new(run_task_context);
+                model_override: None,
+                default_model: agent_config.default_model.clone(),
+            }));
+            let run_task_tool = RunTaskTool::new_with_shared_context(context.clone());
             executor.register_tool(std::sync::Arc::new(run_task_tool));
-        }
+            Some(context)
+        } else {
+            None
+        };
 
         // Register run_combo tool with empty combo list initially
         // Combos will be populated later via set_combos()
@@ -367,6 +377,7 @@ impl Agent {
             model_override: None,
             agent_config,
             combo_context,
+            run_task_context,
         }
     }
 
@@ -454,7 +465,11 @@ impl Agent {
 
     pub fn set_model_override(&mut self, model: Option<String>) {
         self.model_override = model.clone();
+        let model_for_combo = model.clone();
         self.update_combo_context(move |ctx| {
+            ctx.model_override = model_for_combo;
+        });
+        self.update_run_task_context(move |ctx| {
             ctx.model_override = model;
         });
     }
@@ -470,6 +485,21 @@ impl Agent {
         F: FnOnce(&mut RunComboContext) + Send + 'static,
     {
         let ctx = self.combo_context.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let mut guard = ctx.lock().await;
+                update(&mut guard);
+            });
+        }
+    }
+
+    fn update_run_task_context<F>(&self, update: F)
+    where
+        F: FnOnce(&mut RunTaskContext) + Send + 'static,
+    {
+        let Some(ctx) = self.run_task_context.clone() else {
+            return;
+        };
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 let mut guard = ctx.lock().await;

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -238,13 +238,33 @@ pub struct ToolsConfig {
 /// - `inherit`: Inherit the model from the parent agent
 /// - Custom model name: Use a specific model (e.g., "claude-3-opus")
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(try_from = "String", into = "String")]
 pub enum SubagentModelConfig {
     /// Inherit model configuration from parent agent.
-    #[serde(rename = "inherit")]
     Inherit,
     /// Use a custom model.
     Custom(String),
+}
+
+impl TryFrom<String> for SubagentModelConfig {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.eq_ignore_ascii_case("inherit") {
+            Ok(SubagentModelConfig::Inherit)
+        } else {
+            Ok(SubagentModelConfig::Custom(value))
+        }
+    }
+}
+
+impl From<SubagentModelConfig> for String {
+    fn from(value: SubagentModelConfig) -> Self {
+        match value {
+            SubagentModelConfig::Inherit => "inherit".to_string(),
+            SubagentModelConfig::Custom(model) => model,
+        }
+    }
 }
 
 /// Subagent configuration.

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -232,6 +232,21 @@ pub struct ToolsConfig {
     pub deny: Option<Vec<String>>,
 }
 
+/// Model configuration for subagents.
+///
+/// Supports two modes:
+/// - `inherit`: Inherit the model from the parent agent
+/// - Custom model name: Use a specific model (e.g., "claude-3-opus")
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SubagentModelConfig {
+    /// Inherit model configuration from parent agent.
+    #[serde(rename = "inherit")]
+    Inherit,
+    /// Use a custom model.
+    Custom(String),
+}
+
 /// Subagent configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SubagentConfig {
@@ -255,6 +270,12 @@ pub struct SubagentConfig {
     /// Tools available to this subagent.
     #[serde(default)]
     pub tools: Option<Vec<String>>,
+
+    /// Model configuration for this subagent.
+    /// - `inherit`: Inherit model from parent agent (default behavior if not specified)
+    /// - Custom model name: Use a specific model
+    #[serde(default)]
+    pub model: Option<SubagentModelConfig>,
 }
 
 /// Safe commands configuration.
@@ -420,6 +441,53 @@ path = "./agents/reviewer.toml"
         );
         assert_eq!(subagents[1].name, "reviewer");
         assert!(subagents[1].description.is_none());
+    }
+
+    #[test]
+    fn parse_subagent_model_inherit() {
+        let toml = r#"
+[agent]
+name = "main-agent"
+
+[[agent.subagents]]
+name = "coder"
+model = "inherit"
+"#;
+        let config = AgentConfig::from_toml(toml).expect("parse config");
+        let subagents = config.subagents.expect("subagents should be present");
+        assert_eq!(subagents[0].model, Some(SubagentModelConfig::Inherit));
+    }
+
+    #[test]
+    fn parse_subagent_model_custom() {
+        let toml = r#"
+[agent]
+name = "main-agent"
+
+[[agent.subagents]]
+name = "coder"
+model = "claude-3-opus"
+"#;
+        let config = AgentConfig::from_toml(toml).expect("parse config");
+        let subagents = config.subagents.expect("subagents should be present");
+        assert_eq!(
+            subagents[0].model,
+            Some(SubagentModelConfig::Custom("claude-3-opus".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_subagent_model_none() {
+        let toml = r#"
+[agent]
+name = "main-agent"
+
+[[agent.subagents]]
+name = "coder"
+"#;
+        let config = AgentConfig::from_toml(toml).expect("parse config");
+        let subagents = config.subagents.expect("subagents should be present");
+        assert!(subagents[0].model.is_none());
     }
 
     #[test]

--- a/src/tools/run_task.rs
+++ b/src/tools/run_task.rs
@@ -19,7 +19,7 @@ use crate::{
     Config, OutputChunk,
     agent::{
         AgentConfig, ChatStreamUpdate, Content, ExecuteStatus, Executor, Message, StopReason,
-        SubagentConfig,
+        SubagentConfig, SubagentModelConfig,
     },
     exec::StreamKind,
     provider::{Block, ToolUse},
@@ -112,6 +112,10 @@ pub struct RunTaskContext {
     pub config: Config,
     /// Shared executor for permission inheritance.
     pub executor: Executor,
+    /// Model override inherited from parent agent.
+    pub model_override: Option<String>,
+    /// Default model inherited from parent agent config.
+    pub default_model: Option<String>,
 }
 
 /// Tool for delegating tasks to subagents.
@@ -125,6 +129,14 @@ impl RunTaskTool {
         Self {
             context: Arc::new(Mutex::new(context)),
         }
+    }
+
+    /// Create a new RunTaskTool with a shared context.
+    ///
+    /// This allows the caller to retain a reference to the context
+    /// for updating model_override when the parent agent's model changes.
+    pub fn new_with_shared_context(context: Arc<Mutex<RunTaskContext>>) -> Self {
+        Self { context }
     }
 
     /// Get the shared context for streaming execution.
@@ -233,7 +245,11 @@ where
     let ctx = context.lock().await;
 
     // Find subagent config
-    let subagent_config = ctx.subagents.iter().find(|s| s.name == input.subagent_name);
+    let subagent_config = ctx
+        .subagents
+        .iter()
+        .find(|s| s.name == input.subagent_name)
+        .cloned();
 
     let Some(subagent_config) = subagent_config else {
         let available: Vec<_> = ctx.subagents.iter().map(|s| s.name.as_str()).collect();
@@ -295,6 +311,8 @@ where
     // Clone config and executor for the subagent
     let subagent_base_config = ctx.config.clone();
     let mut parent_executor = ctx.executor.clone();
+    let parent_model_override = ctx.model_override.clone();
+    let parent_default_model = ctx.default_model.clone();
 
     // Drop lock before async operations
     drop(ctx);
@@ -305,10 +323,23 @@ where
         parent_executor.apply_tool_policies(Some(tools), None);
     }
 
-    // Override model if subagent has one configured
-    if let Some(ref model) = subagent_agent_config.default_model {
-        // TODO: Apply model override to subagent
-        debug!(model = %model, "Subagent has custom model configured");
+    // Determine model override for subagent with priority:
+    // 1. SubagentConfig.model field (from agent.toml [[subagents]] section)
+    //    - Inherit: explicitly inherit from parent
+    //    - Custom(model): use specified model
+    // 2. AgentConfig.default_model (from subagent's own config file)
+    // 3. Parent agent current model (override or default)
+    let subagent_model_override = resolve_subagent_model(
+        &subagent_config,
+        &subagent_agent_config,
+        parent_model_override,
+        parent_default_model,
+    );
+    if matches!(subagent_config.model, Some(SubagentModelConfig::Inherit)) {
+        debug!("Subagent configured to inherit model from parent");
+    }
+    if let Some(ref model) = subagent_model_override {
+        debug!(model = %model, "Subagent will use model");
     }
 
     // Build subagent system prompt
@@ -323,6 +354,7 @@ where
         parent_executor,
         subagent_system_prompt,
         input.prompt,
+        subagent_model_override,
         cancel_token,
         on_event_boxed,
     )
@@ -374,6 +406,20 @@ fn build_subagent_system_prompt(config: &AgentConfig, input: &RunTaskInput) -> S
     )
 }
 
+fn resolve_subagent_model(
+    subagent_config: &SubagentConfig,
+    subagent_agent_config: &AgentConfig,
+    parent_model_override: Option<String>,
+    parent_default_model: Option<String>,
+) -> Option<String> {
+    let parent_model = parent_model_override.or(parent_default_model);
+    match &subagent_config.model {
+        Some(SubagentModelConfig::Inherit) => parent_model,
+        Some(SubagentModelConfig::Custom(model)) => Some(model.clone()),
+        None => subagent_agent_config.default_model.clone().or(parent_model),
+    }
+}
+
 /// Execute the subagent loop.
 ///
 /// Returns a boxed future to break type-level recursion that would otherwise
@@ -383,6 +429,7 @@ fn execute_subagent(
     executor: Executor,
     system_prompt: String,
     initial_prompt: String,
+    model_override: Option<String>,
     cancel_token: CancellationToken,
     on_event: SubagentEventCallback,
 ) -> BoxFuture<'static, Result<RunTaskOutput, String>> {
@@ -492,6 +539,7 @@ fn execute_subagent(
         // Create subagent and configure it
         let mut subagent = Agent::new(config);
         subagent.set_system_prompt(&system_prompt);
+        subagent.set_model_override(model_override);
 
         // Send initial message
         let user_message = Message::user(Content::Text(initial_prompt));
@@ -826,5 +874,81 @@ mod tests {
         assert_eq!(json["success"], true);
         assert_eq!(json["turns"], 3);
         assert!(json.get("error").is_none() || json["error"].is_null());
+    }
+
+    fn make_subagent_config(model: Option<SubagentModelConfig>) -> SubagentConfig {
+        SubagentConfig {
+            name: "subagent".to_string(),
+            path: None,
+            description: None,
+            system_prompt: None,
+            tools: None,
+            model,
+        }
+    }
+
+    #[test]
+    fn resolve_subagent_model_inherit_uses_parent_override() {
+        let subagent = make_subagent_config(Some(SubagentModelConfig::Inherit));
+        let subagent_agent_config = AgentConfig::default();
+
+        let result = resolve_subagent_model(
+            &subagent,
+            &subagent_agent_config,
+            Some("parent-override".to_string()),
+            Some("parent-default".to_string()),
+        );
+
+        assert_eq!(result, Some("parent-override".to_string()));
+    }
+
+    #[test]
+    fn resolve_subagent_model_inherit_uses_parent_default_when_no_override() {
+        let subagent = make_subagent_config(Some(SubagentModelConfig::Inherit));
+        let subagent_agent_config = AgentConfig::default();
+
+        let result = resolve_subagent_model(
+            &subagent,
+            &subagent_agent_config,
+            None,
+            Some("parent-default".to_string()),
+        );
+
+        assert_eq!(result, Some("parent-default".to_string()));
+    }
+
+    #[test]
+    fn resolve_subagent_model_prefers_subagent_default_model() {
+        let subagent = make_subagent_config(None);
+        let subagent_agent_config = AgentConfig {
+            default_model: Some("subagent-model".to_string()),
+            ..Default::default()
+        };
+
+        let result = resolve_subagent_model(
+            &subagent,
+            &subagent_agent_config,
+            Some("parent-override".to_string()),
+            Some("parent-default".to_string()),
+        );
+
+        assert_eq!(result, Some("subagent-model".to_string()));
+    }
+
+    #[test]
+    fn resolve_subagent_model_custom_wins() {
+        let subagent = make_subagent_config(Some(SubagentModelConfig::Custom(
+            "custom-model".to_string(),
+        )));
+        let subagent_agent_config = AgentConfig::default();
+
+        let result = resolve_subagent_model(
+            &subagent,
+            &subagent_agent_config,
+            Some("parent-override".to_string()),
+            Some("parent-default".to_string()),
+        );
+
+        assert_eq!(result, Some("custom-model".to_string()));
     }
 }


### PR DESCRIPTION
Fixes #121

## Summary
This PR fixes the bug where subagents do not inherit the current agent's model configuration. Subagents were using the default first model instead of inheriting the parent agent's model settings.

## Changes
- **New SubagentModelConfig enum** in `src/agent/config.rs`: Supports "inherit" or custom model name
- **Added model field** to SubagentConfig: Configurable via [[agent.subagents]] in agent.toml
- **Model resolution logic** in `src/tools/run_task.rs`: Priority system (subagent model → subagent default → parent model)
- **Runtime propagation** in `src/agent.rs`: Model changes in parent agent now propagate to all subagents

## Model Configuration Examples
```toml
# Explicitly inherit from parent
[[agent.subagents]]
name = "coder"
model = "inherit"

# Use a custom model
[[agent.subagents]]
name = "reviewer"
model = "claude-3-opus"

# Fall back to subagent's own default_model
[[agent.subagents]]
name = "tester"
```