### PR TITLE
feat: Support displaying combo and subagent transcripts

### DIFF
--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,7 +1,7 @@
 use coco_macro::ComponentExt;
 use code_combo::tools::{
     ComboEvent as ComboToolEvent, ComboInfo, ComboStreamKind, Final, RUN_COMBO_TOOL_NAME,
-    RunComboInput,
+    RunComboInput, SubagentEvent,
 };
 use code_combo::{
     Agent, Block as ChatBlock, ChatResponse, ChatStreamUpdate, Config, Content as ChatContent,
@@ -76,6 +76,20 @@ pub struct Chat<'a> {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+struct ComboTranscript {
+    id: String,
+    name: String,
+    messages: Vec<ChatMessage>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct SubagentTranscript {
+    id: String,
+    name: String,
+    messages: Vec<ChatMessage>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 struct Inner {
     state: ChatState,
     focus: Focus,
@@ -96,6 +110,10 @@ struct Inner {
     #[serde(default)]
     system_prompt: Option<String>,
     messages: Vec<code_combo::Message>,
+    #[serde(default)]
+    combo_transcripts: Vec<ComboTranscript>,
+    #[serde(default)]
+    subagent_transcripts: Vec<SubagentTranscript>,
 }
 
 impl Default for Inner {
@@ -104,6 +122,8 @@ impl Default for Inner {
         Self {
             system_prompt: None,
             messages: vec![],
+            combo_transcripts: Vec::new(),
+            subagent_transcripts: Vec::new(),
             state: ChatState::Ready,
             focus: Focus::Input,
             auto_accept_edits: false,
@@ -432,6 +452,9 @@ impl Chat<'static> {
             ComboEvent::ReplyToolResult { .. } => {
                 // Result is handled by Combo component
             }
+            ComboEvent::Transcript { id, name, messages } => {
+                self.store_combo_transcript(id.clone(), name.clone(), messages.clone());
+            }
         }
     }
 
@@ -655,6 +678,11 @@ impl Chat<'static> {
             ComboToolEvent::Cancelled { name } => ComboEvent::Cancelled {
                 id: Some(id.to_string()),
                 name: name.clone(),
+            },
+            ComboToolEvent::Transcript { name, messages } => ComboEvent::Transcript {
+                id: id.to_string(),
+                name: name.clone(),
+                messages: messages.clone(),
             },
         }
     }
@@ -1062,12 +1090,21 @@ impl Chat<'static> {
         let agent_messages = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(self.agent.dump_messages())
         });
+        let (combo_transcripts, subagent_transcripts) = {
+            let state = self.state.read();
+            (
+                state.combo_transcripts.clone(),
+                state.subagent_transcripts.clone(),
+            )
+        };
 
         self.transcript.clear();
         let iter = agent_messages
             .into_iter()
             .map(|message| Message::system(TranscriptMessage::new(message).into()));
         self.transcript.extend(iter);
+        self.append_combo_transcripts(combo_transcripts);
+        self.append_subagent_transcripts(subagent_transcripts);
         self.view = ViewMode::Transcript;
         global::signal_dirty();
     }
@@ -1076,6 +1113,85 @@ impl Chat<'static> {
         self.view = ViewMode::Chat;
         self.update_focus(Focus::InputBlur);
         global::signal_dirty();
+    }
+
+    fn append_combo_transcripts(&mut self, transcripts: Vec<ComboTranscript>) {
+        for transcript in transcripts {
+            if transcript.messages.is_empty() {
+                continue;
+            }
+            let header = format!("Combo transcript: {} ({})", transcript.name, transcript.id);
+            self.transcript
+                .push(Message::system(Plain::new(header).into()).with_role_prefix(false));
+            let iter = transcript
+                .messages
+                .into_iter()
+                .map(|message| Message::system(TranscriptMessage::new(message).into()));
+            self.transcript.extend(iter);
+        }
+    }
+
+    fn append_subagent_transcripts(&mut self, transcripts: Vec<SubagentTranscript>) {
+        for transcript in transcripts {
+            if transcript.messages.is_empty() {
+                continue;
+            }
+            let header = format!(
+                "Subagent transcript: {} ({})",
+                transcript.name, transcript.id
+            );
+            self.transcript
+                .push(Message::system(Plain::new(header).into()).with_role_prefix(false));
+            let iter = transcript
+                .messages
+                .into_iter()
+                .map(|message| Message::system(TranscriptMessage::new(message).into()));
+            self.transcript.extend(iter);
+        }
+    }
+
+    fn store_combo_transcript(&mut self, id: String, name: String, messages: Vec<ChatMessage>) {
+        if messages.is_empty() {
+            return;
+        }
+        {
+            let mut state = self.state.write();
+            if let Some(existing) = state
+                .combo_transcripts
+                .iter_mut()
+                .find(|entry| entry.id == id)
+            {
+                existing.name = name;
+                existing.messages = messages;
+            } else {
+                state
+                    .combo_transcripts
+                    .push(ComboTranscript { id, name, messages });
+            }
+        }
+        global::trigger_schedule_session_save();
+    }
+
+    fn store_subagent_transcript(&mut self, id: String, name: String, messages: Vec<ChatMessage>) {
+        if messages.is_empty() {
+            return;
+        }
+        {
+            let mut state = self.state.write();
+            if let Some(existing) = state
+                .subagent_transcripts
+                .iter_mut()
+                .find(|entry| entry.id == id)
+            {
+                existing.name = name;
+                existing.messages = messages;
+            } else {
+                state
+                    .subagent_transcripts
+                    .push(SubagentTranscript { id, name, messages });
+            }
+        }
+        global::trigger_schedule_session_save();
     }
 
     /// Handle the "New Session" command
@@ -1372,10 +1488,22 @@ impl Component for Chat<'static> {
                 }
                 self.dispatch_combo_event(combo_event);
             }
-            Event::Answer(AnswerEvent::SubagentEvent { .. }) => {
+            evt @ Event::Answer(AnswerEvent::SubagentEvent { id, event }) => {
+                if let SubagentEvent::Transcript {
+                    subagent_name,
+                    messages,
+                } = event
+                {
+                    self.store_subagent_transcript(
+                        id.clone(),
+                        subagent_name.clone(),
+                        messages.clone(),
+                    );
+                    return;
+                }
                 // RunTask tool is executing, set chat status to Processing
                 self.set_processing();
-                let _ = self.messages.on_tool_event(event);
+                let _ = self.messages.on_tool_event(evt);
             }
             Event::Answer(AnswerEvent::ToolOutput { .. }) => {
                 let _ = self.messages.on_tool_event(event);

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,7 +1,7 @@
 use coco_macro::ComponentExt;
 use code_combo::tools::{
     ComboEvent as ComboToolEvent, ComboInfo, ComboStreamKind, Final, RUN_COMBO_TOOL_NAME,
-    RunComboInput, SubagentEvent,
+    RUN_TASK_TOOL_NAME, RunComboInput, RunTaskInput, SubagentEvent,
 };
 use code_combo::{
     Agent, Block as ChatBlock, ChatResponse, ChatStreamUpdate, Config, Content as ChatContent,
@@ -40,8 +40,7 @@ use super::{
     Action, AnswerEvent, AskEvent, BotMessage, BotStreamKind, CacheInvalidation, Combo,
     ComboAction, ComboEvent, CommandPaletteAction, Component, Event, Input, Message, Messages,
     NavigationKey, NavigationResult, Plain, SessionAction, ShortcutHints, ShortcutHintsPanel,
-    Thinking, Tool, ToolAction, TranscriptLink, TranscriptLinkKind, TranscriptLinkTarget,
-    TranscriptMessage,
+    Thinking, Tool, ToolAction, TranscriptLinkKind, TranscriptLinkTarget, TranscriptMessage,
 };
 use crate::{
     components::{CommandPalette, Content, Persistable},
@@ -1133,8 +1132,8 @@ impl Chat<'static> {
         let agent_messages = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(self.agent.dump_messages())
         });
-        self.append_transcript_messages(agent_messages);
-        self.append_transcript_links();
+        let link_map = self.build_transcript_link_map(&agent_messages);
+        self.append_transcript_messages(agent_messages, &link_map);
     }
 
     fn build_combo_transcript(&mut self, id: &str, name: &str) {
@@ -1145,7 +1144,9 @@ impl Chat<'static> {
                 .push(Message::system(Plain::new(message).into()).with_role_prefix(false));
             return;
         };
-        self.append_transcript_messages(entry.messages.clone());
+        let messages = entry.messages.clone();
+        let link_map = self.build_transcript_link_map(&messages);
+        self.append_transcript_messages(messages, &link_map);
     }
 
     fn build_subagent_transcript(&mut self, id: &str, name: &str) {
@@ -1160,63 +1161,69 @@ impl Chat<'static> {
                 .push(Message::system(Plain::new(message).into()).with_role_prefix(false));
             return;
         };
-        self.append_transcript_messages(entry.messages.clone());
+        let messages = entry.messages.clone();
+        let link_map = self.build_transcript_link_map(&messages);
+        self.append_transcript_messages(messages, &link_map);
     }
 
-    fn append_transcript_messages(&mut self, messages: Vec<ChatMessage>) {
-        let iter = messages
-            .into_iter()
-            .map(|message| Message::system(TranscriptMessage::new(message).into()));
+    fn append_transcript_messages(
+        &mut self,
+        messages: Vec<ChatMessage>,
+        link_map: &HashMap<String, TranscriptLinkTarget>,
+    ) {
+        let iter = messages.into_iter().map(|message| {
+            Message::system(TranscriptMessage::new_with_links(message, link_map).into())
+        });
         self.transcript.extend(iter);
     }
 
-    fn append_transcript_links(&mut self) {
-        let state = self.state.read();
-        if state.combo_transcripts.is_empty() && state.subagent_transcripts.is_empty() {
-            return;
-        }
-
-        self.transcript
-            .push(Message::system(Plain::new(String::new()).into()).with_role_prefix(false));
-
-        if !state.combo_transcripts.is_empty() {
-            self.transcript.push(
-                Message::system(Plain::new("Combo transcripts:".to_string()).into())
-                    .with_role_prefix(false),
-            );
-            for entry in &state.combo_transcripts {
-                let target = TranscriptLinkTarget {
-                    kind: TranscriptLinkKind::Combo,
-                    id: entry.id.clone(),
-                    name: entry.name.clone(),
+    fn build_transcript_link_map(
+        &self,
+        messages: &[ChatMessage],
+    ) -> HashMap<String, TranscriptLinkTarget> {
+        let mut map = HashMap::new();
+        for message in messages {
+            let ChatContent::Multiple(blocks) = &message.content else {
+                continue;
+            };
+            for block in blocks {
+                let ChatBlock::ToolUse(tool_use) = block else {
+                    continue;
                 };
-                let link = TranscriptLink::new(target, entry.messages.len());
-                self.transcript
-                    .push(Message::system(link.into()).with_role_prefix(false));
+                match tool_use.name.as_str() {
+                    RUN_COMBO_TOOL_NAME => {
+                        if let Ok(input) =
+                            serde_json::from_value::<RunComboInput>(tool_use.input.clone())
+                        {
+                            map.insert(
+                                tool_use.id.clone(),
+                                TranscriptLinkTarget {
+                                    kind: TranscriptLinkKind::Combo,
+                                    id: tool_use.id.clone(),
+                                    name: input.combo_name,
+                                },
+                            );
+                        }
+                    }
+                    RUN_TASK_TOOL_NAME => {
+                        if let Ok(input) =
+                            serde_json::from_value::<RunTaskInput>(tool_use.input.clone())
+                        {
+                            map.insert(
+                                tool_use.id.clone(),
+                                TranscriptLinkTarget {
+                                    kind: TranscriptLinkKind::Subagent,
+                                    id: tool_use.id.clone(),
+                                    name: input.subagent_name,
+                                },
+                            );
+                        }
+                    }
+                    _ => {}
+                }
             }
         }
-
-        if !state.subagent_transcripts.is_empty() {
-            if !state.combo_transcripts.is_empty() {
-                self.transcript.push(
-                    Message::system(Plain::new(String::new()).into()).with_role_prefix(false),
-                );
-            }
-            self.transcript.push(
-                Message::system(Plain::new("Subagent transcripts:".to_string()).into())
-                    .with_role_prefix(false),
-            );
-            for entry in &state.subagent_transcripts {
-                let target = TranscriptLinkTarget {
-                    kind: TranscriptLinkKind::Subagent,
-                    id: entry.id.clone(),
-                    name: entry.name.clone(),
-                };
-                let link = TranscriptLink::new(target, entry.messages.len());
-                self.transcript
-                    .push(Message::system(link.into()).with_role_prefix(false));
-            }
-        }
+        map
     }
 
     fn ensure_transcript_focus(&mut self) {
@@ -1242,8 +1249,8 @@ impl Chat<'static> {
 
     fn transcript_selected_link_target(&self) -> Option<TranscriptLinkTarget> {
         self.transcript
-            .selected_message_as::<TranscriptLink>()
-            .map(|link| link.target())
+            .selected_message_as::<TranscriptMessage>()
+            .and_then(|message| message.link_target())
     }
 
     fn open_transcript_link(&mut self) {

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -40,7 +40,8 @@ use super::{
     Action, AnswerEvent, AskEvent, BotMessage, BotStreamKind, CacheInvalidation, Combo,
     ComboAction, ComboEvent, CommandPaletteAction, Component, Event, Input, Message, Messages,
     NavigationKey, NavigationResult, Plain, SessionAction, ShortcutHints, ShortcutHintsPanel,
-    Thinking, Tool, ToolAction, TranscriptMessage,
+    Thinking, Tool, ToolAction, TranscriptLink, TranscriptLinkKind, TranscriptLinkTarget,
+    TranscriptMessage,
 };
 use crate::{
     components::{CommandPalette, Content, Persistable},
@@ -70,6 +71,7 @@ pub struct Chat<'a> {
     pending_combo_tool_events: HashMap<String, Vec<ComboEvent>>,
     last_usage: Option<UsageStats>,
     retry_status: Option<RetryAttempt>,
+    transcript_scopes: Vec<TranscriptScope>,
 
     token_schedule_session_save: Option<CancellationToken>,
     cancellation_guard: CancellationGuard,
@@ -173,6 +175,12 @@ enum ViewMode {
     Transcript,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+enum TranscriptScope {
+    Combo { id: String, name: String },
+    Subagent { id: String, name: String },
+}
+
 const CTRL_C_WINDOW: Duration = Duration::from_secs(2);
 #[derive(Debug, Default)]
 struct CancellationGuard {
@@ -261,6 +269,7 @@ impl Chat<'static> {
             pending_combo_tool_events: HashMap::new(),
             last_usage: None,
             retry_status: None,
+            transcript_scopes: Vec::new(),
             token_schedule_session_save: None,
             cancellation_guard: CancellationGuard::default(),
         }
@@ -841,7 +850,12 @@ impl Chat<'static> {
 
     fn transcript_shortcut_hints(&self) -> ShortcutHints {
         let mut hints = self.transcript.shortcut_hints();
-        hints.push_visible(&[("Back", "Esc")]);
+        let back_label = if self.transcript_scopes.is_empty() {
+            "Close"
+        } else {
+            "Back"
+        };
+        hints.push_visible(&[(back_label, "Esc")]);
         hints.push_visible(&[("Up", "k"), ("Down", "j")]);
         hints.push_hidden(&[("Scroll Up", "C-y"), ("Down", "C-e")]);
         hints.push_hidden(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]);
@@ -1087,24 +1101,8 @@ impl Chat<'static> {
 
     fn open_transcript(&mut self) {
         self.update_focus(Focus::InputBlur);
-        let agent_messages = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.agent.dump_messages())
-        });
-        let (combo_transcripts, subagent_transcripts) = {
-            let state = self.state.read();
-            (
-                state.combo_transcripts.clone(),
-                state.subagent_transcripts.clone(),
-            )
-        };
-
-        self.transcript.clear();
-        let iter = agent_messages
-            .into_iter()
-            .map(|message| Message::system(TranscriptMessage::new(message).into()));
-        self.transcript.extend(iter);
-        self.append_combo_transcripts(combo_transcripts);
-        self.append_subagent_transcripts(subagent_transcripts);
+        self.transcript_scopes.clear();
+        self.rebuild_transcript_view();
         self.view = ViewMode::Transcript;
         global::signal_dirty();
     }
@@ -1112,48 +1110,199 @@ impl Chat<'static> {
     fn close_transcript(&mut self) {
         self.view = ViewMode::Chat;
         self.update_focus(Focus::InputBlur);
+        self.transcript_scopes.clear();
         global::signal_dirty();
     }
 
-    fn append_combo_transcripts(&mut self, transcripts: Vec<ComboTranscript>) {
-        for transcript in transcripts {
-            if transcript.messages.is_empty() {
-                continue;
+    fn rebuild_transcript_view(&mut self) {
+        self.transcript.clear();
+        let scope = self.transcript_scopes.last().cloned();
+        match scope {
+            None => self.build_root_transcript(),
+            Some(TranscriptScope::Combo { id, name }) => {
+                self.build_combo_transcript(&id, &name);
             }
-            let header = format!("Combo transcript: {} ({})", transcript.name, transcript.id);
+            Some(TranscriptScope::Subagent { id, name }) => {
+                self.build_subagent_transcript(&id, &name);
+            }
+        }
+        self.ensure_transcript_focus();
+    }
+
+    fn build_root_transcript(&mut self) {
+        let agent_messages = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(self.agent.dump_messages())
+        });
+        self.append_transcript_messages(agent_messages);
+        self.append_transcript_links();
+    }
+
+    fn build_combo_transcript(&mut self, id: &str, name: &str) {
+        let state = self.state.read();
+        let Some(entry) = state.combo_transcripts.iter().find(|entry| entry.id == id) else {
+            let message = format!("Combo transcript not found: {} ({})", name, id);
             self.transcript
-                .push(Message::system(Plain::new(header).into()).with_role_prefix(false));
-            let iter = transcript
-                .messages
-                .into_iter()
-                .map(|message| Message::system(TranscriptMessage::new(message).into()));
-            self.transcript.extend(iter);
+                .push(Message::system(Plain::new(message).into()).with_role_prefix(false));
+            return;
+        };
+        self.append_transcript_messages(entry.messages.clone());
+    }
+
+    fn build_subagent_transcript(&mut self, id: &str, name: &str) {
+        let state = self.state.read();
+        let Some(entry) = state
+            .subagent_transcripts
+            .iter()
+            .find(|entry| entry.id == id)
+        else {
+            let message = format!("Subagent transcript not found: {} ({})", name, id);
+            self.transcript
+                .push(Message::system(Plain::new(message).into()).with_role_prefix(false));
+            return;
+        };
+        self.append_transcript_messages(entry.messages.clone());
+    }
+
+    fn append_transcript_messages(&mut self, messages: Vec<ChatMessage>) {
+        let iter = messages
+            .into_iter()
+            .map(|message| Message::system(TranscriptMessage::new(message).into()));
+        self.transcript.extend(iter);
+    }
+
+    fn append_transcript_links(&mut self) {
+        let state = self.state.read();
+        if state.combo_transcripts.is_empty() && state.subagent_transcripts.is_empty() {
+            return;
+        }
+
+        self.transcript
+            .push(Message::system(Plain::new(String::new()).into()).with_role_prefix(false));
+
+        if !state.combo_transcripts.is_empty() {
+            self.transcript.push(
+                Message::system(Plain::new("Combo transcripts:".to_string()).into())
+                    .with_role_prefix(false),
+            );
+            for entry in &state.combo_transcripts {
+                let target = TranscriptLinkTarget {
+                    kind: TranscriptLinkKind::Combo,
+                    id: entry.id.clone(),
+                    name: entry.name.clone(),
+                };
+                let link = TranscriptLink::new(target, entry.messages.len());
+                self.transcript
+                    .push(Message::system(link.into()).with_role_prefix(false));
+            }
+        }
+
+        if !state.subagent_transcripts.is_empty() {
+            if !state.combo_transcripts.is_empty() {
+                self.transcript.push(
+                    Message::system(Plain::new(String::new()).into()).with_role_prefix(false),
+                );
+            }
+            self.transcript.push(
+                Message::system(Plain::new("Subagent transcripts:".to_string()).into())
+                    .with_role_prefix(false),
+            );
+            for entry in &state.subagent_transcripts {
+                let target = TranscriptLinkTarget {
+                    kind: TranscriptLinkKind::Subagent,
+                    id: entry.id.clone(),
+                    name: entry.name.clone(),
+                };
+                let link = TranscriptLink::new(target, entry.messages.len());
+                self.transcript
+                    .push(Message::system(link.into()).with_role_prefix(false));
+            }
         }
     }
 
-    fn append_subagent_transcripts(&mut self, transcripts: Vec<SubagentTranscript>) {
-        for transcript in transcripts {
-            if transcript.messages.is_empty() {
-                continue;
-            }
-            let header = format!(
-                "Subagent transcript: {} ({})",
-                transcript.name, transcript.id
-            );
-            self.transcript
-                .push(Message::system(Plain::new(header).into()).with_role_prefix(false));
-            let iter = transcript
-                .messages
-                .into_iter()
-                .map(|message| Message::system(TranscriptMessage::new(message).into()));
-            self.transcript.extend(iter);
+    fn ensure_transcript_focus(&mut self) {
+        if self.transcript.selected_idx().is_none() && !self.transcript.is_empty() {
+            self.transcript.focus(0);
         }
+    }
+
+    fn move_transcript_selection(&mut self, key: NavigationKey) {
+        if self.transcript.selected_idx().is_none() {
+            match key {
+                NavigationKey::Down => {
+                    let _ = self.transcript.focus(0);
+                }
+                NavigationKey::Up => {
+                    let _ = self.transcript.select_last();
+                }
+            }
+            return;
+        }
+        let _ = self.transcript.handle_navigation(key);
+    }
+
+    fn transcript_selected_link_target(&self) -> Option<TranscriptLinkTarget> {
+        self.transcript
+            .selected_message_as::<TranscriptLink>()
+            .map(|link| link.target())
+    }
+
+    fn open_transcript_link(&mut self) {
+        let Some(target) = self.transcript_selected_link_target() else {
+            return;
+        };
+        let scope = match target.kind {
+            TranscriptLinkKind::Combo => TranscriptScope::Combo {
+                id: target.id,
+                name: target.name,
+            },
+            TranscriptLinkKind::Subagent => TranscriptScope::Subagent {
+                id: target.id,
+                name: target.name,
+            },
+        };
+        self.transcript_scopes.push(scope);
+        self.rebuild_transcript_view();
+    }
+
+    fn back_or_close_transcript(&mut self) {
+        if self.transcript_scopes.pop().is_some() {
+            self.rebuild_transcript_view();
+        } else {
+            self.close_transcript();
+        }
+    }
+
+    fn transcript_breadcrumb_line(&self) -> Line<'static> {
+        let theme = global::theme();
+        let mut crumbs = vec!["Transcript".to_string()];
+        if self.transcript_scopes.is_empty() {
+            crumbs.push("Root".to_string());
+        } else {
+            for scope in &self.transcript_scopes {
+                let label = match scope {
+                    TranscriptScope::Combo { name, .. } => format!("Combo: {}", name),
+                    TranscriptScope::Subagent { name, .. } => format!("Subagent: {}", name),
+                };
+                crumbs.push(label);
+            }
+        }
+        let breadcrumb = crumbs.join(" / ");
+        Line::from(Span::styled(breadcrumb, theme.ui.folded_hint))
     }
 
     fn store_combo_transcript(&mut self, id: String, name: String, messages: Vec<ChatMessage>) {
         if messages.is_empty() {
             return;
         }
+        let should_refresh = if self.view == ViewMode::Transcript {
+            match self.transcript_scopes.last() {
+                None => true,
+                Some(TranscriptScope::Combo { id: scope_id, .. }) => scope_id == &id,
+                _ => false,
+            }
+        } else {
+            false
+        };
         {
             let mut state = self.state.write();
             if let Some(existing) = state
@@ -1170,12 +1319,24 @@ impl Chat<'static> {
             }
         }
         global::trigger_schedule_session_save();
+        if should_refresh {
+            self.rebuild_transcript_view();
+        }
     }
 
     fn store_subagent_transcript(&mut self, id: String, name: String, messages: Vec<ChatMessage>) {
         if messages.is_empty() {
             return;
         }
+        let should_refresh = if self.view == ViewMode::Transcript {
+            match self.transcript_scopes.last() {
+                None => true,
+                Some(TranscriptScope::Subagent { id: scope_id, .. }) => scope_id == &id,
+                _ => false,
+            }
+        } else {
+            false
+        };
         {
             let mut state = self.state.write();
             if let Some(existing) = state
@@ -1192,6 +1353,9 @@ impl Chat<'static> {
             }
         }
         global::trigger_schedule_session_save();
+        if should_refresh {
+            self.rebuild_transcript_view();
+        }
     }
 
     /// Handle the "New Session" command
@@ -1554,12 +1718,19 @@ impl Component for Chat<'static> {
         }
         if self.view == ViewMode::Transcript {
             match (key.modifiers, key.code) {
-                (KM::NONE, Esc) => self.close_transcript(),
+                (KM::NONE, Esc) | (KM::NONE, Backspace) => self.back_or_close_transcript(),
+                (KM::NONE, Enter) => self.open_transcript_link(),
                 (KM::NONE, Char('k')) => {
-                    self.transcript.scroll_up(1);
+                    self.move_transcript_selection(NavigationKey::Up);
                 }
                 (KM::NONE, Char('j')) => {
-                    self.transcript.scroll_down(1);
+                    self.move_transcript_selection(NavigationKey::Down);
+                }
+                (KM::NONE, Up) => {
+                    self.move_transcript_selection(NavigationKey::Up);
+                }
+                (KM::NONE, Down) => {
+                    self.move_transcript_selection(NavigationKey::Down);
                 }
                 (KM::CONTROL, Char('y')) => {
                     self.transcript.scroll_up(1);
@@ -1863,6 +2034,7 @@ impl Chat<'static> {
         bottom_block = bottom_block
             .title_bottom(Line::from(""))
             .title_bottom(Line::from(" Transcript ").bold());
+        bottom_block = bottom_block.title_bottom(self.transcript_breadcrumb_line());
         let hints = self.transcript_shortcut_hints();
         bottom_block = self
             .shortcut_hints

--- a/crates/coco-tui/src/components/message.rs
+++ b/crates/coco-tui/src/components/message.rs
@@ -161,6 +161,10 @@ impl Message {
         false
     }
 
+    pub fn content_as_any(&self) -> &dyn Any {
+        self.content.as_any()
+    }
+
     pub fn content_as_mut_any(&mut self) -> &mut dyn Any {
         self.content.as_mut_any()
     }

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -330,6 +330,12 @@ impl Messages {
         self.focus.get()
     }
 
+    pub fn selected_message_as<T: 'static>(&self) -> Option<&T> {
+        let idx = self.focus.get()?;
+        let message = self.messages.read().get(idx)?;
+        message.content_as_any().downcast_ref::<T>()
+    }
+
     fn update_focus(&mut self, new_focus: Option<usize>) {
         let old_focus = self.focus.get();
         if old_focus == new_focus {

--- a/crates/coco-tui/src/components/messages/tool/run_task.rs
+++ b/crates/coco-tui/src/components/messages/tool/run_task.rs
@@ -450,6 +450,7 @@ impl<'a> RunTask<'a> {
                 drop(state);
                 self.rebuild_output();
             }
+            SubagentEvent::Transcript { .. } => {}
         }
     }
 

--- a/crates/coco-tui/src/components/transcript.rs
+++ b/crates/coco-tui/src/components/transcript.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use coco_macro::{ComponentExt, ContentComponentExt};
 use code_combo::{Block as ChatBlock, Content as ChatContent, Message as ChatMessage};
 use ratatui::{
@@ -26,6 +28,7 @@ struct TranscriptState {
 pub struct TranscriptMessage {
     state: TranscriptState,
     segments: Vec<Box<dyn ContentComponent>>,
+    link_target: Option<TranscriptLinkTarget>,
 }
 
 const INDENT_STEP: u16 = 2;
@@ -84,82 +87,6 @@ pub struct TranscriptLinkTarget {
     pub id: String,
     pub name: String,
 }
-
-#[derive(Serialize, Deserialize)]
-struct TranscriptLinkState {
-    target: TranscriptLinkTarget,
-    message_count: usize,
-}
-
-#[derive(ComponentExt, ContentComponentExt)]
-#[component(type_id = "transcript_link")]
-pub struct TranscriptLink {
-    state: TranscriptLinkState,
-    widget: Paragraph<'static>,
-}
-
-impl TranscriptLink {
-    pub fn new(target: TranscriptLinkTarget, message_count: usize) -> Self {
-        let text = format!(
-            "{}: {} ({}) - {} messages",
-            match target.kind {
-                TranscriptLinkKind::Combo => "Combo",
-                TranscriptLinkKind::Subagent => "Subagent",
-            },
-            target.name,
-            target.id,
-            message_count
-        );
-        let widget = Paragraph::new_wrap(text.clone(), Wrap { trim: false });
-        Self {
-            state: TranscriptLinkState {
-                target,
-                message_count,
-            },
-            widget,
-        }
-    }
-
-    pub fn target(&self) -> TranscriptLinkTarget {
-        self.state.target.clone()
-    }
-}
-
-impl Persistable for TranscriptLink {
-    fn save(&self) -> Session {
-        session::save(&self.state)
-    }
-
-    fn load(session: Session) -> Result<Self> {
-        let state: TranscriptLinkState = session::load(session)?;
-        Ok(Self::new(state.target, state.message_count))
-    }
-}
-
-impl Component for TranscriptLink {
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        frame.render_widget(&self.widget, area);
-        Ok(())
-    }
-}
-
-impl Content for TranscriptLink {
-    fn height(&self, width: u16) -> usize {
-        self.widget.line_count(width)
-    }
-
-    fn is_actionable(&self) -> bool {
-        true
-    }
-
-    fn shortcut_hints(&self) -> ShortcutHints {
-        let mut hints = ShortcutHints::default();
-        hints.push_visible(&[("Open", "Enter")]);
-        hints
-    }
-}
-
-impl ContentComponent for TranscriptLink {}
 
 #[derive(Serialize, Deserialize)]
 struct TranscriptTextState {
@@ -345,6 +272,8 @@ impl ContentComponent for TranscriptThinking {}
 #[derive(Serialize, Deserialize)]
 struct TranscriptToolUseState {
     tool_use: code_combo::ToolUse,
+    #[serde(default)]
+    link_target: Option<TranscriptLinkTarget>,
 }
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -355,11 +284,12 @@ struct TranscriptToolUse {
 }
 
 impl TranscriptToolUse {
-    fn new(tool_use: &code_combo::ToolUse) -> Self {
+    fn new(tool_use: &code_combo::ToolUse, link_target: Option<TranscriptLinkTarget>) -> Self {
         let input = json_component(&tool_use.input);
         Self {
             state: TranscriptToolUseState {
                 tool_use: tool_use.clone(),
+                link_target,
             },
             input,
         }
@@ -373,7 +303,7 @@ impl Persistable for TranscriptToolUse {
 
     fn load(session: Session) -> Result<Self> {
         let state: TranscriptToolUseState = session::load(session)?;
-        Ok(Self::new(&state.tool_use))
+        Ok(Self::new(&state.tool_use, state.link_target))
     }
 }
 
@@ -436,6 +366,18 @@ impl Content for TranscriptToolUse {
         let body_height = child_height(self.input.as_ref(), width, INDENT_STEP * 2);
         header_height + id_height + name_height + input_height + body_height
     }
+
+    fn is_actionable(&self) -> bool {
+        self.state.link_target.is_some()
+    }
+
+    fn shortcut_hints(&self) -> ShortcutHints {
+        if self.state.link_target.is_some() {
+            ShortcutHints::from_visible(&[("Open", "Enter")])
+        } else {
+            ShortcutHints::default()
+        }
+    }
 }
 
 impl ContentComponent for TranscriptToolUse {}
@@ -445,6 +387,8 @@ struct TranscriptToolResultState {
     tool_use_id: String,
     is_error: Option<bool>,
     content: ChatContent,
+    #[serde(default)]
+    link_target: Option<TranscriptLinkTarget>,
 }
 
 #[derive(ComponentExt, ContentComponentExt)]
@@ -455,13 +399,19 @@ struct TranscriptToolResult {
 }
 
 impl TranscriptToolResult {
-    fn new(tool_use_id: &str, is_error: Option<bool>, content: &ChatContent) -> Self {
+    fn new(
+        tool_use_id: &str,
+        is_error: Option<bool>,
+        content: &ChatContent,
+        link_target: Option<TranscriptLinkTarget>,
+    ) -> Self {
         let content_section = TranscriptContentSection::new(content, true);
         Self {
             state: TranscriptToolResultState {
                 tool_use_id: tool_use_id.to_string(),
                 is_error,
                 content: content.clone(),
+                link_target,
             },
             content: content_section,
         }
@@ -479,6 +429,7 @@ impl Persistable for TranscriptToolResult {
             &state.tool_use_id,
             state.is_error,
             &state.content,
+            state.link_target,
         ))
     }
 }
@@ -559,6 +510,18 @@ impl Content for TranscriptToolResult {
         total += child_height(&self.content, width, INDENT_STEP * 2);
         total
     }
+
+    fn is_actionable(&self) -> bool {
+        self.state.link_target.is_some()
+    }
+
+    fn shortcut_hints(&self) -> ShortcutHints {
+        if self.state.link_target.is_some() {
+            ShortcutHints::from_visible(&[("Open", "Enter")])
+        } else {
+            ShortcutHints::default()
+        }
+    }
 }
 
 impl ContentComponent for TranscriptToolResult {}
@@ -578,7 +541,22 @@ struct TranscriptBlocks {
 
 impl TranscriptBlocks {
     fn new(blocks: &[ChatBlock], detect_json: bool) -> Self {
-        let items = build_block_items(blocks, detect_json);
+        let items = build_block_items(blocks, detect_json, &HashMap::new());
+        Self {
+            state: TranscriptBlocksState {
+                blocks: blocks.to_vec(),
+                detect_json,
+            },
+            items,
+        }
+    }
+
+    fn new_with_links(
+        blocks: &[ChatBlock],
+        detect_json: bool,
+        link_map: &HashMap<String, TranscriptLinkTarget>,
+    ) -> Self {
+        let items = build_block_items(blocks, detect_json, link_map);
         Self {
             state: TranscriptBlocksState {
                 blocks: blocks.to_vec(),
@@ -651,6 +629,22 @@ impl TranscriptBlocksSection {
     fn new(content: &ChatContent, detect_json: bool) -> Self {
         let blocks = blocks_from_content(content);
         let blocks = TranscriptBlocks::new(&blocks, detect_json);
+        Self {
+            state: TranscriptBlocksSectionState {
+                content: content.clone(),
+                detect_json,
+            },
+            blocks,
+        }
+    }
+
+    fn new_with_links(
+        content: &ChatContent,
+        detect_json: bool,
+        link_map: &HashMap<String, TranscriptLinkTarget>,
+    ) -> Self {
+        let blocks = blocks_from_content(content);
+        let blocks = TranscriptBlocks::new_with_links(&blocks, detect_json, link_map);
         Self {
             state: TranscriptBlocksSectionState {
                 content: content.clone(),
@@ -779,24 +773,61 @@ impl Content for TranscriptContentSection {
 impl ContentComponent for TranscriptContentSection {}
 
 impl TranscriptMessage {
-    pub fn new(message: ChatMessage) -> Self {
-        let segments = build_segments(&message);
+    pub fn new_with_links(
+        message: ChatMessage,
+        link_map: &HashMap<String, TranscriptLinkTarget>,
+    ) -> Self {
+        let segments = build_segments(&message, link_map);
+        let link_target = message_link_target(&message, link_map);
         Self {
             state: TranscriptState { message },
             segments,
+            link_target,
         }
+    }
+
+    pub fn link_target(&self) -> Option<TranscriptLinkTarget> {
+        self.link_target.clone()
     }
 }
 
-fn build_segments(message: &ChatMessage) -> Vec<Box<dyn ContentComponent>> {
+fn build_segments(
+    message: &ChatMessage,
+    link_map: &HashMap<String, TranscriptLinkTarget>,
+) -> Vec<Box<dyn ContentComponent>> {
     let role = match message.role {
         code_combo::Role::User => "user",
         code_combo::Role::Assistant => "assistant",
     };
     vec![
         TranscriptPlain::new(format!("role: {role}")).into(),
-        TranscriptBlocksSection::new(&message.content, false).into(),
+        TranscriptBlocksSection::new_with_links(&message.content, false, link_map).into(),
     ]
+}
+
+fn message_link_target(
+    message: &ChatMessage,
+    link_map: &HashMap<String, TranscriptLinkTarget>,
+) -> Option<TranscriptLinkTarget> {
+    let ChatContent::Multiple(blocks) = &message.content else {
+        return None;
+    };
+    for block in blocks {
+        match block {
+            ChatBlock::ToolUse(tool_use) => {
+                if let Some(target) = link_map.get(&tool_use.id) {
+                    return Some(target.clone());
+                }
+            }
+            ChatBlock::ToolResult { tool_use_id, .. } => {
+                if let Some(target) = link_map.get(tool_use_id) {
+                    return Some(target.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn blocks_from_content(content: &ChatContent) -> Vec<ChatBlock> {
@@ -806,26 +837,42 @@ fn blocks_from_content(content: &ChatContent) -> Vec<ChatBlock> {
     }
 }
 
-fn build_block_items(blocks: &[ChatBlock], detect_json: bool) -> Vec<Box<dyn ContentComponent>> {
+fn build_block_items(
+    blocks: &[ChatBlock],
+    detect_json: bool,
+    link_map: &HashMap<String, TranscriptLinkTarget>,
+) -> Vec<Box<dyn ContentComponent>> {
     blocks
         .iter()
-        .map(|block| block_component(block, detect_json))
+        .map(|block| block_component(block, detect_json, link_map))
         .collect()
 }
 
-fn block_component(block: &ChatBlock, detect_json: bool) -> Box<dyn ContentComponent> {
+fn block_component(
+    block: &ChatBlock,
+    detect_json: bool,
+    link_map: &HashMap<String, TranscriptLinkTarget>,
+) -> Box<dyn ContentComponent> {
     match block {
         ChatBlock::Text { text } => TranscriptText::new(text, detect_json).into(),
         ChatBlock::Thinking {
             thinking,
             signature,
         } => TranscriptThinking::new(thinking, signature.clone()).into(),
-        ChatBlock::ToolUse(tool_use) => TranscriptToolUse::new(tool_use).into(),
+        ChatBlock::ToolUse(tool_use) => {
+            TranscriptToolUse::new(tool_use, link_map.get(&tool_use.id).cloned()).into()
+        }
         ChatBlock::ToolResult {
             tool_use_id,
             is_error,
             content,
-        } => TranscriptToolResult::new(tool_use_id, *is_error, content).into(),
+        } => TranscriptToolResult::new(
+            tool_use_id,
+            *is_error,
+            content,
+            link_map.get(tool_use_id).cloned(),
+        )
+        .into(),
     }
 }
 
@@ -912,7 +959,7 @@ impl Persistable for TranscriptMessage {
 
     fn load(session: Session) -> Result<Self> {
         let state: TranscriptState = session::load(session)?;
-        Ok(Self::new(state.message))
+        Ok(Self::new_with_links(state.message, &HashMap::new()))
     }
 }
 
@@ -941,6 +988,18 @@ impl Content for TranscriptMessage {
             .iter()
             .map(|segment| segment.height(width))
             .sum()
+    }
+
+    fn is_actionable(&self) -> bool {
+        self.link_target.is_some()
+    }
+
+    fn shortcut_hints(&self) -> ShortcutHints {
+        if self.link_target.is_some() {
+            ShortcutHints::from_visible(&[("Open", "Enter")])
+        } else {
+            ShortcutHints::default()
+        }
     }
 }
 

--- a/crates/coco-tui/src/components/transcript.rs
+++ b/crates/coco-tui/src/components/transcript.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    components::{CodeHighlight, Component, Content, ContentComponent, Persistable},
+    components::{CodeHighlight, Component, Content, ContentComponent, Persistable, ShortcutHints},
     error::Result,
     session::{self, Session},
     widgets::Paragraph,
@@ -70,6 +70,96 @@ impl Content for TranscriptPlain {
 }
 
 impl ContentComponent for TranscriptPlain {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptLinkKind {
+    Combo,
+    Subagent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptLinkTarget {
+    pub kind: TranscriptLinkKind,
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptLinkState {
+    target: TranscriptLinkTarget,
+    message_count: usize,
+}
+
+#[derive(ComponentExt, ContentComponentExt)]
+#[component(type_id = "transcript_link")]
+pub struct TranscriptLink {
+    state: TranscriptLinkState,
+    widget: Paragraph<'static>,
+}
+
+impl TranscriptLink {
+    pub fn new(target: TranscriptLinkTarget, message_count: usize) -> Self {
+        let text = format!(
+            "{}: {} ({}) - {} messages",
+            match target.kind {
+                TranscriptLinkKind::Combo => "Combo",
+                TranscriptLinkKind::Subagent => "Subagent",
+            },
+            target.name,
+            target.id,
+            message_count
+        );
+        let widget = Paragraph::new_wrap(text.clone(), Wrap { trim: false });
+        Self {
+            state: TranscriptLinkState {
+                target,
+                message_count,
+            },
+            widget,
+        }
+    }
+
+    pub fn target(&self) -> TranscriptLinkTarget {
+        self.state.target.clone()
+    }
+}
+
+impl Persistable for TranscriptLink {
+    fn save(&self) -> Session {
+        session::save(&self.state)
+    }
+
+    fn load(session: Session) -> Result<Self> {
+        let state: TranscriptLinkState = session::load(session)?;
+        Ok(Self::new(state.target, state.message_count))
+    }
+}
+
+impl Component for TranscriptLink {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        frame.render_widget(&self.widget, area);
+        Ok(())
+    }
+}
+
+impl Content for TranscriptLink {
+    fn height(&self, width: u16) -> usize {
+        self.widget.line_count(width)
+    }
+
+    fn is_actionable(&self) -> bool {
+        true
+    }
+
+    fn shortcut_hints(&self) -> ShortcutHints {
+        let mut hints = ShortcutHints::default();
+        hints.push_visible(&[("Open", "Enter")]);
+        hints
+    }
+}
+
+impl ContentComponent for TranscriptLink {}
 
 #[derive(Serialize, Deserialize)]
 struct TranscriptTextState {

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -1,5 +1,6 @@
 use code_combo::{
-    OutputChunk, RetryUpdate, Starter, TextEdit, ThinkingConfig, ToolUse, UsageStats,
+    Message as ChatMessage, OutputChunk, RetryUpdate, Starter, TextEdit, ThinkingConfig, ToolUse,
+    UsageStats,
     tools::{ComboEvent as ComboToolEvent, Final, SubagentEvent},
 };
 use crossterm::event::{KeyEvent, MouseEvent};
@@ -166,6 +167,11 @@ pub enum ComboEvent {
     Cancelled {
         id: Option<String>,
         name: Option<String>,
+    },
+    Transcript {
+        id: String,
+        name: String,
+        messages: Vec<ChatMessage>,
     },
 }
 

--- a/src/tools/run_combo.rs
+++ b/src/tools/run_combo.rs
@@ -168,6 +168,13 @@ pub enum ComboEvent {
         /// Combo name if available.
         name: Option<String>,
     },
+    /// Transcript messages collected during combo execution.
+    Transcript {
+        /// Combo name.
+        name: String,
+        /// Transcript messages for the combo reply agent.
+        messages: Vec<Message>,
+    },
 }
 
 /// Information about a discovered combo.
@@ -725,6 +732,7 @@ async fn execute_combo(
                     exit_code,
                 },
             );
+            emit_combo_transcript(&on_event_for_emit, &combo_name, &reply_agent).await;
             return Err(format!("Join error: {}", err));
         }
     };
@@ -752,6 +760,7 @@ async fn execute_combo(
                 name: Some(combo_name.clone()),
             },
         );
+        emit_combo_transcript(&on_event_for_emit, &combo_name, &reply_agent).await;
         return Ok(RunComboOutput {
             success: false,
             summary: "Combo execution was cancelled".to_string(),
@@ -771,6 +780,7 @@ async fn execute_combo(
 
     // Check combo result
     if let Err(e) = starter.combo {
+        emit_combo_transcript(&on_event_for_emit, &combo_name, &reply_agent).await;
         return Ok(RunComboOutput {
             success: false,
             summary: summary_parts.join("\n"),
@@ -804,6 +814,8 @@ async fn execute_combo(
         }
     };
 
+    emit_combo_transcript(&on_event_for_emit, &combo_name, &reply_agent).await;
+
     Ok(RunComboOutput {
         success,
         summary,
@@ -820,6 +832,20 @@ fn emit_combo_event(on_event: &ComboEventCallback, event: ComboEvent) {
     if let Ok(mut f) = on_event.lock() {
         (*f)(&event);
     }
+}
+
+async fn emit_combo_transcript(on_event: &ComboEventCallback, name: &str, agent: &Agent) {
+    let messages = agent.dump_messages().await;
+    if messages.is_empty() {
+        return;
+    }
+    emit_combo_event(
+        on_event,
+        ComboEvent::Transcript {
+            name: name.to_string(),
+            messages,
+        },
+    );
 }
 
 fn build_reply_agent(

--- a/src/tools/run_task.rs
+++ b/src/tools/run_task.rs
@@ -101,6 +101,13 @@ pub enum SubagentEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         input_summary: Option<String>,
     },
+    /// Transcript messages captured for the subagent.
+    Transcript {
+        /// Subagent name.
+        subagent_name: String,
+        /// Transcript messages for the subagent.
+        messages: Vec<Message>,
+    },
 }
 
 /// Configuration needed to create and run subagent instances.
@@ -352,11 +359,14 @@ where
     let result = execute_subagent(
         subagent_base_config,
         parent_executor,
-        subagent_system_prompt,
-        input.prompt,
-        subagent_model_override,
-        cancel_token,
-        on_event_boxed,
+        SubagentExecutionParams {
+            system_prompt: subagent_system_prompt,
+            initial_prompt: input.prompt,
+            model_override: subagent_model_override,
+            cancel_token,
+            subagent_name: input.subagent_name.clone(),
+            on_event: on_event_boxed,
+        },
     )
     .await;
 
@@ -420,6 +430,22 @@ fn resolve_subagent_model(
     }
 }
 
+/// Parameters for executing a subagent.
+struct SubagentExecutionParams {
+    /// System prompt for the subagent.
+    system_prompt: String,
+    /// Initial prompt from the user.
+    initial_prompt: String,
+    /// Model override to use (if any).
+    model_override: Option<String>,
+    /// Cancellation token for the operation.
+    cancel_token: CancellationToken,
+    /// Name of the subagent.
+    subagent_name: String,
+    /// Callback for subagent events.
+    on_event: SubagentEventCallback,
+}
+
 /// Execute the subagent loop.
 ///
 /// Returns a boxed future to break type-level recursion that would otherwise
@@ -427,11 +453,7 @@ fn resolve_subagent_model(
 fn execute_subagent(
     config: Config,
     executor: Executor,
-    system_prompt: String,
-    initial_prompt: String,
-    model_override: Option<String>,
-    cancel_token: CancellationToken,
-    on_event: SubagentEventCallback,
+    params: SubagentExecutionParams,
 ) -> BoxFuture<'static, Result<RunTaskOutput, String>> {
     use crate::agent::Agent;
 
@@ -447,8 +469,8 @@ fn execute_subagent(
         };
 
         // Clone Arc for closures
-        let on_event_for_emit = on_event.clone();
-        let on_event_for_update = on_event.clone();
+        let on_event_for_emit = params.on_event.clone();
+        let on_event_for_update = params.on_event.clone();
 
         // Helper to emit events
         let emit_event = move |event: SubagentEvent| {
@@ -526,7 +548,7 @@ fn execute_subagent(
 
             // Emit remaining content
             for (stream, line) in lines_to_emit {
-                if let Ok(mut f) = on_event.lock() {
+                if let Ok(mut f) = params.on_event.lock() {
                     (*f)(&SubagentEvent::Output(OutputChunk {
                         timestamp: now_ms(),
                         stream,
@@ -538,18 +560,18 @@ fn execute_subagent(
 
         // Create subagent and configure it
         let mut subagent = Agent::new(config);
-        subagent.set_system_prompt(&system_prompt);
-        subagent.set_model_override(model_override);
+        subagent.set_system_prompt(&params.system_prompt);
+        subagent.set_model_override(params.model_override);
 
         // Send initial message
-        let user_message = Message::user(Content::Text(initial_prompt));
+        let user_message = Message::user(Content::Text(params.initial_prompt));
 
         let mut turns = 0;
         let max_turns = 50; // Prevent infinite loops
 
         // Initial chat
         let response = subagent
-            .chat_stream(user_message, cancel_token.clone(), &emit_update)
+            .chat_stream(user_message, params.cancel_token.clone(), &emit_update)
             .await
             .map_err(|e| format!("Subagent chat failed: {}", e))?;
 
@@ -562,15 +584,17 @@ fn execute_subagent(
 
         debug!(?stop_reason, turns, "Subagent initial response");
 
+        let mut output: Option<RunTaskOutput> = None;
+
         while matches!(stop_reason, Some(StopReason::ToolUse)) && turns < max_turns {
-            if cancel_token.is_cancelled() {
-                flush_buffers();
-                return Ok(RunTaskOutput {
+            if params.cancel_token.is_cancelled() {
+                output = Some(RunTaskOutput {
                     success: false,
-                    response: final_response,
+                    response: final_response.clone(),
                     turns,
                     error: Some("Cancelled".to_string()),
                 });
+                break;
             }
 
             // Extract and execute tool calls
@@ -596,7 +620,7 @@ fn execute_subagent(
                 });
 
                 // Clone info for the execute_with_output callback
-                let on_event_for_exec = on_event.clone();
+                let on_event_for_exec = params.on_event.clone();
                 let tool_id_for_perm = tool_use.id.clone();
                 let tool_name_for_perm = tool_use.name.clone();
                 let input_summary_for_perm = input_summary.clone();
@@ -614,7 +638,7 @@ fn execute_subagent(
                         &tool_use.id,
                         &tool_use.name,
                         input,
-                        cancel_token.clone(),
+                        params.cancel_token.clone(),
                         |output| match &output {
                             crate::agent::Output::ToolOutput(chunk) => {
                                 if let Ok(mut f) = on_event_for_exec.lock() {
@@ -714,7 +738,7 @@ fn execute_subagent(
 
             // Continue conversation
             let next_response = subagent
-                .chat_stream_with_history(cancel_token.clone(), &emit_update)
+                .chat_stream_with_history(params.cancel_token.clone(), &emit_update)
                 .await
                 .map_err(|e| format!("Subagent continuation failed: {}", e))?;
 
@@ -726,21 +750,30 @@ fn execute_subagent(
             debug!(?stop_reason, turns, "Subagent continuation response");
         }
 
-        debug!(
-            turns,
-            response_len = final_response.len(),
-            "Subagent execution completed, exiting loop"
-        );
+        if output.is_none() {
+            debug!(
+                turns,
+                response_len = final_response.len(),
+                "Subagent execution completed, exiting loop"
+            );
+            output = Some(RunTaskOutput {
+                success: true,
+                response: final_response,
+                turns,
+                error: None,
+            });
+        }
 
         // Flush any remaining buffered content before returning
         flush_buffers();
 
-        Ok(RunTaskOutput {
-            success: true,
-            response: final_response,
-            turns,
-            error: None,
-        })
+        let transcript_messages = subagent.dump_messages().await;
+        emit_event(SubagentEvent::Transcript {
+            subagent_name: params.subagent_name,
+            messages: transcript_messages,
+        });
+
+        Ok(output.expect("subagent output should be set"))
     })
 }
 


### PR DESCRIPTION
Closes #129

## Summary

This PR adds support for displaying and navigating transcripts from combo and subagent executions, providing users with better visibility into the execution history and conversation flow.

## Changes

### Core Features
- **Transcript Storage**: Added storage for combo and subagent transcripts in the chat state, persisting across sessions
- **Multi-level Transcript Navigation**: Implemented a scope-based navigation system allowing users to drill down from root transcript to combo/subagent transcript
- **Transcript Links**: Tool uses and results in transcripts now display as actionable links when they have associated combo/subagent executions
- **Breadcrumb Navigation**: Added breadcrumb display showing current transcript scope (e.g., Transcript / Root or Transcript / Combo: script_name)

### UI/UX Improvements
- **Keyboard Shortcuts**:
  - Enter - Open linked transcript (when on a tool use/result with a combo/subagent)
  - Esc or Backspace - Go back to previous scope or close transcript
  - k/j or Up/Down - Navigate between transcript messages
- **Visual Indicators**: Actionable items show Open hint in shortcut hints
- **Dynamic Labels**: Back button shows Back when in nested scope, Close when at root

### Technical Implementation
- Added TranscriptScope enum to track navigation state (Combo/Subagent with id and name)
- Added ComboTranscript and SubagentTranscript structs for serialization
- Implemented build_transcript_link_map() to identify tool uses with associated executions
- Refactored execute_subagent() to use a SubagentExecutionParams struct for cleaner code organization
- Added emit_combo_transcript() and emit_subagent_transcript() to capture execution history