### PR TITLE
feat: add gh and sleep commands to safe commands list

### DIFF
--- a/src/agent/safe_commands.toml
+++ b/src/agent/safe_commands.toml
@@ -210,3 +210,47 @@ flags = [{ name = "--dry-run", arg = "none" }]
 [[commands]]
 command = ["cargo", "check"]
 allow_any = true
+
+[[commands]]
+name = "sleep"
+allow_positional = true
+flags = [
+  { name = "--help", arg = "none" },
+  { name = "--version", arg = "none" },
+]
+
+[[commands]]
+command = ["gh", "--help"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "--version"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "issue", "list"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "issue", "view"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "pr", "list"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "pr", "view"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "repo", "view"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "release", "list"]
+allow_any = true
+
+[[commands]]
+command = ["gh", "release", "view"]
+allow_any = true


### PR DESCRIPTION
## Summary

This PR addresses #143 by adding `gh` (GitHub CLI) and `sleep` commands to the safe commands list.

## Changes

### 1. Sleep Command
- Added `sleep` command support
- Allows positional arguments for specifying duration
- Safe flags: `--help`, `--version`

### 2. GitHub CLI (gh) - Read-Only Operations
Added safe read-only `gh` commands:
- `gh --help` and `gh --version`
- `gh issue list` and `gh issue view`
- `gh pr list` and `gh pr view`
- `gh repo view`
- `gh release list` and `gh release view`

## Use Cases

These additions enable:
- **Automation workflows**: Query issues and PRs, monitor CI runs
- **Rate limiting**: Add delays between API calls
- **Monitoring**: Watch repository status and releases
- **Debugging**: Test timing-dependent behavior

## Security

All `gh` commands added are read-only operations (list/view only). Write operations like `gh issue create`, `gh pr create`, etc. remain restricted unless explicitly authorized.

Fixes #143