### PR TITLE
feat: implement exponential backoff for retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
 name = "anthropic"
 version = "0.1.0"
 dependencies = [
+ "backon",
  "bon",
  "bytes",
  "futures-core",
@@ -157,6 +158,17 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -994,6 +1006,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1678,7 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 name = "openai"
 version = "0.1.0"
 dependencies = [
+ "backon",
  "bytes",
  "futures-core",
  "reqwest",

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -25,6 +25,7 @@ snafu.workspace = true
 
 # Logging
 tracing.workspace = true
+backon = "1.6.0"
 
 [dev-dependencies]
 # Async Runtime

--- a/crates/anthropic/src/client.rs
+++ b/crates/anthropic/src/client.rs
@@ -1,5 +1,7 @@
 pub mod messages;
 
+use std::time::Duration;
+
 use reqwest::{
     Url,
     header::{HeaderMap, HeaderValue},
@@ -17,6 +19,21 @@ pub struct Client {
     model: String,
     base_url: Url,
     cli: reqwest::Client,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetryConfig {
+    pub max_attempts: usize,
+    pub max_delay: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            max_delay: Duration::from_secs(60),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -50,6 +67,7 @@ impl Client {
         thinking: Option<Thinking>,
         temperature: Option<f64>,
         max_tokens: Option<usize>,
+        retry_config: RetryConfig,
     ) -> Result<messages::MessagesResponse, Whatever> {
         let req = build_request(
             &self.model,
@@ -61,7 +79,7 @@ impl Client {
             temperature,
             max_tokens,
         );
-        messages::messages(&self.cli, &self.base_url, req).await
+        messages::messages(&self.cli, &self.base_url, req, retry_config).await
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -74,6 +92,7 @@ impl Client {
         thinking: Option<Thinking>,
         temperature: Option<f64>,
         max_tokens: Option<usize>,
+        retry_config: RetryConfig,
     ) -> Result<messages::MessagesStream, Whatever> {
         let req = build_request(
             &self.model,
@@ -85,7 +104,7 @@ impl Client {
             temperature,
             max_tokens,
         );
-        messages::messages_stream(&self.cli, &self.base_url, req).await
+        messages::messages_stream(&self.cli, &self.base_url, req, retry_config).await
     }
 }
 
@@ -143,6 +162,7 @@ pub struct MessagesBuilder<'a> {
     thinking: Option<Thinking>,
     temperature: Option<f64>,
     max_tokens: Option<usize>,
+    retry_config: RetryConfig,
 }
 
 impl<'a> MessagesBuilder<'a> {
@@ -155,6 +175,7 @@ impl<'a> MessagesBuilder<'a> {
             thinking: None,
             temperature: None,
             max_tokens: None,
+            retry_config: RetryConfig::default(),
         }
     }
 
@@ -185,6 +206,11 @@ impl<'a> MessagesBuilder<'a> {
 
     pub fn maybe_max_tokens(mut self, max_tokens: Option<usize>) -> Self {
         self.max_tokens = max_tokens;
+        self
+    }
+
+    pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
+        self.retry_config = retry_config;
         self
     }
 
@@ -199,7 +225,13 @@ impl<'a> MessagesBuilder<'a> {
             self.temperature,
             self.max_tokens,
         );
-        messages::messages(&self.client.cli, &self.client.base_url, req).await
+        messages::messages(
+            &self.client.cli,
+            &self.client.base_url,
+            req,
+            self.retry_config,
+        )
+        .await
     }
 }
 
@@ -211,6 +243,7 @@ pub struct MessagesStreamBuilder<'a> {
     thinking: Option<Thinking>,
     temperature: Option<f64>,
     max_tokens: Option<usize>,
+    retry_config: RetryConfig,
 }
 
 impl<'a> MessagesStreamBuilder<'a> {
@@ -223,6 +256,7 @@ impl<'a> MessagesStreamBuilder<'a> {
             thinking: None,
             temperature: None,
             max_tokens: None,
+            retry_config: RetryConfig::default(),
         }
     }
 
@@ -256,6 +290,11 @@ impl<'a> MessagesStreamBuilder<'a> {
         self
     }
 
+    pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
+        self.retry_config = retry_config;
+        self
+    }
+
     pub async fn call(self) -> Result<messages::MessagesStream, Whatever> {
         let req = build_request(
             &self.client.model,
@@ -267,7 +306,13 @@ impl<'a> MessagesStreamBuilder<'a> {
             self.temperature,
             self.max_tokens,
         );
-        messages::messages_stream(&self.client.cli, &self.client.base_url, req).await
+        messages::messages_stream(
+            &self.client.cli,
+            &self.client.base_url,
+            req,
+            self.retry_config,
+        )
+        .await
     }
 }
 

--- a/crates/anthropic/src/client.rs
+++ b/crates/anthropic/src/client.rs
@@ -1,6 +1,6 @@
 pub mod messages;
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use reqwest::{
     Url,
@@ -21,10 +21,21 @@ pub struct Client {
     cli: reqwest::Client,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
+pub struct RetryAttempt {
+    pub attempt: usize,
+    pub max_attempts: usize,
+    pub delay: Duration,
+    pub error: String,
+}
+
+pub type RetryNotifier = Arc<dyn Fn(RetryAttempt) + Send + Sync>;
+
+#[derive(Clone)]
 pub struct RetryConfig {
     pub max_attempts: usize,
     pub max_delay: Duration,
+    pub notifier: Option<RetryNotifier>,
 }
 
 impl Default for RetryConfig {
@@ -32,6 +43,7 @@ impl Default for RetryConfig {
         Self {
             max_attempts: 3,
             max_delay: Duration::from_secs(60),
+            notifier: None,
         }
     }
 }

--- a/crates/anthropic/src/client/messages.rs
+++ b/crates/anthropic/src/client/messages.rs
@@ -15,7 +15,7 @@ use serde_json::{Map, Value};
 use snafu::{Whatever, prelude::*};
 use tracing::{trace, warn};
 
-use crate::{Block, Message, RetryConfig, Role, Tool};
+use crate::{Block, Message, RetryAttempt, RetryConfig, Role, Tool};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -613,6 +613,9 @@ pub async fn messages_stream(
     let body = serde_json::to_string(&req).whatever_context("encode request error")?;
     let client = client.clone();
     let url_clone = url.clone();
+    let notify = retry_config.notifier.clone();
+    let max_attempts = retry_config.max_attempts;
+    let mut attempts = 0usize;
     let backoff = build_backoff(retry_config);
     let result = (|| {
         let body = body.clone();
@@ -645,7 +648,16 @@ pub async fn messages_stream(
     })
     .retry(backoff)
     .when(AnthropicRequestError::is_retryable)
-    .notify(|err, dur| {
+    .notify(move |err, dur| {
+        attempts = attempts.saturating_add(1);
+        if let Some(notify) = notify.as_ref() {
+            notify(RetryAttempt {
+                attempt: attempts,
+                max_attempts,
+                delay: dur,
+                error: err.to_string(),
+            });
+        }
         warn!(
             error = %err,
             delay = ?dur,
@@ -668,6 +680,9 @@ pub async fn messages(
     let body = serde_json::to_string(&req).whatever_context("encode request error")?;
     let client = client.clone();
     let url_clone = url.clone();
+    let notify = retry_config.notifier.clone();
+    let max_attempts = retry_config.max_attempts;
+    let mut attempts = 0usize;
     let backoff = build_backoff(retry_config);
     let result = (|| {
         let body = body.clone();
@@ -700,7 +715,16 @@ pub async fn messages(
     })
     .retry(backoff)
     .when(AnthropicRequestError::is_retryable)
-    .notify(|err, dur| {
+    .notify(move |err, dur| {
+        attempts = attempts.saturating_add(1);
+        if let Some(notify) = notify.as_ref() {
+            notify(RetryAttempt {
+                attempt: attempts,
+                max_attempts,
+                delay: dur,
+                error: err.to_string(),
+            });
+        }
         warn!(error = %err, delay = ?dur, "retrying anthropic messages request");
     })
     .await;

--- a/crates/anthropic/src/client/messages.rs
+++ b/crates/anthropic/src/client/messages.rs
@@ -2,8 +2,10 @@ use std::{
     collections::VecDeque,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
+use backon::{ExponentialBuilder, Retryable};
 use bon::bon;
 use bytes::Bytes;
 use futures_core::Stream;
@@ -11,9 +13,9 @@ use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use snafu::{Whatever, prelude::*};
-use tracing::trace;
+use tracing::{trace, warn};
 
-use crate::{Block, Message, Role, Tool};
+use crate::{Block, Message, RetryConfig, Role, Tool};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -602,60 +604,107 @@ pub async fn messages_stream(
     client: &reqwest::Client,
     base_url: &Url,
     mut req: MessagesRequest,
+    retry_config: RetryConfig,
 ) -> Result<MessagesStream, Whatever> {
     let url = base_url
         .join("v1/messages")
         .whatever_context("join url error")?;
     req.stream = Some(true);
-    let req = serde_json::to_string(&req).whatever_context("encode request error")?;
-    let resp = client
-        .post(url)
-        .body(req.clone())
-        .header("Content-Type", "application/json")
-        .header("Accept", "text/event-stream")
-        .send()
-        .await
-        .whatever_context("send request error")?;
+    let body = serde_json::to_string(&req).whatever_context("encode request error")?;
+    let client = client.clone();
+    let url_clone = url.clone();
+    let backoff = build_backoff(retry_config);
+    let result = (|| {
+        let body = body.clone();
+        let url = url_clone.clone();
+        let client = client.clone();
+        async move {
+            let body_clone = body.clone();
+            let resp = client
+                .post(url)
+                .body(body_clone)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/event-stream")
+                .send()
+                .await
+                .map_err(|err| AnthropicRequestError::transport("messages stream", err))?;
 
-    let status = resp.status();
-    trace!(req, ?status, "messages stream API invoked");
+            let status = resp.status();
+            trace!(req = %body, ?status, "messages stream API invoked");
 
-    if !status.is_success() {
-        let resp = resp.text().await.whatever_context("read response error")?;
-        let message = format_error_message(status, &resp);
-        whatever!("{message}")
-    }
+            if !status.is_success() {
+                let resp = resp
+                    .text()
+                    .await
+                    .map_err(|err| AnthropicRequestError::transport("messages stream", err))?;
+                return Err(AnthropicRequestError::http_status(status, resp));
+            }
 
-    Ok(MessagesStream::new(resp))
+            Ok(MessagesStream::new(resp))
+        }
+    })
+    .retry(backoff)
+    .when(AnthropicRequestError::is_retryable)
+    .notify(|err, dur| {
+        warn!(
+            error = %err,
+            delay = ?dur,
+            "retrying anthropic messages stream request"
+        );
+    })
+    .await;
+    result.map_err(AnthropicRequestError::into_whatever)
 }
 
 pub async fn messages(
     client: &reqwest::Client,
     base_url: &Url,
     req: MessagesRequest,
+    retry_config: RetryConfig,
 ) -> Result<MessagesResponse, Whatever> {
     let url = base_url
         .join("v1/messages")
         .whatever_context("join url error")?;
-    let req = serde_json::to_string(&req).whatever_context("encode request error")?;
-    let resp = client
-        .post(url)
-        .body(req.clone())
-        .header("Content-Type", "application/json")
-        .send()
-        .await
-        .whatever_context("send request error")?;
+    let body = serde_json::to_string(&req).whatever_context("encode request error")?;
+    let client = client.clone();
+    let url_clone = url.clone();
+    let backoff = build_backoff(retry_config);
+    let result = (|| {
+        let body = body.clone();
+        let url = url_clone.clone();
+        let client = client.clone();
+        async move {
+            let body_clone = body.clone();
+            let resp = client
+                .post(url)
+                .body(body_clone)
+                .header("Content-Type", "application/json")
+                .send()
+                .await
+                .map_err(|err| AnthropicRequestError::transport("messages", err))?;
 
-    let status = resp.status();
-    let resp = resp.text().await.whatever_context("read response error")?;
-    trace!(req, resp, ?status, "messages API invoked");
+            let status = resp.status();
+            let resp_body = resp
+                .text()
+                .await
+                .map_err(|err| AnthropicRequestError::transport("messages", err))?;
+            trace!(req = %body, resp = %resp_body, ?status, "messages API invoked");
 
-    if !status.is_success() {
-        let message = format_error_message(status, &resp);
-        whatever!("{message}")
-    }
+            if !status.is_success() {
+                return Err(AnthropicRequestError::http_status(status, resp_body));
+            }
 
-    serde_json::from_str(&resp).whatever_context("decode response error")
+            serde_json::from_str(&resp_body)
+                .map_err(|err| AnthropicRequestError::decode("messages", err))
+        }
+    })
+    .retry(backoff)
+    .when(AnthropicRequestError::is_retryable)
+    .notify(|err, dur| {
+        warn!(error = %err, delay = ?dur, "retrying anthropic messages request");
+    })
+    .await;
+    result.map_err(AnthropicRequestError::into_whatever)
 }
 
 fn format_error_message(status: StatusCode, body: &str) -> String {
@@ -674,6 +723,108 @@ fn format_error_message(status: StatusCode, body: &str) -> String {
             message
         }
         Err(_) => format!("request failed with status {status}: {body}"),
+    }
+}
+
+#[derive(Debug)]
+enum AnthropicRequestError {
+    Transport {
+        context: &'static str,
+        source: reqwest::Error,
+    },
+    HttpStatus {
+        status: StatusCode,
+        body: String,
+    },
+    Decode {
+        context: &'static str,
+        message: String,
+    },
+}
+
+impl AnthropicRequestError {
+    fn transport(context: &'static str, err: reqwest::Error) -> Self {
+        Self::Transport {
+            context,
+            source: err,
+        }
+    }
+
+    fn http_status(status: StatusCode, body: String) -> Self {
+        Self::HttpStatus { status, body }
+    }
+
+    fn decode(context: &'static str, err: serde_json::Error) -> Self {
+        Self::Decode {
+            context,
+            message: err.to_string(),
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Transport { source, .. } => source.is_timeout() || source.is_connect(),
+            Self::HttpStatus { status, .. } => is_retryable_status(*status),
+            Self::Decode { .. } => false,
+        }
+    }
+
+    fn into_whatever(self) -> Whatever {
+        match self {
+            Self::Transport { context, source } => <Whatever as snafu::FromString>::without_source(
+                format!("send {context} request error: {source}"),
+            ),
+            Self::HttpStatus { status, body } => {
+                <Whatever as snafu::FromString>::without_source(format_error_message(status, &body))
+            }
+            Self::Decode { context, message } => <Whatever as snafu::FromString>::without_source(
+                format!("decode {context} response error: {message}"),
+            ),
+        }
+    }
+}
+
+impl std::fmt::Display for AnthropicRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport { source, .. } => write!(f, "transport error: {source}"),
+            Self::HttpStatus { status, .. } => write!(f, "http status {status}"),
+            Self::Decode { message, .. } => write!(f, "decode error: {message}"),
+        }
+    }
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::SERVICE_UNAVAILABLE
+    )
+}
+
+fn build_backoff(retry: RetryConfig) -> ExponentialBuilder {
+    let mut builder = ExponentialBuilder::default()
+        .with_jitter()
+        .with_max_times(retry.max_attempts);
+    if retry.max_delay == Duration::from_millis(0) {
+        builder = builder.without_max_delay();
+    } else {
+        builder = builder.with_max_delay(retry.max_delay);
+    }
+    builder
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::*;
+
+    #[test]
+    fn retryable_status_codes() {
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
     }
 }
 
@@ -808,7 +959,7 @@ mod tests {
         use snafu::Whatever;
 
         use crate::{
-            Message, MessagesRequest,
+            Message, MessagesRequest, RetryConfig,
             client::{messages::messages, tests::*},
         };
 
@@ -836,6 +987,7 @@ mod tests {
                     .messages(msgs)
                     .model(&model)
                     .build(),
+                RetryConfig::default(),
             )
             .await?;
             println!("{resp:?}");

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -5,8 +5,9 @@ use code_combo::tools::{
 };
 use code_combo::{
     Agent, Block as ChatBlock, ChatResponse, ChatStreamUpdate, Config, Content as ChatContent,
-    Message as ChatMessage, Output, RuntimeOverrides, Starter, StopReason, TextEdit, ToolUse,
-    UsageStats, discover_starters, load_runtime_overrides, save_runtime_overrides,
+    Message as ChatMessage, Output, RetryAttempt, RetryNotifier, RetryUpdate, RuntimeOverrides,
+    Starter, StopReason, TextEdit, ToolUse, UsageStats, discover_starters, load_runtime_overrides,
+    save_runtime_overrides,
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
@@ -68,6 +69,7 @@ pub struct Chat<'a> {
     combo_tool_messages: HashSet<String>,
     pending_combo_tool_events: HashMap<String, Vec<ComboEvent>>,
     last_usage: Option<UsageStats>,
+    retry_status: Option<RetryAttempt>,
 
     token_schedule_session_save: Option<CancellationToken>,
     cancellation_guard: CancellationGuard,
@@ -218,6 +220,10 @@ impl Chat<'static> {
     pub fn new(config: Config) -> Self {
         let mut agent = Agent::new(config);
         agent.set_ignore_workspace_scripts(global::ignore_workspace_scripts());
+        agent.set_retry_notifier(Some(RetryNotifier::new(|update| {
+            let tx = global::event_tx();
+            tx.send(AnswerEvent::RetryUpdate { update }.into()).ok();
+        })));
 
         Self {
             state: State::default(),
@@ -234,6 +240,7 @@ impl Chat<'static> {
             combo_tool_messages: HashSet::new(),
             pending_combo_tool_events: HashMap::new(),
             last_usage: None,
+            retry_status: None,
             token_schedule_session_save: None,
             cancellation_guard: CancellationGuard::default(),
         }
@@ -841,7 +848,11 @@ impl Chat<'static> {
         };
         block = block
             .title_bottom(Line::from(""))
-            .title_bottom(self.widget_state_indicator())
+            .title_bottom(self.widget_state_indicator());
+        if let Some(line) = self.retry_indicator_line() {
+            block = block.title_bottom(line);
+        }
+        block = block
             .title_bottom(self.model_indicator())
             .title_bottom(self.auto_accept_indicator())
             .title_bottom(self.thinking_indicator());
@@ -888,6 +899,22 @@ impl Chat<'static> {
             format!(" {message} "),
             theme.ui.status_warning,
         )))
+    }
+
+    fn retry_indicator_line(&self) -> Option<Line<'static>> {
+        let retry = self.retry_status.as_ref()?;
+        let delay_ms = retry.delay.as_millis();
+        let delay_text = if delay_ms >= 1000 {
+            format!("{:.1}s", retry.delay.as_secs_f64())
+        } else {
+            format!("{delay_ms}ms")
+        };
+        let theme = global::theme();
+        let text = format!(
+            " retrying in {delay_text} (attempt {}/{}) ",
+            retry.attempt, retry.max_attempts
+        );
+        Some(Line::from(Span::styled(text, theme.ui.status_warning)))
     }
 
     fn widget_state_indicator(&self) -> Line<'_> {
@@ -1265,6 +1292,17 @@ impl Component for Chat<'static> {
                     Some(total) => add_usage(total, usage),
                     None => {
                         self.last_usage = Some(usage.clone());
+                    }
+                }
+                global::signal_dirty();
+            }
+            Event::Answer(AnswerEvent::RetryUpdate { update }) => {
+                match update {
+                    RetryUpdate::Attempt(attempt) => {
+                        self.retry_status = Some(attempt.clone());
+                    }
+                    RetryUpdate::Finished { .. } => {
+                        self.retry_status = None;
                     }
                 }
                 global::signal_dirty();

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -1,5 +1,5 @@
 use code_combo::{
-    OutputChunk, Starter, TextEdit, ThinkingConfig, ToolUse, UsageStats,
+    OutputChunk, RetryUpdate, Starter, TextEdit, ThinkingConfig, ToolUse, UsageStats,
     tools::{ComboEvent as ComboToolEvent, Final, SubagentEvent},
 };
 use crossterm::event::{KeyEvent, MouseEvent};
@@ -46,6 +46,9 @@ pub enum AnswerEvent {
         index: usize,
         kind: BotStreamKind,
         text: String,
+    },
+    RetryUpdate {
+        update: RetryUpdate,
     },
     Cancelled,
     Usage {

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -15,3 +15,4 @@ bytes = "1.9.0"
 futures-core.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+backon = "1.6.0"

--- a/crates/openai/src/client.rs
+++ b/crates/openai/src/client.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::VecDeque,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
@@ -24,10 +25,21 @@ pub struct Client {
     has_version_prefix: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
+pub struct RetryAttempt {
+    pub attempt: usize,
+    pub max_attempts: usize,
+    pub delay: Duration,
+    pub error: String,
+}
+
+pub type RetryNotifier = Arc<dyn Fn(RetryAttempt) + Send + Sync>;
+
+#[derive(Clone)]
 pub struct RetryConfig {
     pub max_attempts: usize,
     pub max_delay: Duration,
+    pub notifier: Option<RetryNotifier>,
 }
 
 impl Default for RetryConfig {
@@ -35,6 +47,7 @@ impl Default for RetryConfig {
         Self {
             max_attempts: 3,
             max_delay: Duration::from_secs(60),
+            notifier: None,
         }
     }
 }
@@ -108,6 +121,9 @@ impl Client {
         let cli = self.cli.clone();
         let request = request;
         let url_clone = url.clone();
+        let notify = retry.notifier.clone();
+        let max_attempts = retry.max_attempts;
+        let mut attempts = 0usize;
         let backoff = build_backoff(retry);
         let result =
             (|| {
@@ -134,7 +150,16 @@ impl Client {
             })
             .retry(backoff)
             .when(OpenAIRequestError::is_retryable)
-            .notify(|err, dur| {
+            .notify(move |err, dur| {
+                attempts = attempts.saturating_add(1);
+                if let Some(notify) = notify.as_ref() {
+                    notify(RetryAttempt {
+                        attempt: attempts,
+                        max_attempts,
+                        delay: dur,
+                        error: err.to_string(),
+                    });
+                }
                 warn!(error = %err, delay = ?dur, "retrying openai chat completions request");
             })
             .await;
@@ -158,6 +183,9 @@ impl Client {
         let cli = self.cli.clone();
         let request = request;
         let url_clone = url.clone();
+        let notify = retry.notifier.clone();
+        let max_attempts = retry.max_attempts;
+        let mut attempts = 0usize;
         let backoff = build_backoff(retry);
         let result = (|| {
             let request = request.clone();
@@ -181,7 +209,16 @@ impl Client {
         })
         .retry(backoff)
         .when(OpenAIRequestError::is_retryable)
-        .notify(|err, dur| {
+        .notify(move |err, dur| {
+            attempts = attempts.saturating_add(1);
+            if let Some(notify) = notify.as_ref() {
+                notify(RetryAttempt {
+                    attempt: attempts,
+                    max_attempts,
+                    delay: dur,
+                    error: err.to_string(),
+                });
+            }
             warn!(error = %err, delay = ?dur, "retrying openai chat completions stream request");
         })
         .await;

--- a/crates/openai/src/client.rs
+++ b/crates/openai/src/client.rs
@@ -2,13 +2,15 @@ use std::{
     collections::VecDeque,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
+use backon::{ExponentialBuilder, Retryable};
 use bytes::Bytes;
 use futures_core::Stream;
 use reqwest::{StatusCode, Url, header::HeaderMap};
 use snafu::{ResultExt, Whatever};
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ErrorResponse,
@@ -20,6 +22,21 @@ pub struct Client {
     base_url: Url,
     cli: reqwest::Client,
     has_version_prefix: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetryConfig {
+    pub max_attempts: usize,
+    pub max_delay: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            max_delay: Duration::from_secs(60),
+        }
+    }
 }
 
 type Result<T> = std::result::Result<T, Whatever>;
@@ -79,6 +96,7 @@ impl Client {
     pub async fn chat_completions(
         &self,
         mut request: ChatCompletionRequest,
+        retry: RetryConfig,
     ) -> Result<ChatCompletionResponse> {
         request.model = self.model.clone();
         request.stream = None;
@@ -87,29 +105,46 @@ impl Client {
             .base_url
             .join(self.api_path("chat/completions"))
             .whatever_context("build chat completions url")?;
-        let resp = self
-            .cli
-            .post(url)
-            .json(&request)
-            .send()
-            .await
-            .whatever_context("send chat completions request")?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp
-                .text()
-                .await
-                .unwrap_or_else(|_| "failed to read error response".to_string());
-            return Err(parse_error(status, &body));
-        }
-        resp.json::<ChatCompletionResponse>()
-            .await
-            .whatever_context("decode chat completions response")
+        let cli = self.cli.clone();
+        let request = request;
+        let url_clone = url.clone();
+        let backoff = build_backoff(retry);
+        let result =
+            (|| {
+                let request = request.clone();
+                let url = url_clone.clone();
+                let cli = cli.clone();
+                async move {
+                    let resp =
+                        cli.post(url).json(&request).send().await.map_err(|err| {
+                            OpenAIRequestError::transport("chat completions", err)
+                        })?;
+                    let status = resp.status();
+                    if !status.is_success() {
+                        let body = resp
+                            .text()
+                            .await
+                            .unwrap_or_else(|err| format!("failed to read error response: {err}"));
+                        return Err(OpenAIRequestError::http_status(status, body));
+                    }
+                    resp.json::<ChatCompletionResponse>()
+                        .await
+                        .map_err(|err| OpenAIRequestError::decode("chat completions", err))
+                }
+            })
+            .retry(backoff)
+            .when(OpenAIRequestError::is_retryable)
+            .notify(|err, dur| {
+                warn!(error = %err, delay = ?dur, "retrying openai chat completions request");
+            })
+            .await;
+        result.map_err(OpenAIRequestError::into_whatever)
     }
 
     pub async fn chat_completions_stream(
         &self,
         mut request: ChatCompletionRequest,
+        retry: RetryConfig,
     ) -> Result<ChatCompletionStream> {
         request.model = self.model.clone();
         request.stream = Some(true);
@@ -120,22 +155,37 @@ impl Client {
             .base_url
             .join(self.api_path("chat/completions"))
             .whatever_context("build chat completions stream url")?;
-        let resp = self
-            .cli
-            .post(url)
-            .json(&request)
-            .send()
-            .await
-            .whatever_context("send chat completions stream request")?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp
-                .text()
-                .await
-                .unwrap_or_else(|_| "failed to read error response".to_string());
-            return Err(parse_error(status, &body));
-        }
-        Ok(ChatCompletionStream::new(resp))
+        let cli = self.cli.clone();
+        let request = request;
+        let url_clone = url.clone();
+        let backoff = build_backoff(retry);
+        let result = (|| {
+            let request = request.clone();
+            let url = url_clone.clone();
+            let cli = cli.clone();
+            async move {
+                let resp =
+                    cli.post(url).json(&request).send().await.map_err(|err| {
+                        OpenAIRequestError::transport("chat completions stream", err)
+                    })?;
+                let status = resp.status();
+                if !status.is_success() {
+                    let body = resp
+                        .text()
+                        .await
+                        .unwrap_or_else(|err| format!("failed to read error response: {err}"));
+                    return Err(OpenAIRequestError::http_status(status, body));
+                }
+                Ok(ChatCompletionStream::new(resp))
+            }
+        })
+        .retry(backoff)
+        .when(OpenAIRequestError::is_retryable)
+        .notify(|err, dur| {
+            warn!(error = %err, delay = ?dur, "retrying openai chat completions stream request");
+        })
+        .await;
+        result.map_err(OpenAIRequestError::into_whatever)
     }
 }
 
@@ -152,6 +202,93 @@ fn parse_error(status: StatusCode, body: &str) -> Whatever {
     } else {
         <Whatever as snafu::FromString>::without_source(format!("openai error ({status}): {body}"))
     }
+}
+
+#[derive(Debug)]
+enum OpenAIRequestError {
+    Transport {
+        context: &'static str,
+        source: reqwest::Error,
+    },
+    HttpStatus {
+        status: StatusCode,
+        body: String,
+    },
+    Decode {
+        context: &'static str,
+        message: String,
+    },
+}
+
+impl OpenAIRequestError {
+    fn transport(context: &'static str, err: reqwest::Error) -> Self {
+        Self::Transport {
+            context,
+            source: err,
+        }
+    }
+
+    fn http_status(status: StatusCode, body: String) -> Self {
+        Self::HttpStatus { status, body }
+    }
+
+    fn decode(context: &'static str, err: reqwest::Error) -> Self {
+        Self::Decode {
+            context,
+            message: err.to_string(),
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Transport { source, .. } => source.is_timeout() || source.is_connect(),
+            Self::HttpStatus { status, .. } => is_retryable_status(*status),
+            Self::Decode { .. } => false,
+        }
+    }
+
+    fn into_whatever(self) -> Whatever {
+        match self {
+            Self::Transport { context, source } => <Whatever as snafu::FromString>::without_source(
+                format!("send {context} request error: {source}"),
+            ),
+            Self::HttpStatus { status, body } => parse_error(status, &body),
+            Self::Decode { context, message } => <Whatever as snafu::FromString>::without_source(
+                format!("decode {context} response error: {message}"),
+            ),
+        }
+    }
+}
+
+impl std::fmt::Display for OpenAIRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport { source, .. } => write!(f, "transport error: {source}"),
+            Self::HttpStatus { status, .. } => write!(f, "http status {status}"),
+            Self::Decode { message, .. } => write!(f, "decode error: {message}"),
+        }
+    }
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::SERVICE_UNAVAILABLE
+    )
+}
+
+fn build_backoff(retry: RetryConfig) -> ExponentialBuilder {
+    let mut builder = ExponentialBuilder::default()
+        .with_jitter()
+        .with_max_times(retry.max_attempts);
+    if retry.max_delay == Duration::from_millis(0) {
+        builder = builder.without_max_delay();
+    } else {
+        builder = builder.with_max_delay(retry.max_delay);
+    }
+    builder
 }
 
 struct SseEvent {
@@ -322,4 +459,17 @@ fn parse_chat_completion_chunk(event: SseEvent) -> Result<Option<ChatCompletionC
     let chunk: ChatCompletionChunk =
         serde_json::from_str(text).whatever_context("decode chat completion chunk")?;
     Ok(Some(chunk))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_status_codes() {
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
+    }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -56,6 +56,7 @@ pub struct Agent {
     thinking_enabled: bool,
     thinking_cleanup_pending: bool,
     model_override: Option<String>,
+    retry_notifier: Option<crate::RetryNotifier>,
 
     /// Full agent configuration loaded at initialization
     agent_config: AgentConfig,
@@ -375,6 +376,7 @@ impl Agent {
             thinking_enabled: false,
             thinking_cleanup_pending: false,
             model_override: None,
+            retry_notifier: None,
             agent_config,
             combo_context,
             run_task_context,
@@ -472,6 +474,10 @@ impl Agent {
         self.update_run_task_context(move |ctx| {
             ctx.model_override = model;
         });
+    }
+
+    pub fn set_retry_notifier(&mut self, notifier: Option<crate::RetryNotifier>) {
+        self.retry_notifier = notifier;
     }
 
     pub fn set_ignore_workspace_scripts(&mut self, ignore: bool) {
@@ -1128,6 +1134,7 @@ impl Agent {
                 let model = Self::resolve_model(provider, selected_model);
                 let mut options = self.config.request_options_for_model(&model);
                 options.apply_override(&provider.request_overrides);
+                options.retry_notifier = self.retry_notifier.clone();
                 options
             }
             Err(_) => RequestOptions::default(),

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::config::EnvString;
+use crate::{RetryNotifier, config::EnvString};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -80,6 +80,7 @@ pub struct RequestOptions {
     pub thinking_budget_tokens: Option<usize>,
     pub retry_max_attempts: usize,
     pub retry_max_delay_ms: u64,
+    pub retry_notifier: Option<RetryNotifier>,
 }
 
 impl RequestOptions {
@@ -157,6 +158,7 @@ impl Default for RequestOptions {
             thinking_budget_tokens: None,
             retry_max_attempts: DEFAULT_RETRY_MAX_ATTEMPTS,
             retry_max_delay_ms: DEFAULT_RETRY_MAX_DELAY_MS,
+            retry_notifier: None,
         }
     }
 }

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -49,6 +49,10 @@ pub struct ModelRequestConfig {
     pub max_tokens: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_budget_tokens: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_max_attempts: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_max_delay_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -58,7 +62,7 @@ pub struct ModelPreset {
     pub options: ModelRequestConfig,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RequestOptions {
     pub disable_tools: bool,
     pub disable_tool_choice: bool,
@@ -74,6 +78,8 @@ pub struct RequestOptions {
     pub temperature: Option<f32>,
     pub max_tokens: Option<usize>,
     pub thinking_budget_tokens: Option<usize>,
+    pub retry_max_attempts: usize,
+    pub retry_max_delay_ms: u64,
 }
 
 impl RequestOptions {
@@ -119,6 +125,38 @@ impl RequestOptions {
         }
         if let Some(value) = override_config.thinking_budget_tokens {
             self.thinking_budget_tokens = Some(value);
+        }
+        if let Some(value) = override_config.retry_max_attempts {
+            self.retry_max_attempts = value;
+        }
+        if let Some(value) = override_config.retry_max_delay_ms {
+            self.retry_max_delay_ms = value;
+        }
+    }
+}
+
+const DEFAULT_RETRY_MAX_ATTEMPTS: usize = 3;
+const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 60_000;
+
+impl Default for RequestOptions {
+    fn default() -> Self {
+        Self {
+            disable_tools: false,
+            disable_tool_choice: false,
+            tool_choice_fallback: false,
+            thinking_blocks: ThinkingBlocksMode::default(),
+            ensure_toolcall_thinking: false,
+            disable_stream: false,
+            stringify_nested_tool_inputs: false,
+            offload_combo_reply: None,
+            combo_reply_retries: 0,
+            context_window: None,
+            can_reason: None,
+            temperature: None,
+            max_tokens: None,
+            thinking_budget_tokens: None,
+            retry_max_attempts: DEFAULT_RETRY_MAX_ATTEMPTS,
+            retry_max_delay_ms: DEFAULT_RETRY_MAX_DELAY_MS,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod global;
 pub mod logging;
 mod mcp;
 mod provider;
+mod retry;
 mod runtime_overrides;
 mod text_edit;
 pub mod tools;
@@ -23,6 +24,7 @@ pub use error::*;
 pub use exec::*;
 pub use mcp::*;
 pub use provider::*;
+pub use retry::*;
 pub use runtime_overrides::*;
 pub use text_edit::*;
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -2,7 +2,7 @@ mod anthropic;
 mod openai;
 mod types;
 
-use std::pin::Pin;
+use std::{pin::Pin, time::Duration};
 
 use futures_core::Stream;
 use futures_util::StreamExt;
@@ -72,6 +72,7 @@ impl Client {
                     .maybe_thinking(thinking.map(anthropic_api::Thinking::from))
                     .maybe_temperature(temperature)
                     .maybe_max_tokens(max_tokens)
+                    .retry_config(anthropic_retry_config(request_options))
                     .call()
                     .await
                     .whatever_context_display("failed to send messages")?;
@@ -116,6 +117,7 @@ impl Client {
                     .maybe_thinking(thinking.map(anthropic_api::Thinking::from))
                     .maybe_temperature(temperature)
                     .maybe_max_tokens(max_tokens)
+                    .retry_config(anthropic_retry_config(request_options))
                     .call()
                     .await
                     .whatever_context_display("failed to send messages stream")?;
@@ -164,6 +166,7 @@ impl Client {
                         thinking.map(anthropic_api::Thinking::from),
                         temperature,
                         max_tokens,
+                        anthropic_retry_config(request_options),
                     )
                     .await
                     .whatever_context_display("failed to request tool choice")?;
@@ -208,6 +211,7 @@ impl Client {
                         thinking.map(anthropic_api::Thinking::from),
                         temperature,
                         max_tokens,
+                        anthropic_retry_config(request_options),
                     )
                     .await
                     .whatever_context_display("failed to request tool choice stream")?;
@@ -229,5 +233,12 @@ impl Client {
                 Ok(Box::pin(stream))
             }
         }
+    }
+}
+
+fn anthropic_retry_config(request_options: &RequestOptions) -> anthropic_api::RetryConfig {
+    anthropic_api::RetryConfig {
+        max_attempts: request_options.retry_max_attempts,
+        max_delay: Duration::from_millis(request_options.retry_max_delay_ms),
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -11,7 +11,10 @@ use snafu::Whatever;
 use ::anthropic as anthropic_api;
 use ::openai as openai_api;
 
-use crate::{ProviderConfig, ProviderKind, RequestOptions, Result, ResultDisplayExt};
+use crate::{
+    ProviderConfig, ProviderKind, RequestOptions, Result, ResultDisplayExt,
+    RetryAttempt as CoreRetryAttempt, RetryUpdate,
+};
 
 pub use types::*;
 
@@ -55,7 +58,7 @@ impl Client {
         thinking: Option<Thinking>,
         request_options: &RequestOptions,
     ) -> Result<MessagesResponse> {
-        match self {
+        let result: Result<MessagesResponse> = match self {
             Client::Anthropic(client) => {
                 let temperature = request_options.temperature.map(f64::from);
                 let max_tokens = request_options.max_tokens;
@@ -89,7 +92,9 @@ impl Client {
             )
             .await
             .whatever_context_display("failed to send messages"),
-        }
+        };
+        notify_retry_finished(request_options, result.is_ok());
+        result
     }
 
     pub async fn messages_stream(
@@ -100,7 +105,7 @@ impl Client {
         thinking: Option<Thinking>,
         request_options: &RequestOptions,
     ) -> Result<MessagesStream> {
-        match self {
+        let result: Result<MessagesStream> = match self {
             Client::Anthropic(client) => {
                 let temperature = request_options.temperature.map(f64::from);
                 let max_tokens = request_options.max_tokens;
@@ -138,7 +143,9 @@ impl Client {
                 .whatever_context_display("failed to send messages stream")?;
                 Ok(Box::pin(stream))
             }
-        }
+        };
+        notify_retry_finished(request_options, result.is_ok());
+        result
     }
 
     pub async fn messages_with_tool_choice(
@@ -150,7 +157,7 @@ impl Client {
         thinking: Option<Thinking>,
         request_options: &RequestOptions,
     ) -> Result<MessagesResponse> {
-        match self {
+        let result: Result<MessagesResponse> = match self {
             Client::Anthropic(client) => {
                 let temperature = request_options.temperature.map(f64::from);
                 let max_tokens = request_options.max_tokens;
@@ -183,7 +190,9 @@ impl Client {
             )
             .await
             .whatever_context_display("failed to request tool choice"),
-        }
+        };
+        notify_retry_finished(request_options, result.is_ok());
+        result
     }
 
     pub async fn messages_stream_with_tool_choice(
@@ -195,7 +204,7 @@ impl Client {
         thinking: Option<Thinking>,
         request_options: &RequestOptions,
     ) -> Result<MessagesStream> {
-        match self {
+        let result: Result<MessagesStream> = match self {
             Client::Anthropic(client) => {
                 let temperature = request_options.temperature.map(f64::from);
                 let max_tokens = request_options.max_tokens;
@@ -232,13 +241,34 @@ impl Client {
                 .whatever_context_display("failed to request tool choice stream")?;
                 Ok(Box::pin(stream))
             }
-        }
+        };
+        notify_retry_finished(request_options, result.is_ok());
+        result
+    }
+}
+
+fn notify_retry_finished(request_options: &RequestOptions, success: bool) {
+    if let Some(notifier) = &request_options.retry_notifier {
+        notifier.notify(RetryUpdate::Finished { success });
     }
 }
 
 fn anthropic_retry_config(request_options: &RequestOptions) -> anthropic_api::RetryConfig {
+    let notifier = request_options.retry_notifier.clone().map(|notifier| {
+        let inner: anthropic_api::RetryNotifier =
+            std::sync::Arc::new(move |attempt: anthropic_api::RetryAttempt| {
+                notifier.notify(RetryUpdate::Attempt(CoreRetryAttempt {
+                    attempt: attempt.attempt,
+                    max_attempts: attempt.max_attempts,
+                    delay: attempt.delay,
+                    error: attempt.error,
+                }));
+            });
+        inner
+    });
     anthropic_api::RetryConfig {
         max_attempts: request_options.retry_max_attempts,
         max_delay: Duration::from_millis(request_options.retry_max_delay_ms),
+        notifier,
     }
 }

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -11,12 +11,12 @@ use snafu::Whatever;
 
 use ::openai as openai_api;
 
-use crate::RequestOptions;
 use crate::provider::types::{
     Block, Content, ContentBlockDelta, Message, MessageDelta, MessagesResponse,
     MessagesStreamEvent, Role, StopReason, StreamErrorDetail, Thinking, Tool, ToolChoice, ToolUse,
     UsageStats,
 };
+use crate::{RequestOptions, RetryAttempt as CoreRetryAttempt, RetryUpdate};
 
 struct ToolCallState {
     #[allow(dead_code)]
@@ -81,9 +81,22 @@ pub async fn messages_stream(
 }
 
 fn retry_config_from_options(request_options: &RequestOptions) -> openai_api::RetryConfig {
+    let notifier = request_options.retry_notifier.clone().map(|notifier| {
+        let inner: openai_api::RetryNotifier =
+            std::sync::Arc::new(move |attempt: openai_api::RetryAttempt| {
+                notifier.notify(RetryUpdate::Attempt(CoreRetryAttempt {
+                    attempt: attempt.attempt,
+                    max_attempts: attempt.max_attempts,
+                    delay: attempt.delay,
+                    error: attempt.error,
+                }));
+            });
+        inner
+    });
     openai_api::RetryConfig {
         max_attempts: request_options.retry_max_attempts,
         max_delay: Duration::from_millis(request_options.retry_max_delay_ms),
+        notifier,
     }
 }
 

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures_core::Stream;
@@ -50,7 +51,8 @@ pub async fn messages(
         thinking,
         request_options,
     )?;
-    let response = client.chat_completions(request).await?;
+    let retry_config = retry_config_from_options(request_options);
+    let response = client.chat_completions(request, retry_config).await?;
     Ok(response_into_messages(response))
 }
 
@@ -71,8 +73,18 @@ pub async fn messages_stream(
         thinking,
         request_options,
     )?;
-    let stream = client.chat_completions_stream(request).await?;
+    let retry_config = retry_config_from_options(request_options);
+    let stream = client
+        .chat_completions_stream(request, retry_config)
+        .await?;
     Ok(OpenAIStream::new(stream))
+}
+
+fn retry_config_from_options(request_options: &RequestOptions) -> openai_api::RetryConfig {
+    openai_api::RetryConfig {
+        max_attempts: request_options.retry_max_attempts,
+        max_delay: Duration::from_millis(request_options.retry_max_delay_ms),
+    }
 }
 
 fn build_request(

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,37 @@
+use std::{fmt, sync::Arc, time::Duration};
+
+#[derive(Debug, Clone)]
+pub struct RetryAttempt {
+    pub attempt: usize,
+    pub max_attempts: usize,
+    pub delay: Duration,
+    pub error: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum RetryUpdate {
+    Attempt(RetryAttempt),
+    Finished { success: bool },
+}
+
+#[derive(Clone)]
+pub struct RetryNotifier(Arc<dyn Fn(RetryUpdate) + Send + Sync>);
+
+impl RetryNotifier {
+    pub fn new<F>(notifier: F) -> Self
+    where
+        F: Fn(RetryUpdate) + Send + Sync + 'static,
+    {
+        Self(Arc::new(notifier))
+    }
+
+    pub fn notify(&self, update: RetryUpdate) {
+        (self.0)(update);
+    }
+}
+
+impl fmt::Debug for RetryNotifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RetryNotifier(..)")
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements exponential backoff retry mechanism for provider API calls (Anthropic and OpenAI), addressing issue #114.

## Changes

### Core Implementation
- **New retry module** (`src/retry.rs`): Defines `RetryAttempt`, `RetryUpdate`, and `RetryNotifier` types for retry event tracking
- **Configuration**: Added `retry_max_attempts` (default: 3) and `retry_max_delay_ms` (default: 60000ms) to `RequestOptions` and `ModelRequestConfig`
- **Retry logic**: Uses the `backon` crate with `ExponentialBuilder` including jitter to prevent thundering herd problem

### Provider API Clients
- **OpenAI client** (`crates/openai/src/client.rs`):
  - Wrapped all API calls with exponential backoff retry
  - Added `OpenAIRequestError` with proper error classification (transport, HTTP status, decode)
  - Retryable status codes: 429 (Too Many Requests), 500 (Internal Server Error), 503 (Service Unavailable)
  - Network timeouts and connection errors are also retryable
  - Non-retryable: 400, 401, 403, 404, and decode errors
  
- **Anthropic client** (`crates/anthropic/src/client/messages.rs`):
  - Same retry pattern applied to both streaming and non-streaming message APIs
  - Consistent error classification with OpenAI implementation

### UI Integration
- **TUI chat component** (`crates/coco-tui/src/components/chat.rs`):
  - Added retry status indicator showing current retry attempt and delay before next attempt
  - Displays format: "retrying in {delay} (attempt {current}/{max})"
  - Status clears when retry finishes (success or final failure)

### Logging & Observability
- Each retry attempt logs the error and delay duration using `tracing::warn`
- Retry events are propagated through `RetryNotifier` callback system
- Integrates with TUI event system for real-time status updates

## Issue Reference
Resolves #114