### PR TITLE
feat: Add OSC 9 notification support for TUI

### DIFF
--- a/crates/coco-tui/src/app.rs
+++ b/crates/coco-tui/src/app.rs
@@ -6,7 +6,9 @@ use std::{
 
 use crossterm::{
     cursor,
-    event::{Event as CrosstermEvent, EventStream, KeyEvent},
+    event::{
+        DisableFocusChange, EnableFocusChange, Event as CrosstermEvent, EventStream, KeyEvent,
+    },
     terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use futures::{FutureExt, StreamExt};
@@ -112,8 +114,13 @@ impl App {
 
     pub fn enter(&mut self) -> Result<()> {
         crossterm::terminal::enable_raw_mode().whatever_context("failed to enable raw mode")?;
-        crossterm::execute!(stdout(), EnterAlternateScreen, cursor::Hide)
-            .whatever_context("failed to enter alter screen")?;
+        crossterm::execute!(
+            stdout(),
+            EnterAlternateScreen,
+            cursor::Hide,
+            EnableFocusChange
+        )
+        .whatever_context("failed to enter alter screen")?;
         self.start();
         Ok(())
     }
@@ -143,8 +150,13 @@ impl App {
             self.terminal
                 .flush()
                 .whatever_context("failed to flush terminal")?;
-            crossterm::execute!(stdout(), LeaveAlternateScreen, cursor::Show)
-                .whatever_context("faile to leave alter screen")?;
+            crossterm::execute!(
+                stdout(),
+                LeaveAlternateScreen,
+                cursor::Show,
+                DisableFocusChange
+            )
+            .whatever_context("faile to leave alter screen")?;
             crossterm::terminal::disable_raw_mode()
                 .whatever_context("failed to disable raw mode")?;
         }

--- a/crates/coco-tui/src/app.rs
+++ b/crates/coco-tui/src/app.rs
@@ -188,6 +188,8 @@ impl App {
                     Some(Ok(event)) => match event {
                         CrosstermEvent::Key(key) => Event::Key(key),
                         CrosstermEvent::Mouse(mouse) => Event::Mouse(mouse),
+                        CrosstermEvent::FocusGained => Event::FocusGained,
+                        CrosstermEvent::FocusLost => Event::FocusLost,
                         _ => continue, // ignore other events
                     }
                     Some(Err(err)) => {

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -72,6 +72,7 @@ pub struct Chat<'a> {
     last_usage: Option<UsageStats>,
     retry_status: Option<RetryAttempt>,
     transcript_scopes: Vec<TranscriptScope>,
+    terminal_focused: bool,
 
     token_schedule_session_save: Option<CancellationToken>,
     cancellation_guard: CancellationGuard,
@@ -272,6 +273,7 @@ impl Chat<'static> {
             last_usage: None,
             retry_status: None,
             transcript_scopes: Vec::new(),
+            terminal_focused: true,
             token_schedule_session_save: None,
             cancellation_guard: CancellationGuard::default(),
         }
@@ -787,6 +789,9 @@ impl Chat<'static> {
     }
 
     fn notify_reply_ready(&self, summary: Option<&str>) {
+        if !self.should_notify() {
+            return;
+        }
         let body = match summary {
             Some(text) if !text.trim().is_empty() => format!("Reply ready: {text}"),
             _ => "Reply ready".to_string(),
@@ -795,12 +800,26 @@ impl Chat<'static> {
     }
 
     fn notify_action_required(&self, reason: &str) {
+        if !self.should_notify() {
+            return;
+        }
         let body = if reason.trim().is_empty() {
             "Action required".to_string()
         } else {
             format!("Action required: {reason}")
         };
         notifications::send_osc9(NOTIFY_TITLE, &body);
+    }
+
+    fn should_notify(&self) -> bool {
+        let config = global::config_sync();
+        if !config.ui.notifications.enabled {
+            return false;
+        }
+        if config.ui.notifications.only_when_unfocused && self.terminal_focused {
+            return false;
+        }
+        true
     }
 
     fn reply_summary_from_messages(msgs: &[BotMessage]) -> Option<String> {
@@ -1597,6 +1616,12 @@ impl Component for Chat<'static> {
         match event {
             Event::Key(key) => {
                 self.handle_key_event(key);
+            }
+            Event::FocusGained => {
+                self.terminal_focused = true;
+            }
+            Event::FocusLost => {
+                self.terminal_focused = false;
             }
             Event::Combo(combo) => {
                 // Update agent's combo list when combos are discovered

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -788,6 +788,14 @@ impl Chat<'static> {
         }
     }
 
+    fn update_terminal_focused(&mut self, focused: bool) {
+        if self.terminal_focused == focused {
+            return;
+        }
+        self.terminal_focused = focused;
+        debug!(focused, "terminal focus changed");
+    }
+
     fn notify_reply_ready(&self, summary: Option<&str>) {
         let config = global::config_sync();
         if !self.should_notify(&config) {
@@ -818,6 +826,10 @@ impl Chat<'static> {
             return false;
         }
         if config.ui.notifications.only_when_unfocused && self.terminal_focused {
+            debug!(
+                focused = true,
+                "notification suppressed: only_when_unfocused enabled"
+            );
             return false;
         }
         true
@@ -1619,10 +1631,10 @@ impl Component for Chat<'static> {
                 self.handle_key_event(key);
             }
             Event::FocusGained => {
-                self.terminal_focused = true;
+                self.update_terminal_focused(true);
             }
             Event::FocusLost => {
-                self.terminal_focused = false;
+                self.update_terminal_focused(false);
             }
             Event::Combo(combo) => {
                 // Update agent's combo list when combos are discovered

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -789,18 +789,20 @@ impl Chat<'static> {
     }
 
     fn notify_reply_ready(&self, summary: Option<&str>) {
-        if !self.should_notify() {
+        let config = global::config_sync();
+        if !self.should_notify(&config) {
             return;
         }
         let body = match summary {
             Some(text) if !text.trim().is_empty() => format!("Reply ready: {text}"),
             _ => "Reply ready".to_string(),
         };
-        notifications::send_osc9(NOTIFY_TITLE, &body);
+        notifications::send_notification(NOTIFY_TITLE, &body, &config.ui.notifications.backend);
     }
 
     fn notify_action_required(&self, reason: &str) {
-        if !self.should_notify() {
+        let config = global::config_sync();
+        if !self.should_notify(&config) {
             return;
         }
         let body = if reason.trim().is_empty() {
@@ -808,11 +810,10 @@ impl Chat<'static> {
         } else {
             format!("Action required: {reason}")
         };
-        notifications::send_osc9(NOTIFY_TITLE, &body);
+        notifications::send_notification(NOTIFY_TITLE, &body, &config.ui.notifications.backend);
     }
 
-    fn should_notify(&self) -> bool {
-        let config = global::config_sync();
+    fn should_notify(&self, config: &Config) -> bool {
         if !config.ui.notifications.enabled {
             return false;
         }

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -46,6 +46,7 @@ use crate::{
     components::{CommandPalette, Content, Persistable},
     error::*,
     global::{self, State},
+    notifications,
     session::{self, Session},
     widgets::{BRAILLE_EIGHT_DOUBLE, Throbber, ThrobberState},
 };
@@ -182,6 +183,7 @@ enum TranscriptScope {
 
 const CTRL_C_WINDOW: Duration = Duration::from_secs(2);
 const SESSION_SUMMARY_MAX_LEN: usize = 80;
+const NOTIFY_TITLE: &str = "coco";
 #[derive(Debug, Default)]
 struct CancellationGuard {
     last_hit: State<Option<Instant>>,
@@ -782,6 +784,45 @@ impl Chat<'static> {
             self.cancellation_guard.reset();
             self.state.write().state = ChatState::Ready;
         }
+    }
+
+    fn notify_reply_ready(&self, summary: Option<&str>) {
+        let body = match summary {
+            Some(text) if !text.trim().is_empty() => format!("Reply ready: {text}"),
+            _ => "Reply ready".to_string(),
+        };
+        notifications::send_osc9(NOTIFY_TITLE, &body);
+    }
+
+    fn notify_action_required(&self, reason: &str) {
+        let body = if reason.trim().is_empty() {
+            "Action required".to_string()
+        } else {
+            format!("Action required: {reason}")
+        };
+        notifications::send_osc9(NOTIFY_TITLE, &body);
+    }
+
+    fn reply_summary_from_messages(msgs: &[BotMessage]) -> Option<String> {
+        let mut summary = None;
+        for msg in msgs {
+            if let BotMessage::Plain(text) = msg
+                && let Some(line) = Self::first_non_empty_line(text)
+            {
+                summary = Some(line);
+            }
+        }
+        summary
+    }
+
+    fn first_non_empty_line(text: &str) -> Option<String> {
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+        None
     }
 
     fn is_ready_for_exit(&self) -> bool {
@@ -1586,9 +1627,11 @@ impl Component for Chat<'static> {
                 self.messages.reset_stream();
                 // Check if there are any tool uses that will be executed
                 let has_tool_use = msgs.iter().any(|m| matches!(m, BotMessage::ToolUse(_)));
+                let reply_summary = Self::reply_summary_from_messages(msgs);
                 if !has_tool_use {
                     // Only set ready if no tools to execute
                     self.set_ready();
+                    self.notify_reply_ready(reply_summary.as_deref());
                 }
                 let mut new_messages = Vec::with_capacity(msgs.len());
                 let mut combo_tool_ids = Vec::new();
@@ -1660,6 +1703,7 @@ impl Component for Chat<'static> {
                     self.update_focus(Focus::Messages);
                     self.messages.focus(idx);
                 }
+                self.notify_action_required("Tool permission requested");
                 // Trigger session save after ask event
                 global::trigger_schedule_session_save();
             }
@@ -1670,6 +1714,7 @@ impl Component for Chat<'static> {
                     // Move focus to tool use message when confirmation is required
                     self.update_focus(Focus::Messages);
                     self.messages.focus(idx);
+                    self.notify_action_required("Text edit confirmation required");
                 }
                 // Trigger session save after ask event
                 global::trigger_schedule_session_save();

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -9,6 +9,8 @@ use crossterm::event::{KeyEvent, MouseEvent};
 pub enum Event {
     Key(KeyEvent),
     Mouse(MouseEvent),
+    FocusGained,
+    FocusLost,
 
     Ask(AskEvent),
     Answer(AnswerEvent),

--- a/crates/coco-tui/src/lib.rs
+++ b/crates/coco-tui/src/lib.rs
@@ -8,6 +8,7 @@ pub mod widgets;
 pub mod components;
 pub mod events;
 pub mod logging;
+mod notifications;
 pub mod theme;
 pub mod version;
 

--- a/crates/coco-tui/src/notifications.rs
+++ b/crates/coco-tui/src/notifications.rs
@@ -1,11 +1,36 @@
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    process::Stdio,
+};
+
+use code_combo::NotificationBackend;
+use serde::Serialize;
+use tokio::{io::AsyncWriteExt, process::Command};
 
 const OSC_PREFIX: &str = "\x1b]9;";
 const OSC_SUFFIX: &str = "\x07";
 const MAX_TITLE_LEN: usize = 64;
 const MAX_BODY_LEN: usize = 160;
 
-pub fn send_osc9(title: &str, body: &str) {
+#[derive(Serialize)]
+struct NotificationPayload {
+    title: String,
+    body: String,
+}
+
+pub fn send_notification(title: &str, body: &str, backend: &NotificationBackend) {
+    if title.trim().is_empty() && body.trim().is_empty() {
+        return;
+    }
+    match backend {
+        NotificationBackend::Osc9 => send_osc9(title, body),
+        NotificationBackend::ExternalCommand { executable, args } => {
+            send_external_command(executable, args, title, body);
+        }
+    }
+}
+
+fn send_osc9(title: &str, body: &str) {
     let Some(seq) = build_osc9(title, body) else {
         return;
     };
@@ -15,8 +40,8 @@ pub fn send_osc9(title: &str, body: &str) {
 }
 
 fn build_osc9(title: &str, body: &str) -> Option<String> {
-    let title = sanitize_field(title, MAX_TITLE_LEN);
-    let body = sanitize_field(body, MAX_BODY_LEN);
+    let title = normalize_field(title, MAX_TITLE_LEN, true);
+    let body = normalize_field(body, MAX_BODY_LEN, true);
     if title.is_empty() && body.is_empty() {
         return None;
     }
@@ -30,7 +55,37 @@ fn build_osc9(title: &str, body: &str) -> Option<String> {
     Some(format!("{OSC_PREFIX}{payload}{OSC_SUFFIX}"))
 }
 
-fn sanitize_field(value: &str, max_len: usize) -> String {
+fn send_external_command(executable: &str, args: &[String], title: &str, body: &str) {
+    let title = normalize_field(title, MAX_TITLE_LEN, false);
+    let body = normalize_field(body, MAX_BODY_LEN, false);
+    if title.is_empty() && body.is_empty() {
+        return;
+    }
+    let payload = NotificationPayload { title, body };
+    let Ok(payload_json) = serde_json::to_vec(&payload) else {
+        return;
+    };
+
+    let executable = executable.to_string();
+    let args = args.to_vec();
+    tokio::spawn(async move {
+        let mut cmd = Command::new(executable);
+        cmd.args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(_) => return,
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(&payload_json).await;
+        }
+        let _ = child.wait().await;
+    });
+}
+
+fn normalize_field(value: &str, max_len: usize, replace_semicolon: bool) -> String {
     if max_len == 0 {
         return String::new();
     }
@@ -44,7 +99,7 @@ fn sanitize_field(value: &str, max_len: usize) -> String {
                 continue;
             }
         }
-        if ch == ';' {
+        if replace_semicolon && ch == ';' {
             ch = ':';
         }
         if ch == ' ' {
@@ -81,5 +136,15 @@ mod tests {
         let seq = build_osc9("co;co", "line1\nline2\x1b[31m").expect("sequence");
         let payload = &seq[OSC_PREFIX.len()..seq.len() - OSC_SUFFIX.len()];
         assert_eq!(payload, "co:co;line1 line2[31m");
+    }
+
+    #[test]
+    fn notification_payload_json_is_stable() {
+        let payload = NotificationPayload {
+            title: "coco".to_string(),
+            body: "Reply ready".to_string(),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        assert_eq!(json, "{\"title\":\"coco\",\"body\":\"Reply ready\"}");
     }
 }

--- a/crates/coco-tui/src/notifications.rs
+++ b/crates/coco-tui/src/notifications.rs
@@ -1,0 +1,85 @@
+use std::io::{self, Write};
+
+const OSC_PREFIX: &str = "\x1b]9;";
+const OSC_SUFFIX: &str = "\x07";
+const MAX_TITLE_LEN: usize = 64;
+const MAX_BODY_LEN: usize = 160;
+
+pub fn send_osc9(title: &str, body: &str) {
+    let Some(seq) = build_osc9(title, body) else {
+        return;
+    };
+    let mut stdout = io::stdout();
+    let _ = stdout.write_all(seq.as_bytes());
+    let _ = stdout.flush();
+}
+
+fn build_osc9(title: &str, body: &str) -> Option<String> {
+    let title = sanitize_field(title, MAX_TITLE_LEN);
+    let body = sanitize_field(body, MAX_BODY_LEN);
+    if title.is_empty() && body.is_empty() {
+        return None;
+    }
+    let payload = if !title.is_empty() && !body.is_empty() {
+        format!("{title};{body}")
+    } else if !title.is_empty() {
+        title
+    } else {
+        body
+    };
+    Some(format!("{OSC_PREFIX}{payload}{OSC_SUFFIX}"))
+}
+
+fn sanitize_field(value: &str, max_len: usize) -> String {
+    if max_len == 0 {
+        return String::new();
+    }
+    let mut out = String::with_capacity(value.len().min(max_len));
+    let mut prev_space = false;
+    for mut ch in value.chars() {
+        if ch.is_control() {
+            if matches!(ch, '\n' | '\r' | '\t') {
+                ch = ' ';
+            } else {
+                continue;
+            }
+        }
+        if ch == ';' {
+            ch = ':';
+        }
+        if ch == ' ' {
+            if prev_space {
+                continue;
+            }
+            prev_space = true;
+        } else {
+            prev_space = false;
+        }
+        if out.len() + ch.len_utf8() > max_len {
+            break;
+        }
+        out.push(ch);
+    }
+    out.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn osc9_builds_payload_with_title_and_body() {
+        let seq = build_osc9("coco", "Reply ready").expect("sequence");
+        assert!(seq.starts_with(OSC_PREFIX));
+        assert!(seq.ends_with(OSC_SUFFIX));
+        let payload = &seq[OSC_PREFIX.len()..seq.len() - OSC_SUFFIX.len()];
+        assert_eq!(payload, "coco;Reply ready");
+    }
+
+    #[test]
+    fn osc9_sanitizes_control_chars_and_semicolons() {
+        let seq = build_osc9("co;co", "line1\nline2\x1b[31m").expect("sequence");
+        let payload = &seq[OSC_PREFIX.len()..seq.len() - OSC_SUFFIX.len()];
+        assert_eq!(payload, "co:co;line1 line2[31m");
+    }
+}

--- a/crates/coco-tui/src/notifications.rs
+++ b/crates/coco-tui/src/notifications.rs
@@ -6,6 +6,7 @@ use std::{
 use code_combo::NotificationBackend;
 use serde::Serialize;
 use tokio::{io::AsyncWriteExt, process::Command};
+use tracing::debug;
 
 const OSC_PREFIX: &str = "\x1b]9;";
 const OSC_SUFFIX: &str = "\x07";
@@ -23,8 +24,24 @@ pub fn send_notification(title: &str, body: &str, backend: &NotificationBackend)
         return;
     }
     match backend {
-        NotificationBackend::Osc9 => send_osc9(title, body),
+        NotificationBackend::Osc9 => {
+            debug!(
+                backend = "osc9",
+                title_len = title.len(),
+                body_len = body.len(),
+                "sending notification"
+            );
+            send_osc9(title, body);
+        }
         NotificationBackend::ExternalCommand { executable, args } => {
+            debug!(
+                backend = "external_command",
+                executable = %executable,
+                args = ?args,
+                title_len = title.len(),
+                body_len = body.len(),
+                "sending notification"
+            );
             send_external_command(executable, args, title, body);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ pub use provider::{
     ModelPreset, ModelRequestConfig, ProviderConfig, ProviderKind, RequestOptions,
     ThinkingBlocksMode,
 };
-pub use ui::{MarkdownRenderEngine, UI, UINotifications};
+pub use ui::{MarkdownRenderEngine, NotificationBackend, UI, UINotifications};
 
 type BoxError = Box<dyn StdError + Send + Sync>;
 
@@ -415,7 +415,7 @@ fn table_name_from_table(table: &toml::value::Table, path: &str) -> Result<Strin
 mod tests {
     use super::{
         Config, MarkdownRenderEngine, McpServerConnection, ModelPreset, ModelRequestConfig,
-        SafeCommandsMode, ThinkingBlocksMode, merge_config_values,
+        NotificationBackend, SafeCommandsMode, ThinkingBlocksMode, merge_config_values,
     };
 
     fn base_config() -> String {
@@ -466,6 +466,24 @@ mod tests {
         let config: Config = toml::from_str(&config_str).expect("parse config");
         assert!(!config.ui.notifications.enabled);
         assert!(!config.ui.notifications.only_when_unfocused);
+    }
+
+    #[test]
+    fn parse_config_with_notifications_external_command() {
+        let config_str = [
+            "[ui.notifications]",
+            "enabled = true",
+            "only_when_unfocused = true",
+            "backend = { type = \"external_command\", executable = \"notify-cmd\", args = [\"--json\"] }",
+        ]
+        .join("\n");
+        let config: Config = toml::from_str(&config_str).expect("parse config");
+        assert!(config.ui.notifications.enabled);
+        assert!(config.ui.notifications.only_when_unfocused);
+        assert!(matches!(
+            config.ui.notifications.backend,
+            NotificationBackend::ExternalCommand { .. }
+        ));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ pub use provider::{
     ModelPreset, ModelRequestConfig, ProviderConfig, ProviderKind, RequestOptions,
     ThinkingBlocksMode,
 };
-pub use ui::{MarkdownRenderEngine, UI};
+pub use ui::{MarkdownRenderEngine, UI, UINotifications};
 
 type BoxError = Box<dyn StdError + Send + Sync>;
 
@@ -80,7 +80,10 @@ pub struct Config {
 
 fn ui_is_default(ui: &UI) -> bool {
     let default = UI::default();
-    ui.theme == default.theme && matches!(ui.markdown_render_engine, MarkdownRenderEngine::Native)
+    ui.theme == default.theme
+        && matches!(ui.markdown_render_engine, MarkdownRenderEngine::Native)
+        && ui.notifications.enabled == default.notifications.enabled
+        && ui.notifications.only_when_unfocused == default.notifications.only_when_unfocused
 }
 
 impl Config {
@@ -455,6 +458,18 @@ mod tests {
         let config_str = format!("deny_tools = []\n{}", base_config());
         let config: Config = toml::from_str(&config_str).expect("parse config");
         assert_eq!(config.deny_tools, Some(Vec::new()));
+    }
+
+    #[test]
+    fn parse_config_with_notifications() {
+        let config_str = [
+            "[ui]",
+            "notifications = { enabled = false, only_when_unfocused = false }",
+        ]
+        .join("\n");
+        let config: Config = toml::from_str(&config_str).expect("parse config");
+        assert!(!config.ui.notifications.enabled);
+        assert!(!config.ui.notifications.only_when_unfocused);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,11 +79,7 @@ pub struct Config {
 }
 
 fn ui_is_default(ui: &UI) -> bool {
-    let default = UI::default();
-    ui.theme == default.theme
-        && matches!(ui.markdown_render_engine, MarkdownRenderEngine::Native)
-        && ui.notifications.enabled == default.notifications.enabled
-        && ui.notifications.only_when_unfocused == default.notifications.only_when_unfocused
+    ui == &UI::default()
 }
 
 impl Config {

--- a/src/config/ui.rs
+++ b/src/config/ui.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct UI {
     #[serde(default = "default_theme")]
     pub theme: String,
@@ -22,7 +22,7 @@ impl Default for UI {
     }
 }
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct UINotifications {
     #[serde(default = "default_notifications_enabled")]
     pub enabled: bool,
@@ -47,7 +47,7 @@ impl Default for UINotifications {
     }
 }
 
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum MarkdownRenderEngine {
     #[default]

--- a/src/config/ui.rs
+++ b/src/config/ui.rs
@@ -4,6 +4,8 @@ pub struct UI {
     pub theme: String,
     #[serde(default)]
     pub markdown_render_engine: MarkdownRenderEngine,
+    #[serde(default)]
+    pub notifications: UINotifications,
 }
 
 fn default_theme() -> String {
@@ -15,6 +17,32 @@ impl Default for UI {
         Self {
             theme: default_theme(),
             markdown_render_engine: MarkdownRenderEngine::default(),
+            notifications: UINotifications::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct UINotifications {
+    #[serde(default = "default_notifications_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_notifications_only_when_unfocused")]
+    pub only_when_unfocused: bool,
+}
+
+fn default_notifications_enabled() -> bool {
+    true
+}
+
+fn default_notifications_only_when_unfocused() -> bool {
+    true
+}
+
+impl Default for UINotifications {
+    fn default() -> Self {
+        Self {
+            enabled: default_notifications_enabled(),
+            only_when_unfocused: default_notifications_only_when_unfocused(),
         }
     }
 }

--- a/src/config/ui.rs
+++ b/src/config/ui.rs
@@ -28,6 +28,8 @@ pub struct UINotifications {
     pub enabled: bool,
     #[serde(default = "default_notifications_only_when_unfocused")]
     pub only_when_unfocused: bool,
+    #[serde(default)]
+    pub backend: NotificationBackend,
 }
 
 fn default_notifications_enabled() -> bool {
@@ -43,8 +45,21 @@ impl Default for UINotifications {
         Self {
             enabled: default_notifications_enabled(),
             only_when_unfocused: default_notifications_only_when_unfocused(),
+            backend: NotificationBackend::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NotificationBackend {
+    #[default]
+    Osc9,
+    ExternalCommand {
+        executable: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Default, PartialEq, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
Closes #135

## Summary

Implements OSC 9 escape sequence support for desktop notifications in the TUI, addressing the need for user notification when:
- Subagent requires user confirmation/feedback
- Long-running tasks complete
- Terminal is not in focus

## Changes

### Core Implementation
- **New notifications module** (crates/coco-tui/src/notifications.rs):
  - OSC 9 escape sequence backend (default)
  - External command backend support for custom notification handlers
  - Proper payload sanitization and length limits

### TUI Integration
- **Focus tracking** (app.rs, events.rs):
  - Added FocusGained/FocusLost event handling
  - Track terminal focus state to enable "only_when_unfocused" mode

- **Chat component** (components/chat.rs):
  - Notify when reply is ready (non-tool-use responses)
  - Notify when action is required (tool permissions, text edit confirmations)
  - Configurable notification behavior based on focus state

### Configuration
- **New config options** (src/config/ui.rs):
  ```toml
  [ui.notifications]
  enabled = true              # Enable/disable notifications
  only_when_unfocused = true  # Only notify when terminal loses focus
  backend = { type = "osc9" }  # or external_command
  ```

## Usage

Default (OSC 9) - works with modern terminal emulators:
```
[ui.notifications]
enabled = true
only_when_unfocused = true
```

Custom notification command:
```
[ui.notifications.backend]
type = "external_command"
executable = "notify-send"
args = ["--app-name", "coco", "--category", "im.received"]
```