### PR TITLE
refactor: move combo execution into CLI command with session socket support

### DIFF
--- a/crates/coco-tui/src/actions.rs
+++ b/crates/coco-tui/src/actions.rs
@@ -43,7 +43,11 @@ impl Action {
 #[derive(Debug, Clone)]
 pub enum ComboAction {
     Discover,
-    Execute { name: String, args: Vec<String> },
+    Execute {
+        id: Option<String>,
+        name: String,
+        args: Vec<String>,
+    },
 }
 
 impl From<ComboAction> for Action {

--- a/crates/coco-tui/src/actions.rs
+++ b/crates/coco-tui/src/actions.rs
@@ -48,6 +48,13 @@ pub enum ComboAction {
         name: String,
         args: Vec<String>,
     },
+    /// Execute combo via Bash tool - used when TUI starts with `coco combo run`
+    /// This injects User Prompt + Assistant Bash ToolUse into agent history,
+    /// then spawns tool execution directly.
+    ExecuteViaBash {
+        name: String,
+        args: Vec<String>,
+    },
 }
 
 impl From<ComboAction> for Action {

--- a/crates/coco-tui/src/combo_run_bridge.rs
+++ b/crates/coco-tui/src/combo_run_bridge.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use code_combo::{ComboRunEvent, ComboRunMessage, ComboRunResult};
+use tokio::sync::mpsc::UnboundedSender;
+
+#[derive(Debug, Default)]
+pub struct ComboRunBridge {
+    inner: Mutex<HashMap<String, UnboundedSender<ComboRunMessage>>>,
+}
+
+impl ComboRunBridge {
+    pub fn register(&self, run_id: String, sender: UnboundedSender<ComboRunMessage>) -> bool {
+        let Ok(mut guard) = self.inner.lock() else {
+            return false;
+        };
+        if guard.contains_key(&run_id) {
+            return false;
+        }
+        guard.insert(run_id, sender);
+        true
+    }
+
+    pub fn send_event(&self, run_id: &str, event: ComboRunEvent) -> bool {
+        let Ok(mut guard) = self.inner.lock() else {
+            return false;
+        };
+        let Some(sender) = guard.get(run_id) else {
+            return false;
+        };
+        if sender.send(ComboRunMessage::Event(event)).is_err() {
+            guard.remove(run_id);
+            return false;
+        }
+        true
+    }
+
+    pub fn send_result(&self, run_id: &str, result: ComboRunResult) -> bool {
+        let Ok(mut guard) = self.inner.lock() else {
+            return false;
+        };
+        let Some(sender) = guard.get(run_id) else {
+            return false;
+        };
+        let sent = sender.send(ComboRunMessage::Result(result)).is_ok();
+        guard.remove(run_id);
+        sent
+    }
+
+    pub fn remove(&self, run_id: &str) {
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.remove(run_id);
+        }
+    }
+
+    pub fn contains(&self, run_id: &str) -> bool {
+        let Ok(guard) = self.inner.lock() else {
+            return false;
+        };
+        guard.contains_key(run_id)
+    }
+}

--- a/crates/coco-tui/src/combo_run_server.rs
+++ b/crates/coco-tui/src/combo_run_server.rs
@@ -40,6 +40,10 @@ impl ComboRunSessionServer {
         let server = SessionSocketServer::bind(&socket_path)
             .await
             .whatever_context("failed to bind session socket")?;
+        // Safety: set once during startup before spawning any tasks.
+        unsafe {
+            std::env::set_var("COCO_SESSION_SOCK", &socket_path);
+        }
 
         let shutdown = CancellationToken::new();
         let shutdown_task = shutdown.clone();
@@ -85,7 +89,18 @@ impl ComboRunSessionServer {
 
 async fn resolve_socket_path() -> Result<(PathBuf, Option<SessionEnv>)> {
     if let Ok(path) = std::env::var("COCO_SESSION_SOCK") {
-        return Ok((PathBuf::from(path), None));
+        let socket_path = PathBuf::from(path);
+        let parent_exists = socket_path
+            .parent()
+            .map(|parent| parent.exists())
+            .unwrap_or(false);
+        if parent_exists {
+            return Ok((socket_path, None));
+        }
+        warn!(
+            socket_path = %socket_path.display(),
+            "COCO_SESSION_SOCK parent dir missing; creating new session env"
+        );
     }
     let env = SessionEnv::builder()
         .build()

--- a/crates/coco-tui/src/combo_run_server.rs
+++ b/crates/coco-tui/src/combo_run_server.rs
@@ -1,0 +1,181 @@
+use std::path::{Path, PathBuf};
+
+use code_combo::{
+    ClientMessage, ComboRunMessage, ComboRunPayload, ComboRunResult, ServerConnection,
+    ServerMessage, SessionEnv, SessionSocketServer,
+};
+use snafu::prelude::*;
+use tokio::{net::UnixStream, sync::mpsc, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::{
+    actions::{Action, ComboAction},
+    combo_run_bridge::ComboRunBridge,
+    error::Result,
+    global,
+};
+
+pub struct ComboRunSessionServer {
+    socket_path: PathBuf,
+    shutdown: CancellationToken,
+    join_handle: JoinHandle<()>,
+    _session_env: Option<SessionEnv>,
+}
+
+impl ComboRunSessionServer {
+    pub async fn start(bridge: &'static ComboRunBridge) -> Result<Option<Self>> {
+        let (socket_path, session_env) = resolve_socket_path().await?;
+        if let Some(existing) = try_connect_existing(&socket_path).await? {
+            warn!(
+                socket_path = %existing.display(),
+                "session socket already in use; skipping combo run server"
+            );
+            return Ok(None);
+        }
+        if socket_path.exists() {
+            std::fs::remove_file(&socket_path)
+                .whatever_context("failed to remove existing session socket")?;
+        }
+        let server = SessionSocketServer::bind(&socket_path)
+            .await
+            .whatever_context("failed to bind session socket")?;
+
+        let shutdown = CancellationToken::new();
+        let shutdown_task = shutdown.clone();
+        let join_handle = tokio::spawn(async move {
+            loop {
+                let accept = tokio::select! {
+                    _ = shutdown_task.cancelled() => break,
+                    accept = server.accept() => accept,
+                };
+                let conn = match accept {
+                    Ok(conn) => conn,
+                    Err(err) => {
+                        warn!(?err, "failed to accept combo run connection");
+                        continue;
+                    }
+                };
+                tokio::spawn(async move {
+                    if let Err(err) = handle_connection(conn, bridge).await {
+                        warn!(?err, "combo run connection closed");
+                    }
+                });
+            }
+        });
+
+        Ok(Some(Self {
+            socket_path,
+            shutdown,
+            join_handle,
+            _session_env: session_env,
+        }))
+    }
+
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    pub async fn shutdown(self) {
+        self.shutdown.cancel();
+        let _ = self.join_handle.await;
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+async fn resolve_socket_path() -> Result<(PathBuf, Option<SessionEnv>)> {
+    if let Ok(path) = std::env::var("COCO_SESSION_SOCK") {
+        return Ok((PathBuf::from(path), None));
+    }
+    let env = SessionEnv::builder()
+        .build()
+        .whatever_context("failed to build session env")?;
+    let socket_path = env.socket_path().to_path_buf();
+    Ok((socket_path, Some(env)))
+}
+
+async fn try_connect_existing(path: &Path) -> Result<Option<PathBuf>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    match UnixStream::connect(path).await {
+        Ok(stream) => {
+            drop(stream);
+            Ok(Some(path.to_path_buf()))
+        }
+        Err(err) => {
+            debug!(?err, "failed to connect existing session socket");
+            Ok(None)
+        }
+    }
+}
+
+async fn handle_connection(
+    mut conn: ServerConnection,
+    bridge: &'static ComboRunBridge,
+) -> Result<()> {
+    let message = conn
+        .read_client_message()
+        .await
+        .whatever_context("failed to read client message")?;
+    match message {
+        ClientMessage::ComboRun(payload) => handle_combo_run(conn, payload, bridge).await,
+        other => {
+            warn!(?other, "unexpected message for combo run server");
+            Ok(())
+        }
+    }
+}
+
+async fn handle_combo_run(
+    mut conn: ServerConnection,
+    payload: ComboRunPayload,
+    bridge: &'static ComboRunBridge,
+) -> Result<()> {
+    let run_id = payload.run_id.clone();
+    let (tx, mut rx) = mpsc::unbounded_channel::<ComboRunMessage>();
+    if !bridge.register(run_id.clone(), tx) {
+        let result = ComboRunResult {
+            run_id,
+            success: false,
+            summary: "run_id already in use".to_string(),
+            tool_calls: 0,
+            error: Some("run_id already in use".to_string()),
+        };
+        conn.send_server_message(&ServerMessage::ComboRunResult(result))
+            .await
+            .whatever_context("failed to send combo run error")?;
+        return Ok(());
+    }
+
+    global::action_tx()
+        .send(Action::Combo(ComboAction::Execute {
+            id: Some(payload.run_id),
+            name: payload.combo_name,
+            args: payload.args,
+        }))
+        .ok();
+
+    while let Some(message) = rx.recv().await {
+        let send_result = match message {
+            ComboRunMessage::Event(event) => {
+                conn.send_server_message(&ServerMessage::ComboRunEvent(event))
+                    .await
+            }
+            ComboRunMessage::Result(result) => {
+                let send = conn
+                    .send_server_message(&ServerMessage::ComboRunResult(result))
+                    .await;
+                bridge.remove(&run_id);
+                return send.whatever_context("failed to send combo run result");
+            }
+        };
+        if let Err(err) = send_result {
+            bridge.remove(&run_id);
+            return Err(err).whatever_context("failed to send combo run event");
+        }
+    }
+
+    bridge.remove(&run_id);
+    Ok(())
+}

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,12 +1,14 @@
 use coco_macro::ComponentExt;
 use code_combo::tools::{
-    ComboEvent as ComboToolEvent, ComboInfo, ComboStreamKind, Final, RUN_COMBO_TOOL_NAME,
-    RUN_TASK_TOOL_NAME, RunComboInput, RunTaskInput, SubagentEvent,
+    ComboEvent as ComboToolEvent, ComboInfo, ComboStreamKind as ComboToolStreamKind, Final,
+    RUN_COMBO_TOOL_NAME, RUN_TASK_TOOL_NAME, RunComboInput, RunComboOutput, RunTaskInput,
+    SubagentEvent,
 };
 use code_combo::{
-    Agent, Block as ChatBlock, ChatResponse, ChatStreamUpdate, Config, Content as ChatContent,
-    Message as ChatMessage, Output, RetryAttempt, RetryNotifier, RetryUpdate, RuntimeOverrides,
-    Starter, StopReason, TextEdit, ToolUse, UsageStats, discover_starters, load_runtime_overrides,
+    Agent, Block as ChatBlock, ChatResponse, ChatStreamUpdate, ComboRunEvent, ComboRunResult,
+    ComboStreamKind as ComboRunStreamKind, Config, Content as ChatContent, Message as ChatMessage,
+    Output, RetryAttempt, RetryNotifier, RetryUpdate, RuntimeOverrides, Starter, StopReason,
+    TextEdit, ToolUse, UsageStats, discover_starters, load_runtime_overrides,
     save_runtime_overrides,
 };
 
@@ -633,10 +635,36 @@ impl Chat<'static> {
     }
 
     fn dispatch_combo_event(&mut self, event: ComboEvent) {
+        self.forward_combo_event_to_session(&event);
         self.handle_combo_event_from_tool(&event);
         let combo_event_wrapped = Event::Combo(event);
         let combo_event_ref = &combo_event_wrapped;
         handle_component_event!(self, combo_event_ref);
+    }
+
+    fn forward_combo_event_to_session(&self, event: &ComboEvent) {
+        let Some(run_id) = Self::combo_event_run_id(event) else {
+            return;
+        };
+        let Some(bridge) = global::combo_run_bridge() else {
+            return;
+        };
+        if !bridge.contains(run_id) {
+            return;
+        }
+        let run_event = Self::combo_event_to_run_event(event);
+        bridge.send_event(run_id, run_event);
+    }
+
+    fn forward_combo_result_to_session(&self, run_id: &str, output: &Final, is_error: bool) {
+        let Some(bridge) = global::combo_run_bridge() else {
+            return;
+        };
+        if !bridge.contains(run_id) {
+            return;
+        }
+        let result = combo_run_result_from_final(run_id, output, is_error);
+        bridge.send_result(run_id, result);
     }
 
     fn register_combo_tool_message(&mut self, id: String) {
@@ -711,8 +739,8 @@ impl Chat<'static> {
                 name: name.clone(),
                 index: *index,
                 kind: match kind {
-                    ComboStreamKind::Plain => BotStreamKind::Plain,
-                    ComboStreamKind::Thinking => BotStreamKind::Thinking,
+                    ComboToolStreamKind::Plain => BotStreamKind::Plain,
+                    ComboToolStreamKind::Thinking => BotStreamKind::Thinking,
                 },
                 text: text.clone(),
             },
@@ -766,6 +794,163 @@ impl Chat<'static> {
                 name: name.clone(),
                 messages: messages.clone(),
             },
+        }
+    }
+
+    fn combo_event_to_run_event(event: &ComboEvent) -> ComboRunEvent {
+        match event {
+            ComboEvent::Discovering => ComboRunEvent::Discovering,
+            ComboEvent::Discovered { starters } => ComboRunEvent::Discovered {
+                starters: starters.clone(),
+            },
+            ComboEvent::Executing {
+                id,
+                name,
+                command_line,
+            } => ComboRunEvent::Executing {
+                id: id.clone(),
+                name: name.clone(),
+                command_line: command_line.clone(),
+            },
+            ComboEvent::RecordStart { id, name, tool_use } => ComboRunEvent::RecordStart {
+                id: id.clone(),
+                name: name.clone(),
+                tool_use: tool_use.clone(),
+            },
+            ComboEvent::Output { id, name, chunk } => ComboRunEvent::Output {
+                id: id.clone(),
+                name: name.clone(),
+                chunk: chunk.clone(),
+            },
+            ComboEvent::RecordOutput {
+                id,
+                name,
+                tool_use_id,
+                chunk,
+            } => ComboRunEvent::RecordOutput {
+                id: id.clone(),
+                name: name.clone(),
+                tool_use_id: tool_use_id.clone(),
+                chunk: chunk.clone(),
+            },
+            ComboEvent::RecordEnd {
+                id,
+                name,
+                tool_use_id,
+                is_error,
+                output,
+            } => ComboRunEvent::RecordEnd {
+                id: id.clone(),
+                name: name.clone(),
+                tool_use_id: tool_use_id.clone(),
+                is_error: *is_error,
+                output: output.clone(),
+            },
+            ComboEvent::Prompt {
+                id,
+                name,
+                prompt,
+                thinking,
+            } => ComboRunEvent::Prompt {
+                id: id.clone(),
+                name: name.clone(),
+                prompt: prompt.clone(),
+                thinking: thinking.clone(),
+            },
+            ComboEvent::PromptStream {
+                id,
+                name,
+                index,
+                kind,
+                text,
+            } => ComboRunEvent::PromptStream {
+                id: id.clone(),
+                name: name.clone(),
+                index: *index,
+                kind: match kind {
+                    BotStreamKind::Plain => ComboRunStreamKind::Plain,
+                    BotStreamKind::Thinking => ComboRunStreamKind::Thinking,
+                },
+                text: text.clone(),
+            },
+            ComboEvent::PromptStreamReset { id, name } => ComboRunEvent::PromptStreamReset {
+                id: id.clone(),
+                name: name.clone(),
+            },
+            ComboEvent::ReplyToolUse {
+                id,
+                name,
+                tool_use,
+                thinking,
+                offload,
+            } => ComboRunEvent::ReplyToolUse {
+                id: id.clone(),
+                name: name.clone(),
+                tool_use: tool_use.clone(),
+                thinking: thinking.clone(),
+                offload: *offload,
+            },
+            ComboEvent::ReplyToolResult {
+                id,
+                name,
+                tool_use_id,
+                is_error,
+                output,
+            } => ComboRunEvent::ReplyToolResult {
+                id: id.clone(),
+                name: name.clone(),
+                tool_use_id: tool_use_id.clone(),
+                is_error: *is_error,
+                output: output.clone(),
+            },
+            ComboEvent::Executed {
+                id,
+                name,
+                starter,
+                exit_code,
+            } => ComboRunEvent::Executed {
+                id: id.clone(),
+                name: name.clone(),
+                starter: starter.clone(),
+                exit_code: *exit_code,
+            },
+            ComboEvent::ReplyToolError { message } => ComboRunEvent::ReplyToolError {
+                message: message.clone(),
+            },
+            ComboEvent::NotFound { id, name } => ComboRunEvent::NotFound {
+                id: id.clone(),
+                name: name.clone(),
+            },
+            ComboEvent::Cancelled { id, name } => ComboRunEvent::Cancelled {
+                id: id.clone(),
+                name: name.clone(),
+            },
+            ComboEvent::Transcript { id, name, messages } => ComboRunEvent::Transcript {
+                id: id.clone(),
+                name: name.clone(),
+                messages: messages.clone(),
+            },
+        }
+    }
+
+    fn combo_event_run_id(event: &ComboEvent) -> Option<&str> {
+        match event {
+            ComboEvent::Discovering | ComboEvent::Discovered { .. } => None,
+            ComboEvent::ReplyToolError { .. } => None,
+            ComboEvent::Cancelled { id, .. } => id.as_deref(),
+            ComboEvent::Executing { id, .. }
+            | ComboEvent::RecordStart { id, .. }
+            | ComboEvent::Output { id, .. }
+            | ComboEvent::RecordOutput { id, .. }
+            | ComboEvent::RecordEnd { id, .. }
+            | ComboEvent::Prompt { id, .. }
+            | ComboEvent::PromptStream { id, .. }
+            | ComboEvent::PromptStreamReset { id, .. }
+            | ComboEvent::ReplyToolUse { id, .. }
+            | ComboEvent::ReplyToolResult { id, .. }
+            | ComboEvent::Executed { id, .. }
+            | ComboEvent::NotFound { id, .. }
+            | ComboEvent::Transcript { id, .. } => Some(id.as_str()),
         }
     }
 
@@ -1789,6 +1974,7 @@ impl Component for Chat<'static> {
                 is_error,
                 output,
             }) => {
+                self.forward_combo_result_to_session(id, output, *is_error);
                 if let Some(idx) = self.messages.on_tool_event(event)
                     && !is_error
                     && self.messages.selected_idx() == Some(idx)
@@ -2054,8 +2240,10 @@ impl Component for Chat<'static> {
                 ComboAction::Discover => {
                     self.spawn_combo_discover();
                 }
-                ComboAction::Execute { name, args } => {
-                    let id = format!("toolu_{}", Uuid::new_v4().as_simple());
+                ComboAction::Execute { id, name, args } => {
+                    let id = id
+                        .clone()
+                        .unwrap_or_else(|| format!("toolu_{}", Uuid::new_v4().as_simple()));
                     let combo = Combo::new(&id, name);
                     self.messages.push(Message::user(combo.into()));
                     self.spawn_combo_execute(id, name.clone(), args.clone());
@@ -2392,6 +2580,66 @@ fn sanitize_session_summary(raw: &str) -> Option<String> {
 
 const TOOL_RESULT_MAX_BYTES: usize = 80 * 1024;
 const TOOL_RESULT_TRUNCATION_SUFFIX: &str = "\n... (truncated)";
+
+fn combo_run_result_from_final(run_id: &str, output: &Final, is_error: bool) -> ComboRunResult {
+    match output {
+        Final::Json(value) => combo_run_result_from_json(run_id, value, is_error),
+        Final::Message(message) => ComboRunResult {
+            run_id: run_id.to_string(),
+            success: !is_error,
+            summary: message.clone(),
+            tool_calls: 0,
+            error: if is_error {
+                Some(message.clone())
+            } else {
+                None
+            },
+        },
+    }
+}
+
+fn combo_run_result_from_json(run_id: &str, value: &Value, is_error: bool) -> ComboRunResult {
+    if let Ok(parsed) = serde_json::from_value::<RunComboOutput>(value.clone()) {
+        let error = if is_error && parsed.error.is_none() {
+            Some(parsed.summary.clone())
+        } else {
+            parsed.error.clone()
+        };
+        return ComboRunResult {
+            run_id: run_id.to_string(),
+            success: parsed.success,
+            summary: parsed.summary,
+            tool_calls: parsed.tool_calls,
+            error,
+        };
+    }
+
+    let success = value
+        .get("success")
+        .and_then(Value::as_bool)
+        .unwrap_or(!is_error);
+    let summary = value
+        .get("summary")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let tool_calls = value.get("tool_calls").and_then(Value::as_u64).unwrap_or(0) as usize;
+    let mut error = value
+        .get("error")
+        .and_then(Value::as_str)
+        .map(|value| value.to_string());
+    if is_error && error.is_none() {
+        error = Some(summary.clone());
+    }
+
+    ComboRunResult {
+        run_id: run_id.to_string(),
+        success,
+        summary,
+        tool_calls,
+        error,
+    }
+}
 
 fn final_to_tool_content(output: &Final) -> ChatContent {
     let text = match output {

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1011,12 +1011,15 @@ impl Chat<'static> {
     }
 
     fn format_combo_run_command(&self, name: &str, args: &[String]) -> String {
-        let mut command = format!("coco combo run {name}");
-        if !args.is_empty() {
-            command.push_str(" -- ");
-            command.push_str(&args.join(" "));
+        let mut parts = Vec::with_capacity(args.len() + 4);
+        parts.push("coco".to_string());
+        parts.push("combo".to_string());
+        parts.push("run".to_string());
+        parts.push(display_combo_arg(name));
+        for arg in args {
+            parts.push(display_combo_arg(arg));
         }
-        command
+        parts.join(" ")
     }
 
     fn spawn_tool_use(&mut self, tool_use: &ToolUse) {
@@ -1638,11 +1641,22 @@ impl Chat<'static> {
     }
 
     fn parse_combo_name_from_command(&self, command: &str) -> Option<String> {
-        let mut tokens = command.split_whitespace();
-        match (tokens.next(), tokens.next(), tokens.next(), tokens.next()) {
-            (Some("coco"), Some("combo"), Some("run"), Some(name)) => Some(name.to_string()),
-            _ => None,
+        let tokens: Vec<&str> = command.split_whitespace().collect();
+        for (idx, token) in tokens.iter().enumerate() {
+            if !is_combo_command_token(token)
+                || tokens.get(idx + 1) != Some(&"combo")
+                || tokens.get(idx + 2) != Some(&"run")
+            {
+                continue;
+            }
+            let mut name_idx = idx + 3;
+            if tokens.get(name_idx) == Some(&"--") {
+                name_idx += 1;
+            }
+            let name = tokens.get(name_idx)?;
+            return Some(trim_combo_token(name));
         }
+        None
     }
 
     fn ensure_transcript_focus(&mut self) {
@@ -2640,6 +2654,41 @@ fn add_usage(total: &mut UsageStats, delta: &UsageStats) {
     if let Some(delta_total) = delta.total_tokens {
         total.total_tokens = Some(total.total_tokens.unwrap_or(0) + delta_total);
     }
+}
+
+fn display_combo_arg(value: &str) -> String {
+    if value.is_empty() {
+        return "\"\"".to_string();
+    }
+    if value.bytes().all(|byte| {
+        matches!(byte, b'a'..=b'z'
+            | b'A'..=b'Z'
+            | b'0'..=b'9'
+            | b'_'
+            | b'-'
+            | b'.'
+            | b'/'
+            | b':')
+    }) {
+        return value.to_string();
+    }
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+fn is_combo_command_token(token: &str) -> bool {
+    if token == "coco" {
+        return true;
+    }
+    let trimmed = trim_combo_token(token);
+    std::path::Path::new(&trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "coco")
+}
+
+fn trim_combo_token(token: &str) -> String {
+    token.trim_matches('"').trim_matches('\'').to_string()
 }
 
 fn session_summary_prompt() -> String {

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -81,6 +81,14 @@ pub struct Chat<'a> {
     /// Combo IDs triggered via session socket (LLM Bash Tool calling `coco combo run`).
     /// These combos should NOT trigger spawn_chat_task on completion - the Bash Tool will.
     session_combo_ids: HashSet<String>,
+    /// Maps combo run_id to Bash Tool id for UI event routing.
+    /// When LLM's Bash Tool executes `coco combo run`, the Combo UI is created with Bash Tool's
+    /// id, but combo events use run_id. This mapping routes events to the correct UI.
+    combo_run_id_to_bash_id: HashMap<String, String>,
+    /// Pending Bash Tool ids waiting for combo execution via session socket.
+    /// Maps combo name to Bash Tool id. When ComboAction::Execute arrives, we look up
+    /// the Bash Tool id by name and establish the run_id -> bash_id mapping.
+    pending_bash_combo_ids: HashMap<String, String>,
     manual_combo_runs: HashSet<String>,
     manual_combo_tool_uses: HashSet<String>,
     manual_combo_commands: HashMap<String, String>,
@@ -294,6 +302,8 @@ impl Chat<'static> {
             combo_thinking_active: false,
             combo_tool_messages: HashSet::new(),
             session_combo_ids: HashSet::new(),
+            combo_run_id_to_bash_id: HashMap::new(),
+            pending_bash_combo_ids: HashMap::new(),
             manual_combo_runs: HashSet::new(),
             manual_combo_tool_uses: HashSet::new(),
             manual_combo_commands: HashMap::new(),
@@ -2069,6 +2079,22 @@ impl Component for Chat<'static> {
                                 } else {
                                     Message::bot(Tool::new(tool_use.to_owned()).into())
                                 }
+                            } else if tool_use.name == BASH_TOOL_NAME {
+                                // For Bash Tool executing `coco combo run`, create Combo UI
+                                // with permission support (Method 2)
+                                if let Some(name) = self.combo_name_from_bash_tool_use(&tool_use) {
+                                    // Record pending mapping for later run_id -> bash_id linkage
+                                    self.pending_bash_combo_ids
+                                        .insert(name.clone(), tool_use.id.clone());
+                                    combo_tool_ids.push(tool_use.id.clone());
+                                    // Create Combo UI with bash_tool_use for permission handling
+                                    Message::bot(
+                                        Combo::new_with_bash_tool_use(tool_use.to_owned(), &name)
+                                            .into(),
+                                    )
+                                } else {
+                                    Message::bot(Tool::new(tool_use.to_owned()).into())
+                                }
                             } else {
                                 Message::bot(Tool::new(tool_use.to_owned()).into())
                             }
@@ -2215,6 +2241,8 @@ impl Component for Chat<'static> {
                 // For session combos (triggered by LLM's Bash Tool), don't spawn_chat_task.
                 // The Bash Tool will complete and its ToolResult will trigger spawn_chat_task.
                 if self.session_combo_ids.remove(id) {
+                    // Clean up the run_id -> bash_id mapping
+                    self.combo_run_id_to_bash_id.remove(id);
                     global::trigger_schedule_session_save();
                     return;
                 }
@@ -2270,10 +2298,17 @@ impl Component for Chat<'static> {
                 global::trigger_schedule_session_save();
             }
             Event::Answer(AnswerEvent::ComboToolEvent { id, event }) => {
-                let combo_event = self.combo_tool_event_to_combo_event(id, event);
-                if !self.combo_tool_messages.contains(id) {
+                // For Method 2, Combo UI uses bash_id but events use run_id.
+                // Look up the bash_id mapping for routing.
+                let ui_id = self
+                    .combo_run_id_to_bash_id
+                    .get(id)
+                    .cloned()
+                    .unwrap_or_else(|| id.clone());
+                let combo_event = self.combo_tool_event_to_combo_event(&ui_id, event);
+                if !self.combo_tool_messages.contains(&ui_id) {
                     self.pending_combo_tool_events
-                        .entry(id.clone())
+                        .entry(ui_id)
                         .or_default()
                         .push(combo_event);
                     return;
@@ -2479,14 +2514,29 @@ impl Component for Chat<'static> {
                     // This is triggered by LLM's Bash Tool calling `coco combo run`.
                     // Track this combo so we don't trigger spawn_chat_task on completion -
                     // the Bash Tool will handle that when it completes.
-                    let id = id
+                    let run_id = id
                         .clone()
                         .unwrap_or_else(|| format!("toolu_{}", Uuid::new_v4().as_simple()));
-                    self.session_combo_ids.insert(id.clone());
-                    let combo = Combo::new(&id, name);
-                    self.messages.push(Message::bot(combo.into()));
-                    self.spawn_combo_execute(id, name.clone(), args.clone());
-                    debug!("Combo message pushed (via Bash Tool)");
+                    self.session_combo_ids.insert(run_id.clone());
+
+                    // Check if there's a pending Bash Tool for this combo (Method 2)
+                    if let Some(bash_id) = self.pending_bash_combo_ids.remove(name) {
+                        // Combo UI already exists with bash_id, establish mapping for event routing
+                        self.combo_run_id_to_bash_id
+                            .insert(run_id.clone(), bash_id.clone());
+                        debug!(
+                            "Combo execution started (run_id={}, bash_id={})",
+                            run_id, bash_id
+                        );
+                        // Combo UI is already registered via combo_tool_ids in bot message handling
+                        self.spawn_combo_execute(run_id, name.clone(), args.clone());
+                    } else {
+                        // No pending Bash Tool - create Combo UI (fallback for direct execution)
+                        let combo = Combo::new(&run_id, name);
+                        self.messages.push(Message::bot(combo.into()));
+                        self.register_combo_tool_message(run_id.clone());
+                        self.spawn_combo_execute(run_id, name.clone(), args.clone());
+                    }
                 }
                 ComboAction::ExecuteViaBash { name, args } => {
                     let tool_use_id = format!("toolu_{}", Uuid::new_v4().as_simple());

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -612,17 +612,11 @@ impl Chat<'static> {
     }
 
     fn spawn_combo_execute(&mut self, id: String, name: String, args: Vec<String>) {
-        // Create tool use for run_combo
-        let tool_use = ToolUse {
-            id,
-            name: RUN_COMBO_TOOL_NAME.to_string(),
-            input: serde_json::json!({ "combo_name": name, "args": args }),
-        };
-
-        // Grant permission and execute
-        self.agent.grant_once(&tool_use.id, &tool_use.name);
-        self.register_combo_tool_message(tool_use.id.clone());
-        self.spawn_tool_use(&tool_use);
+        self.set_processing();
+        self.register_combo_tool_message(id.clone());
+        let cancel_token = self.cancellation_guard.token();
+        let agent = self.agent.clone();
+        tokio::task::spawn(task_combo_execute(agent, id, name, args, cancel_token));
     }
 
     fn dispatch_combo_event(&mut self, event: ComboEvent) {
@@ -3302,6 +3296,65 @@ async fn task_tool_use(mut agent: Agent, tool_use: ToolUse, cancel_token: Cancel
             },
         )
         .await;
+}
+
+async fn task_combo_execute(
+    agent: Agent,
+    id: String,
+    name: String,
+    args: Vec<String>,
+    cancel_token: CancellationToken,
+) {
+    let tx = global::event_tx();
+    let auto_accept = agent.auto_accept_edits();
+    let id_for_event = id.clone();
+    let event_tx = tx.clone();
+    let output = agent
+        .execute_combo_with_output(name, args, cancel_token.clone(), move |event| {
+            let _ = event_tx.send(
+                AnswerEvent::ComboToolEvent {
+                    id: id_for_event.clone(),
+                    event: event.clone(),
+                }
+                .into(),
+            );
+        })
+        .await;
+    match Output::from(output) {
+        Output::Success(output) => {
+            let _ = tx.send(
+                AnswerEvent::ToolResult {
+                    id,
+                    is_error: false,
+                    is_user_cancelled: cancel_token.is_cancelled(),
+                    output,
+                }
+                .into(),
+            );
+        }
+        Output::Failure(output) => {
+            let _ = tx.send(
+                AnswerEvent::ToolResult {
+                    id,
+                    is_error: true,
+                    is_user_cancelled: cancel_token.is_cancelled(),
+                    output,
+                }
+                .into(),
+            );
+        }
+        Output::TextEdit(edit) => {
+            let _ = tx.send(
+                AskEvent::TextEdit {
+                    id,
+                    edit,
+                    auto_accept,
+                }
+                .into(),
+            );
+        }
+        _ => {}
+    }
 }
 
 async fn task_apply_text_edit(

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -78,6 +78,9 @@ pub struct Chat<'a> {
     prev_focus: Option<Focus>,
     combo_thinking_active: bool,
     combo_tool_messages: HashSet<String>,
+    /// Combo IDs triggered via session socket (LLM Bash Tool calling `coco combo run`).
+    /// These combos should NOT trigger spawn_chat_task on completion - the Bash Tool will.
+    session_combo_ids: HashSet<String>,
     manual_combo_runs: HashSet<String>,
     manual_combo_tool_uses: HashSet<String>,
     manual_combo_commands: HashMap<String, String>,
@@ -290,6 +293,7 @@ impl Chat<'static> {
             prev_focus: None,
             combo_thinking_active: false,
             combo_tool_messages: HashSet::new(),
+            session_combo_ids: HashSet::new(),
             manual_combo_runs: HashSet::new(),
             manual_combo_tool_uses: HashSet::new(),
             manual_combo_commands: HashMap::new(),
@@ -519,14 +523,14 @@ impl Chat<'static> {
             ComboEvent::ReplyToolUse { offload: true, .. } => {
                 self.set_processing();
             }
-            ComboEvent::Executed { id, starter, .. } => {
+            ComboEvent::Executed { starter, .. } => {
                 self.set_combo_thinking_active(false);
                 if let Err(err) = starter.combo.as_ref() {
                     warn!(?err, "Failed to execute starter");
                 }
-                if !self.manual_combo_runs.contains(id) {
-                    self.spawn_chat_with_history();
-                }
+                // Don't call spawn_chat_with_history here.
+                // For ExecuteViaBash: manual_combo_runs handles LLM trigger via ToolResult.
+                // For LLM Bash Tool: Bash Tool completion triggers LLM automatically.
             }
             ComboEvent::Discovered { .. }
             | ComboEvent::NotFound { .. }
@@ -602,11 +606,6 @@ impl Chat<'static> {
     fn spawn_chat_task(&mut self, content: ChatContent) {
         let cancel_token = self.cancellation_guard.start_token();
         tokio::task::spawn(task_chat(self.agent.clone(), content, cancel_token));
-    }
-
-    fn spawn_chat_with_history(&mut self) {
-        let cancel_token = self.cancellation_guard.start_token();
-        tokio::task::spawn(task_chat_with_history(self.agent.clone(), cancel_token));
     }
 
     fn spawn_combo_discover(&mut self) {
@@ -1024,14 +1023,14 @@ impl Chat<'static> {
                 }
                 self.handle_combo_event(event);
             }
-            ComboEvent::Executed { id, starter, .. } => {
+            ComboEvent::Executed { starter, .. } => {
                 self.set_combo_thinking_active(false);
                 if let Err(err) = starter.combo.as_ref() {
                     warn!(?err, "Failed to execute starter");
                 }
-                if !self.manual_combo_runs.contains(id) {
-                    self.spawn_chat_with_history();
-                }
+                // Don't call spawn_chat_with_history here.
+                // For ExecuteViaBash: manual_combo_runs handles LLM trigger via ToolResult.
+                // For LLM Bash Tool: Bash Tool completion triggers LLM automatically.
             }
             _ => self.handle_combo_event(event),
         }
@@ -2202,6 +2201,13 @@ impl Component for Chat<'static> {
                     return;
                 }
 
+                // For session combos (triggered by LLM's Bash Tool), don't spawn_chat_task.
+                // The Bash Tool will complete and its ToolResult will trigger spawn_chat_task.
+                if self.session_combo_ids.remove(id) {
+                    global::trigger_schedule_session_save();
+                    return;
+                }
+
                 // Build content for this tool result
                 let mut content = final_to_tool_content(output);
                 if *is_user_cancelled {
@@ -2459,16 +2465,53 @@ impl Component for Chat<'static> {
                     self.spawn_combo_discover();
                 }
                 ComboAction::Execute { id, name, args } => {
+                    // This is triggered by LLM's Bash Tool calling `coco combo run`.
+                    // Track this combo so we don't trigger spawn_chat_task on completion -
+                    // the Bash Tool will handle that when it completes.
                     let id = id
                         .clone()
                         .unwrap_or_else(|| format!("toolu_{}", Uuid::new_v4().as_simple()));
-                    self.manual_combo_runs.insert(id.clone());
-                    let command_line = self.format_combo_run_command(name, args);
-                    self.manual_combo_commands.insert(id.clone(), command_line);
+                    self.session_combo_ids.insert(id.clone());
                     let combo = Combo::new(&id, name);
-                    self.messages.push(Message::user(combo.into()));
+                    self.messages.push(Message::bot(combo.into()));
                     self.spawn_combo_execute(id, name.clone(), args.clone());
-                    debug!("Combo message pushed");
+                    debug!("Combo message pushed (via Bash Tool)");
+                }
+                ComboAction::ExecuteViaBash { name, args } => {
+                    let tool_use_id = format!("toolu_{}", Uuid::new_v4().as_simple());
+                    let command_line = self.format_combo_run_command(name, args);
+
+                    // 1. Register as manual combo run
+                    self.manual_combo_runs.insert(tool_use_id.clone());
+                    self.manual_combo_commands
+                        .insert(tool_use_id.clone(), command_line.clone());
+
+                    // 2. Inject User Prompt (agent history + UI)
+                    let prompt = format!("User use combo {command_line}");
+                    self.append_agent_message_sync(ChatMessage::user(ChatContent::Text(
+                        prompt.clone(),
+                    )));
+                    self.messages.push(Message::user(Plain::new(prompt).into()));
+
+                    // 3. Inject Assistant Bash ToolUse (agent history only, not executed)
+                    let tool_use = ToolUse {
+                        id: tool_use_id.clone(),
+                        name: BASH_TOOL_NAME.to_string(),
+                        input: serde_json::json!({ "command": command_line }),
+                    };
+                    self.append_agent_message_sync(ChatMessage::assistant(ChatContent::Multiple(
+                        vec![ChatBlock::ToolUse(tool_use.clone())],
+                    )));
+                    self.manual_combo_tool_uses.insert(tool_use_id.clone());
+                    self.manual_combo_prompted.insert(tool_use_id.clone());
+
+                    // 4. Create Combo UI (not Tool UI) and execute combo directly
+                    // We don't spawn_tool_use because that would execute bash which would
+                    // connect to session socket and create a different run_id
+                    let combo = Combo::new(&tool_use_id, name);
+                    self.messages.push(Message::bot(combo.into()));
+                    self.spawn_combo_execute(tool_use_id, name.clone(), args.clone());
+                    debug!("ExecuteViaBash: Combo UI created and combo spawned directly");
                 }
             },
             Action::Tool(action) => match action {
@@ -3066,97 +3109,6 @@ async fn task_chat(mut agent: Agent, content: ChatContent, cancel_token: Cancell
         let thinking_seen_stream = thinking_seen.clone();
         let resp = agent
             .chat_stream(msg, cancel_token.clone(), move |update| {
-                match update {
-                    ChatStreamUpdate::Reset => {
-                        plain_seen_stream.store(false, Ordering::Relaxed);
-                        thinking_seen_stream.store(false, Ordering::Relaxed);
-                        stream_tx.send(AnswerEvent::BotStreamReset.into()).ok();
-                    }
-                    ChatStreamUpdate::Plain { index, text } => {
-                        plain_seen_stream.store(true, Ordering::Relaxed);
-                        stream_tx
-                            .send(
-                                AnswerEvent::BotStream {
-                                    index,
-                                    kind: BotStreamKind::Plain,
-                                    text,
-                                }
-                                .into(),
-                            )
-                            .ok();
-                    }
-                    ChatStreamUpdate::Thinking { index, text } => {
-                        thinking_seen_stream.store(true, Ordering::Relaxed);
-                        stream_tx
-                            .send(
-                                AnswerEvent::BotStream {
-                                    index,
-                                    kind: BotStreamKind::Thinking,
-                                    text,
-                                }
-                                .into(),
-                            )
-                            .ok();
-                    }
-                };
-            })
-            .await;
-        streamed_plain = plain_seen.load(Ordering::Relaxed);
-        streamed_thinking = thinking_seen.load(Ordering::Relaxed);
-        resp
-    };
-
-    let chat_resp = match chat_resp {
-        Ok(resp) => resp,
-        Err(err) => {
-            if cancel_token.is_cancelled() {
-                tx.send(AnswerEvent::Cancelled.into()).ok();
-                return;
-            }
-            warn!(?err, "chat request failed");
-            tx.send(
-                AnswerEvent::Bot(vec![BotMessage::System(format!(
-                    "Chat request failed: {err}"
-                ))])
-                .into(),
-            )
-            .ok();
-            return;
-        }
-    };
-
-    handle_chat_response(
-        agent,
-        cancel_token,
-        chat_resp,
-        streamed_plain,
-        streamed_thinking,
-    )
-    .await;
-}
-
-async fn task_chat_with_history(mut agent: Agent, cancel_token: CancellationToken) {
-    let tx = global::event_tx();
-
-    if cancel_token.is_cancelled() {
-        return;
-    }
-    tx.send(Event::Ask(AskEvent::Bot)).unwrap();
-    tx.send(AnswerEvent::BotStreamReset.into()).ok();
-
-    let disable_stream = agent.disable_stream_for_current_model();
-    let mut streamed_plain = false;
-    let mut streamed_thinking = false;
-    let chat_resp = if disable_stream {
-        agent.chat_with_history().await
-    } else {
-        let stream_tx = tx.clone();
-        let plain_seen = Arc::new(AtomicBool::new(false));
-        let thinking_seen = Arc::new(AtomicBool::new(false));
-        let plain_seen_stream = plain_seen.clone();
-        let thinking_seen_stream = thinking_seen.clone();
-        let resp = agent
-            .chat_stream_with_history(cancel_token.clone(), move |update| {
                 match update {
                     ChatStreamUpdate::Reset => {
                         plain_seen_stream.store(false, Ordering::Relaxed);

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,8 +1,8 @@
 use coco_macro::ComponentExt;
 use code_combo::tools::{
-    ComboEvent as ComboToolEvent, ComboInfo, ComboStreamKind as ComboToolStreamKind, Final,
-    RUN_COMBO_TOOL_NAME, RUN_TASK_TOOL_NAME, RunComboInput, RunComboOutput, RunTaskInput,
-    SubagentEvent,
+    BASH_TOOL_NAME, BashOutput, ComboEvent as ComboToolEvent, ComboInfo,
+    ComboStreamKind as ComboToolStreamKind, Final, RUN_COMBO_TOOL_NAME, RUN_TASK_TOOL_NAME,
+    RunComboInput, RunComboOutput, RunTaskInput, SubagentEvent,
 };
 use code_combo::{
     Agent, Block as ChatBlock, ChatResponse, ChatStreamUpdate, ComboRunEvent, ComboRunResult,
@@ -78,6 +78,10 @@ pub struct Chat<'a> {
     prev_focus: Option<Focus>,
     combo_thinking_active: bool,
     combo_tool_messages: HashSet<String>,
+    manual_combo_runs: HashSet<String>,
+    manual_combo_tool_uses: HashSet<String>,
+    manual_combo_commands: HashMap<String, String>,
+    manual_combo_prompted: HashSet<String>,
     pending_combo_tool_events: HashMap<String, Vec<ComboEvent>>,
     last_usage: Option<UsageStats>,
     retry_status: Option<RetryAttempt>,
@@ -286,6 +290,10 @@ impl Chat<'static> {
             prev_focus: None,
             combo_thinking_active: false,
             combo_tool_messages: HashSet::new(),
+            manual_combo_runs: HashSet::new(),
+            manual_combo_tool_uses: HashSet::new(),
+            manual_combo_commands: HashMap::new(),
+            manual_combo_prompted: HashSet::new(),
             pending_combo_tool_events: HashMap::new(),
             last_usage: None,
             retry_status: None,
@@ -508,12 +516,14 @@ impl Chat<'static> {
             ComboEvent::ReplyToolUse { offload: true, .. } => {
                 self.set_processing();
             }
-            ComboEvent::Executed { starter, .. } => {
+            ComboEvent::Executed { id, starter, .. } => {
                 self.set_combo_thinking_active(false);
                 if let Err(err) = starter.combo.as_ref() {
                     warn!(?err, "Failed to execute starter");
                 }
-                self.spawn_chat_with_history();
+                if !self.manual_combo_runs.contains(id) {
+                    self.spawn_chat_with_history();
+                }
             }
             ComboEvent::Discovered { .. }
             | ComboEvent::NotFound { .. }
@@ -611,25 +621,6 @@ impl Chat<'static> {
 
         // Grant permission and execute
         self.agent.grant_once(&tool_use.id, &tool_use.name);
-        let agent = self.agent.clone();
-        let tool_use_message =
-            ChatMessage::assistant(ChatContent::Multiple(vec![ChatBlock::tool_use(
-                &tool_use.id,
-                &tool_use.name,
-                tool_use.input.clone(),
-            )]));
-        let mut prompt = format!("Run combo {}", name);
-        if !args.is_empty() {
-            prompt.push_str(" with args: ");
-            prompt.push_str(&args.join(" "));
-        }
-        let prompt_message = ChatMessage::user(ChatContent::Text(prompt));
-        tokio::spawn(async move {
-            if agent.dump_messages().await.is_empty() {
-                agent.append_message(prompt_message).await;
-            }
-            agent.append_message(tool_use_message).await;
-        });
         self.register_combo_tool_message(tool_use.id.clone());
         self.spawn_tool_use(&tool_use);
     }
@@ -956,14 +947,66 @@ impl Chat<'static> {
 
     fn handle_combo_event_from_tool(&mut self, event: &ComboEvent) {
         match event {
-            ComboEvent::Executed { starter, .. } => {
+            ComboEvent::Executing {
+                id, command_line, ..
+            } => {
+                if self.manual_combo_runs.contains(id) {
+                    self.manual_combo_commands
+                        .insert(id.clone(), command_line.clone());
+                    self.ensure_manual_combo_tool_use(id, command_line);
+                }
+                self.handle_combo_event(event);
+            }
+            ComboEvent::Executed { id, starter, .. } => {
                 self.set_combo_thinking_active(false);
                 if let Err(err) = starter.combo.as_ref() {
                     warn!(?err, "Failed to execute starter");
                 }
+                if !self.manual_combo_runs.contains(id) {
+                    self.spawn_chat_with_history();
+                }
             }
             _ => self.handle_combo_event(event),
         }
+    }
+
+    fn ensure_manual_combo_tool_use(&mut self, id: &str, command_line: &str) {
+        if !self.manual_combo_runs.contains(id) {
+            return;
+        }
+        self.ensure_manual_combo_prompt(id, command_line);
+        if !self.manual_combo_tool_uses.insert(id.to_string()) {
+            return;
+        }
+        let tool_use = ToolUse {
+            id: id.to_string(),
+            name: BASH_TOOL_NAME.to_string(),
+            input: serde_json::json!({ "command": command_line }),
+        };
+        let message =
+            ChatMessage::assistant(ChatContent::Multiple(vec![ChatBlock::ToolUse(tool_use)]));
+        self.append_agent_message_sync(message);
+    }
+
+    fn ensure_manual_combo_prompt(&mut self, id: &str, command_line: &str) {
+        if !self.manual_combo_runs.contains(id) {
+            return;
+        }
+        if !self.manual_combo_prompted.insert(id.to_string()) {
+            return;
+        }
+        let prompt = format!("User use combo {command_line}");
+        let message = ChatMessage::user(ChatContent::Text(prompt));
+        self.append_agent_message_sync(message);
+    }
+
+    fn append_agent_message_sync(&self, message: ChatMessage) {
+        let agent = self.agent.clone();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                agent.append_message(message).await;
+            });
+        });
     }
 
     fn spawn_tool_use(&mut self, tool_use: &ToolUse) {
@@ -1974,6 +2017,7 @@ impl Component for Chat<'static> {
                 is_error,
                 output,
             }) => {
+                let is_manual_combo = self.manual_combo_runs.contains(id);
                 self.forward_combo_result_to_session(id, output, *is_error);
                 if let Some(idx) = self.messages.on_tool_event(event)
                     && !is_error
@@ -1982,6 +2026,49 @@ impl Component for Chat<'static> {
                     // Move focus back to Input if tool use success.
                     self.update_focus(Focus::Input);
                     self.messages.blur();
+                }
+
+                if is_manual_combo {
+                    let command_line = self
+                        .manual_combo_commands
+                        .remove(id)
+                        .unwrap_or_else(|| format!("combo {id}"));
+                    self.ensure_manual_combo_tool_use(id, &command_line);
+                    let result = combo_run_result_from_final(id, output, *is_error);
+                    let mut summary = result.summary.trim().to_string();
+                    if summary.is_empty() {
+                        summary = result
+                            .error
+                            .clone()
+                            .unwrap_or_else(|| "Combo completed.".to_string());
+                    }
+                    let (stdout, stderr, exit_code) = if result.success {
+                        (summary.clone(), String::new(), 0)
+                    } else {
+                        let stderr = result.error.clone().unwrap_or_else(|| summary.clone());
+                        (summary.clone(), stderr, 1)
+                    };
+                    let bash_output = BashOutput {
+                        exit_code,
+                        stdout,
+                        stderr,
+                        timed_out: false,
+                    };
+                    let bash_value =
+                        serde_json::to_value(bash_output).unwrap_or(Value::String(summary));
+                    let content = final_to_tool_content(&Final::Json(bash_value));
+                    let content = ChatContent::Multiple(vec![ChatBlock::ToolResult {
+                        tool_use_id: id.clone(),
+                        is_error: Some(!result.success),
+                        content,
+                    }]);
+                    let content = self.build_user_content(content);
+                    self.spawn_chat_task(content);
+                    self.manual_combo_runs.remove(id);
+                    self.manual_combo_tool_uses.remove(id);
+                    self.manual_combo_prompted.remove(id);
+                    global::trigger_schedule_session_save();
+                    return;
                 }
 
                 // Build content for this tool result
@@ -2244,6 +2331,13 @@ impl Component for Chat<'static> {
                     let id = id
                         .clone()
                         .unwrap_or_else(|| format!("toolu_{}", Uuid::new_v4().as_simple()));
+                    self.manual_combo_runs.insert(id.clone());
+                    let mut command_line = name.clone();
+                    if !args.is_empty() {
+                        command_line.push(' ');
+                        command_line.push_str(&args.join(" "));
+                    }
+                    self.manual_combo_commands.insert(id.clone(), command_line);
                     let combo = Combo::new(&id, name);
                     self.messages.push(Message::user(combo.into()));
                     self.spawn_combo_execute(id, name.clone(), args.clone());

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1656,11 +1656,22 @@ impl Chat<'static> {
                     }
                     BASH_TOOL_NAME => {
                         if let Some(name) = self.combo_name_from_bash_tool_use(tool_use) {
+                            // For Bash Tool executing `coco combo run`, find the combo's
+                            // actual run_id from combo_transcripts since it differs from
+                            // the Bash Tool's id.
+                            let combo_id = self
+                                .state
+                                .read()
+                                .combo_transcripts
+                                .iter()
+                                .find(|entry| entry.name == name)
+                                .map(|entry| entry.id.clone())
+                                .unwrap_or_else(|| tool_use.id.clone());
                             map.insert(
                                 tool_use.id.clone(),
                                 TranscriptLinkTarget {
                                     kind: TranscriptLinkKind::Combo,
-                                    id: tool_use.id.clone(),
+                                    id: combo_id,
                                     name,
                                 },
                             );

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -951,9 +951,16 @@ impl Chat<'static> {
                 id, command_line, ..
             } => {
                 if self.manual_combo_runs.contains(id) {
-                    self.manual_combo_commands
-                        .insert(id.clone(), command_line.clone());
-                    self.ensure_manual_combo_tool_use(id, command_line);
+                    if !self.manual_combo_commands.contains_key(id) {
+                        self.manual_combo_commands
+                            .insert(id.clone(), command_line.clone());
+                    }
+                    let command_line = self
+                        .manual_combo_commands
+                        .get(id)
+                        .cloned()
+                        .unwrap_or_else(|| command_line.clone());
+                    self.ensure_manual_combo_tool_use(id, &command_line);
                 }
                 self.handle_combo_event(event);
             }
@@ -1007,6 +1014,15 @@ impl Chat<'static> {
                 agent.append_message(message).await;
             });
         });
+    }
+
+    fn format_combo_run_command(&self, name: &str, args: &[String]) -> String {
+        let mut command = format!("coco combo run {name}");
+        if !args.is_empty() {
+            command.push_str(" -- ");
+            command.push_str(&args.join(" "));
+        }
+        command
     }
 
     fn spawn_tool_use(&mut self, tool_use: &ToolUse) {
@@ -2332,11 +2348,7 @@ impl Component for Chat<'static> {
                         .clone()
                         .unwrap_or_else(|| format!("toolu_{}", Uuid::new_v4().as_simple()));
                     self.manual_combo_runs.insert(id.clone());
-                    let mut command_line = name.clone();
-                    if !args.is_empty() {
-                        command_line.push(' ');
-                        command_line.push_str(&args.join(" "));
-                    }
+                    let command_line = self.format_combo_run_command(name, args);
                     self.manual_combo_commands.insert(id.clone(), command_line);
                     let combo = Combo::new(&id, name);
                     self.messages.push(Message::user(combo.into()));

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1,6 +1,6 @@
 use coco_macro::ComponentExt;
 use code_combo::tools::{
-    BASH_TOOL_NAME, BashOutput, ComboEvent as ComboToolEvent, ComboInfo,
+    BASH_TOOL_NAME, BashInput, BashOutput, ComboEvent as ComboToolEvent, ComboInfo,
     ComboStreamKind as ComboToolStreamKind, Final, RUN_COMBO_TOOL_NAME, RUN_TASK_TOOL_NAME,
     RunComboInput, RunComboOutput, RunTaskInput, SubagentEvent,
 };
@@ -1592,6 +1592,18 @@ impl Chat<'static> {
                             );
                         }
                     }
+                    BASH_TOOL_NAME => {
+                        if let Some(name) = self.combo_name_from_bash_tool_use(tool_use) {
+                            map.insert(
+                                tool_use.id.clone(),
+                                TranscriptLinkTarget {
+                                    kind: TranscriptLinkKind::Combo,
+                                    id: tool_use.id.clone(),
+                                    name,
+                                },
+                            );
+                        }
+                    }
                     RUN_TASK_TOOL_NAME => {
                         if let Ok(input) =
                             serde_json::from_value::<RunTaskInput>(tool_use.input.clone())
@@ -1611,6 +1623,32 @@ impl Chat<'static> {
             }
         }
         map
+    }
+
+    fn combo_name_from_bash_tool_use(&self, tool_use: &ToolUse) -> Option<String> {
+        let input = serde_json::from_value::<BashInput>(tool_use.input.clone()).ok()?;
+        let name = self.parse_combo_name_from_command(&input.command)?;
+        Some(
+            self.combo_name_from_transcript(&tool_use.id)
+                .unwrap_or(name),
+        )
+    }
+
+    fn combo_name_from_transcript(&self, id: &str) -> Option<String> {
+        let state = self.state.read();
+        state
+            .combo_transcripts
+            .iter()
+            .find(|entry| entry.id == id)
+            .map(|entry| entry.name.clone())
+    }
+
+    fn parse_combo_name_from_command(&self, command: &str) -> Option<String> {
+        let mut tokens = command.split_whitespace();
+        match (tokens.next(), tokens.next(), tokens.next(), tokens.next()) {
+            (Some("coco"), Some("combo"), Some("run"), Some(name)) => Some(name.to_string()),
+            _ => None,
+        }
     }
 
     fn ensure_transcript_focus(&mut self) {

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -502,7 +502,10 @@ impl Chat<'static> {
             | ComboEvent::RecordOutput { .. }
             | ComboEvent::RecordEnd { .. }
             | ComboEvent::PromptStream { .. }
-            | ComboEvent::PromptStreamReset { .. } => {
+            | ComboEvent::PromptStreamReset { .. }
+            | ComboEvent::SummaryStream { .. }
+            | ComboEvent::SummaryStreamReset { .. }
+            | ComboEvent::SummaryDone { .. } => {
                 self.set_processing();
             }
             ComboEvent::Prompt { thinking, .. } => {
@@ -733,6 +736,35 @@ impl Chat<'static> {
                 id: id.to_string(),
                 name: name.clone(),
             },
+            ComboToolEvent::SummaryStreamReset { name } => ComboEvent::SummaryStreamReset {
+                id: id.to_string(),
+                name: name.clone(),
+            },
+            ComboToolEvent::SummaryStream {
+                name,
+                index,
+                kind,
+                text,
+            } => ComboEvent::SummaryStream {
+                id: id.to_string(),
+                name: name.clone(),
+                index: *index,
+                kind: match kind {
+                    ComboToolStreamKind::Plain => BotStreamKind::Plain,
+                    ComboToolStreamKind::Thinking => BotStreamKind::Thinking,
+                },
+                text: text.clone(),
+            },
+            ComboToolEvent::SummaryDone {
+                name,
+                summary,
+                thinking,
+            } => ComboEvent::SummaryDone {
+                id: id.to_string(),
+                name: name.clone(),
+                summary: summary.clone(),
+                thinking: thinking.clone(),
+            },
             ComboToolEvent::ReplyToolUse {
                 name,
                 tool_use,
@@ -862,6 +894,37 @@ impl Chat<'static> {
                 id: id.clone(),
                 name: name.clone(),
             },
+            ComboEvent::SummaryStreamReset { id, name } => ComboRunEvent::SummaryStreamReset {
+                id: id.clone(),
+                name: name.clone(),
+            },
+            ComboEvent::SummaryStream {
+                id,
+                name,
+                index,
+                kind,
+                text,
+            } => ComboRunEvent::SummaryStream {
+                id: id.clone(),
+                name: name.clone(),
+                index: *index,
+                kind: match kind {
+                    BotStreamKind::Plain => ComboRunStreamKind::Plain,
+                    BotStreamKind::Thinking => ComboRunStreamKind::Thinking,
+                },
+                text: text.clone(),
+            },
+            ComboEvent::SummaryDone {
+                id,
+                name,
+                summary,
+                thinking,
+            } => ComboRunEvent::SummaryDone {
+                id: id.clone(),
+                name: name.clone(),
+                summary: summary.clone(),
+                thinking: thinking.clone(),
+            },
             ComboEvent::ReplyToolUse {
                 id,
                 name,
@@ -931,6 +994,9 @@ impl Chat<'static> {
             | ComboEvent::Prompt { id, .. }
             | ComboEvent::PromptStream { id, .. }
             | ComboEvent::PromptStreamReset { id, .. }
+            | ComboEvent::SummaryStream { id, .. }
+            | ComboEvent::SummaryStreamReset { id, .. }
+            | ComboEvent::SummaryDone { id, .. }
             | ComboEvent::ReplyToolUse { id, .. }
             | ComboEvent::ReplyToolResult { id, .. }
             | ComboEvent::Executed { id, .. }
@@ -2104,6 +2170,9 @@ impl Component for Chat<'static> {
                             .clone()
                             .unwrap_or_else(|| "Combo completed.".to_string());
                     }
+                    let summary_thinking = summary_thinking_from_final(output);
+                    self.messages
+                        .append_combo_summary(id, &summary, &summary_thinking);
                     let (stdout, stderr, exit_code) = if result.success {
                         (summary.clone(), String::new(), 0)
                     } else {
@@ -2825,6 +2894,15 @@ fn combo_run_result_from_json(run_id: &str, value: &Value, is_error: bool) -> Co
         summary,
         tool_calls,
         error,
+    }
+}
+
+fn summary_thinking_from_final(output: &Final) -> Vec<String> {
+    match output {
+        Final::Json(value) => serde_json::from_value::<RunComboOutput>(value.clone())
+            .map(|parsed| parsed.summary_thinking)
+            .unwrap_or_default(),
+        Final::Message(_) => Vec::new(),
     }
 }
 

--- a/crates/coco-tui/src/components/message.rs
+++ b/crates/coco-tui/src/components/message.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::Thinking;
 use super::{Component, NavigationKey, NavigationResult, ShortcutHints};
 use crate::{
-    components::{Persistable, Tool},
+    components::{Combo, Persistable, Tool},
     error::*,
     global::{self},
     session::{self, Session},
@@ -139,11 +139,15 @@ impl Message {
     }
 
     pub fn is_same_tool_id(&self, id: &str) -> bool {
-        self.content
-            .as_any()
-            .downcast_ref::<Tool>()
-            .map(|tool| tool.tool_use_id() == id)
-            .unwrap_or_default()
+        // Check if this is a Tool with matching id
+        if let Some(tool) = self.content.as_any().downcast_ref::<Tool>() {
+            return tool.tool_use_id() == id;
+        }
+        // Check if this is a Combo with matching id (for Method 2 permission handling)
+        if let Some(combo) = self.content.as_any().downcast_ref::<Combo>() {
+            return combo.matches_id(id);
+        }
+        false
     }
 
     pub fn thinking_mut(&mut self) -> Option<&mut Thinking> {

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -585,6 +585,19 @@ impl Messages {
         None
     }
 
+    pub fn append_combo_summary(&mut self, id: &str, summary: &str, thinking: &[String]) -> bool {
+        let mut messages = self.messages.write();
+        for message in messages.iter_mut() {
+            let Some(combo) = message.content_as_mut_any().downcast_mut::<Combo>() else {
+                continue;
+            };
+            if combo.matches_id(id) {
+                return combo.append_summary(summary, thinking);
+            }
+        }
+        false
+    }
+
     fn ensure_focus_visible(
         &mut self,
         idx: usize,

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -12,9 +12,13 @@ use ratatui::{
     widgets::{Block, Borders},
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use coco_highlight::Lang;
-use code_combo::{OutputChunk, StreamKind, ToolUse, tools::Final};
+use code_combo::{
+    OutputChunk, StreamKind, ToolUse,
+    tools::{Final, RunComboOutput},
+};
 
 use super::RoleMergeMode;
 use super::fold::FoldState;
@@ -70,6 +74,8 @@ struct Inner {
     view: ComboView,
     #[serde(default)]
     output_chunks: Vec<OutputChunk>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    summary: Option<String>,
 }
 
 impl Default for Inner {
@@ -83,6 +89,7 @@ impl Default for Inner {
             display_state: default_display_state(),
             view: ComboView::default(),
             output_chunks: Vec::new(),
+            summary: None,
         }
     }
 }
@@ -99,6 +106,8 @@ pub struct Combo {
     has_child_output: bool,
     is_recording: bool,
     combo_stream_suppressed: bool,
+    summary_streaming: bool,
+    summary_stream_has_output: bool,
 }
 
 const LIMIT: usize = 10;
@@ -134,10 +143,12 @@ impl Combo {
             has_child_output: false,
             is_recording: false,
             combo_stream_suppressed: false,
+            summary_streaming: false,
+            summary_stream_has_output: false,
         }
     }
 
-    fn matches_id(&self, id: &str) -> bool {
+    pub(crate) fn matches_id(&self, id: &str) -> bool {
         self.state.tool_use_id == id
     }
 
@@ -228,6 +239,36 @@ impl Combo {
         self.state.write().view = ComboView::Messages;
         self.messages
             .push(Message::bot(Thinking::new(thinking.to_string()).into()));
+    }
+
+    fn push_summary(&mut self, summary: &str) {
+        self.state.write().view = ComboView::Messages;
+        self.messages
+            .push(Message::bot(Plain::new(summary.to_string()).into()));
+    }
+
+    pub(crate) fn append_summary(&mut self, summary: &str, thinking: &[String]) -> bool {
+        if self.summary_streaming {
+            return false;
+        }
+        if self.state.summary.is_some() {
+            return false;
+        }
+        let trimmed = summary.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+        for block in thinking {
+            let block = block.trim();
+            if block.is_empty() {
+                continue;
+            }
+            self.messages
+                .push(Message::bot(Thinking::new(block.to_string()).into()));
+        }
+        self.state.write().summary = Some(trimmed.to_string());
+        self.push_summary(trimmed);
+        true
     }
 
     fn push_offload_bash_tool_use(&mut self, tool_use: ToolUse) {
@@ -371,6 +412,54 @@ impl Combo {
                         .append_stream_text(*index, *kind, text.clone());
                 }
             }
+            ComboEvent::SummaryStreamReset { id, .. } => {
+                if self.matches_id(id) {
+                    self.state.write().view = ComboView::Messages;
+                    self.messages.finalize_stream();
+                    self.messages.reset_stream();
+                    self.summary_streaming = true;
+                    self.summary_stream_has_output = false;
+                }
+            }
+            ComboEvent::SummaryStream {
+                id,
+                index,
+                kind,
+                text,
+                ..
+            } => {
+                if self.matches_id(id) {
+                    self.state.write().view = ComboView::Messages;
+                    if !text.is_empty() {
+                        self.summary_stream_has_output = true;
+                    }
+                    self.summary_streaming = true;
+                    self.messages
+                        .append_stream_text(*index, *kind, text.clone());
+                }
+            }
+            ComboEvent::SummaryDone {
+                id,
+                summary,
+                thinking,
+                ..
+            } => {
+                if self.matches_id(id) {
+                    self.messages.finalize_stream();
+                    self.messages.reset_stream();
+                    let streamed = self.summary_streaming && self.summary_stream_has_output;
+                    self.summary_streaming = false;
+                    self.summary_stream_has_output = false;
+                    if streamed {
+                        let trimmed = summary.trim();
+                        if !trimmed.is_empty() && self.state.summary.is_none() {
+                            self.state.write().summary = Some(trimmed.to_string());
+                        }
+                    } else {
+                        self.append_summary(summary, thinking);
+                    }
+                }
+            }
             ComboEvent::ReplyToolUse {
                 id,
                 tool_use,
@@ -415,12 +504,15 @@ impl Combo {
                     state.is_error = false;
                     state.view = ComboView::Messages;
                     state.output_chunks.clear();
+                    state.summary = None;
                     state.display_state.expand();
                     drop(state);
                     self.update_command_line(command_line.clone());
                     self.preview_lines = StreamedLines::new(Some(LIMIT));
                     self.messages.reset_stream();
                     self.messages.clear();
+                    self.summary_streaming = false;
+                    self.summary_stream_has_output = false;
                 }
             }
             ComboEvent::Executed {
@@ -465,6 +557,8 @@ impl Combo {
                     self.clear_combo_stream();
                     self.messages.finalize_stream();
                     self.messages.reset_stream();
+                    self.summary_streaming = false;
+                    self.summary_stream_has_output = false;
                     {
                         let mut state = self.state.write();
                         state.starter_state = StarterState::Cancelled;
@@ -814,6 +908,16 @@ impl Combo {
         spans.push(Span::raw(" "));
         spans
     }
+
+    fn maybe_append_summary(&mut self, output: &Final, is_error: bool) {
+        if self.state.summary.is_some() {
+            return;
+        }
+        let Some(summary) = combo_summary_from_output(output, is_error) else {
+            return;
+        };
+        self.append_summary(&summary.summary, &summary.thinking);
+    }
 }
 
 impl Content for Combo {
@@ -918,6 +1022,8 @@ impl Persistable for Combo {
             has_child_output: false,
             is_recording: false,
             combo_stream_suppressed: false,
+            summary_streaming: false,
+            summary_stream_has_output: false,
         };
         Ok(combo)
     }
@@ -979,8 +1085,20 @@ impl Component for Combo {
             Event::Combo(event) => {
                 self.on_combo_event(event);
             }
-            Event::Answer(AnswerEvent::ToolResult { .. })
-            | Event::Answer(AnswerEvent::ToolOutput { .. }) => {
+            Event::Answer(AnswerEvent::ToolResult {
+                id,
+                is_error,
+                output,
+                ..
+            }) => {
+                if self.matches_id(id) {
+                    self.maybe_append_summary(output, *is_error);
+                } else {
+                    // Route tool events to the correct child component by id
+                    self.messages.on_tool_event(event);
+                }
+            }
+            Event::Answer(AnswerEvent::ToolOutput { .. }) => {
                 // Route tool events to the correct child component by id
                 self.messages.on_tool_event(event);
             }
@@ -1049,6 +1167,68 @@ impl Component for Combo {
             NavigationResult::Moved
         } else {
             NavigationResult::Boundary
+        }
+    }
+}
+
+struct ComboSummary {
+    summary: String,
+    thinking: Vec<String>,
+}
+
+fn combo_summary_from_output(output: &Final, _is_error: bool) -> Option<ComboSummary> {
+    match output {
+        Final::Json(value) => {
+            if let Ok(parsed) = serde_json::from_value::<RunComboOutput>(value.clone()) {
+                let summary = parsed.summary.trim();
+                if !summary.is_empty() {
+                    return Some(ComboSummary {
+                        summary: summary.to_string(),
+                        thinking: parsed.summary_thinking,
+                    });
+                }
+                if let Some(error) = parsed.error {
+                    let error = error.trim();
+                    if !error.is_empty() {
+                        return Some(ComboSummary {
+                            summary: error.to_string(),
+                            thinking: parsed.summary_thinking,
+                        });
+                    }
+                }
+                return None;
+            }
+            let summary = value
+                .get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim();
+            if !summary.is_empty() {
+                return Some(ComboSummary {
+                    summary: summary.to_string(),
+                    thinking: Vec::new(),
+                });
+            }
+            value
+                .get("error")
+                .and_then(Value::as_str)
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .map(|summary| ComboSummary {
+                    summary,
+                    thinking: Vec::new(),
+                })
+        }
+        Final::Message(message) => {
+            let trimmed = message.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(ComboSummary {
+                    summary: trimmed.to_string(),
+                    thinking: Vec::new(),
+                })
+            }
         }
     }
 }

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use coco_highlight::Lang;
 use code_combo::{
     OutputChunk, StreamKind, ToolUse,
-    tools::{Final, RunComboOutput},
+    tools::{BashInput, Final, RunComboOutput},
 };
 
 use super::RoleMergeMode;
@@ -158,15 +158,22 @@ impl Combo {
     /// The Combo starts in Discovering state and will transition to AwaitingPermission
     /// when it receives AskEvent::ToolUsePermission.
     pub fn new_with_bash_tool_use(tool_use: ToolUse, name: &str) -> Self {
+        // Extract command from Bash ToolUse input
+        let command_line = serde_json::from_value::<BashInput>(tool_use.input.clone())
+            .map(|input| input.command)
+            .unwrap_or_default();
+        let command = Self::build_command_highlight(&command_line);
+
         Self {
             state: State::new(Inner {
                 tool_use_id: tool_use.id.clone(),
                 name: name.to_string(),
+                command_line,
                 starter_state: StarterState::Discovering,
                 bash_tool_use: Some(tool_use),
                 ..Default::default()
             }),
-            command: None,
+            command,
             messages: Messages::default()
                 .with_role_merge_mode(RoleMergeMode::MergeSkipFirstUser)
                 .with_compact_role(true),

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -30,7 +30,7 @@ use crate::{
         NavigationResult, Persistable, Plain, ShortcutHints, Thinking, Tool,
     },
     error::*,
-    events::{AnswerEvent, ComboEvent, Event},
+    events::{AnswerEvent, AskEvent, ComboEvent, Event},
     global::{self, State},
     session::{self, Session},
     theme::FinalizedTheme,
@@ -44,6 +44,8 @@ use prompt_reply::PromptReply;
 enum StarterState {
     #[default]
     Discovering,
+    /// Awaiting user permission for Bash Tool execution (Method 2)
+    AwaitingPermission,
     NotFound,
     Cancelled,
     Executing,
@@ -76,6 +78,9 @@ struct Inner {
     output_chunks: Vec<OutputChunk>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     summary: Option<String>,
+    /// Bash ToolUse for permission handling (Method 2: LLM calls `coco combo run` via Bash)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    bash_tool_use: Option<ToolUse>,
 }
 
 impl Default for Inner {
@@ -90,6 +95,7 @@ impl Default for Inner {
             view: ComboView::default(),
             output_chunks: Vec::new(),
             summary: None,
+            bash_tool_use: None,
         }
     }
 }
@@ -148,8 +154,39 @@ impl Combo {
         }
     }
 
+    /// Create a Combo for Method 2: LLM calls `coco combo run` via Bash Tool.
+    /// The Combo starts in Discovering state and will transition to AwaitingPermission
+    /// when it receives AskEvent::ToolUsePermission.
+    pub fn new_with_bash_tool_use(tool_use: ToolUse, name: &str) -> Self {
+        Self {
+            state: State::new(Inner {
+                tool_use_id: tool_use.id.clone(),
+                name: name.to_string(),
+                starter_state: StarterState::Discovering,
+                bash_tool_use: Some(tool_use),
+                ..Default::default()
+            }),
+            command: None,
+            messages: Messages::default()
+                .with_role_merge_mode(RoleMergeMode::MergeSkipFirstUser)
+                .with_compact_role(true),
+            preview_lines: default_preview_lines(),
+            is_focused: false,
+            is_child_focused: false,
+            has_child_output: false,
+            is_recording: false,
+            combo_stream_suppressed: false,
+            summary_streaming: false,
+            summary_stream_has_output: false,
+        }
+    }
+
     pub(crate) fn matches_id(&self, id: &str) -> bool {
         self.state.tool_use_id == id
+    }
+
+    fn requiring_permission(&self) -> bool {
+        matches!(self.state.starter_state, StarterState::AwaitingPermission)
     }
 
     fn has_collapsible_body(&self) -> bool {
@@ -869,6 +906,10 @@ impl Combo {
                 " Discovering combo starters...",
                 theme.ui.combo_title_state_discovering,
             ),
+            StarterState::AwaitingPermission => (
+                " Awaiting confirmation",
+                theme.ui.tool_title_state_pending_confirmation,
+            ),
             StarterState::NotFound => (" Not found", theme.ui.combo_title_state_not_found),
             StarterState::Cancelled => (" Cancelled", theme.ui.combo_title_state_cancelled),
             StarterState::Executing => (" Executing...", theme.ui.combo_title_state_executing),
@@ -935,7 +976,10 @@ impl Content for Combo {
     }
 
     fn is_actionable(&self) -> bool {
-        self.has_collapsible_body() || self.can_toggle_view() || self.can_focus_messages()
+        self.requiring_permission()
+            || self.has_collapsible_body()
+            || self.can_toggle_view()
+            || self.can_focus_messages()
     }
 
     fn focus_range(&self, width: u16) -> Option<Range<u16>> {
@@ -958,6 +1002,14 @@ impl Content for Combo {
     }
 
     fn shortcut_hints(&self) -> ShortcutHints {
+        // Show permission hints when awaiting confirmation
+        if self.requiring_permission() {
+            let mut hints = ShortcutHints::default();
+            hints.push_visible(&[("Run", "CR"), ("Allow in Session", "A")]);
+            hints.push_visible(&[("Cancel", "Esc")]);
+            return hints;
+        }
+
         if !self.has_collapsible_body() && !self.can_toggle_view() && !self.can_focus_messages() {
             return ShortcutHints::default();
         }
@@ -1040,6 +1092,34 @@ impl Component for Combo {
     }
 
     fn handle_key_event(&mut self, key: &KeyEvent) {
+        // Handle permission actions when awaiting confirmation
+        if self.requiring_permission() {
+            if let Some(tool_use) = self.state.bash_tool_use.clone() {
+                match (key.modifiers, key.code) {
+                    (KeyModifiers::NONE, KeyCode::Enter) => {
+                        self.state.write().starter_state = StarterState::Discovering;
+                        global::action_tx()
+                            .send(ToolAction::Grant(tool_use).into())
+                            .unwrap();
+                    }
+                    (KeyModifiers::NONE, KeyCode::Char('a') | KeyCode::Char('A')) => {
+                        self.state.write().starter_state = StarterState::Discovering;
+                        global::action_tx()
+                            .send(ToolAction::GrantSession(tool_use).into())
+                            .unwrap();
+                    }
+                    (KeyModifiers::NONE, KeyCode::Esc) => {
+                        self.state.write().starter_state = StarterState::Cancelled;
+                        global::action_tx()
+                            .send(ToolAction::Cancel(tool_use).into())
+                            .unwrap();
+                    }
+                    _ => {}
+                }
+            }
+            return;
+        }
+
         if self.is_child_focused {
             match (key.modifiers, key.code) {
                 (KeyModifiers::NONE, KeyCode::Esc) => self.clear_child_focus(),
@@ -1084,6 +1164,12 @@ impl Component for Combo {
         match event {
             Event::Combo(event) => {
                 self.on_combo_event(event);
+            }
+            Event::Ask(AskEvent::ToolUsePermission(id)) => {
+                // Handle permission request for Bash Tool (Method 2)
+                if self.matches_id(id) && self.state.bash_tool_use.is_some() {
+                    self.state.write().starter_state = StarterState::AwaitingPermission;
+                }
             }
             Event::Answer(AnswerEvent::ToolResult {
                 id,

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -144,6 +144,23 @@ pub enum ComboEvent {
         id: String,
         name: String,
     },
+    SummaryStreamReset {
+        id: String,
+        name: String,
+    },
+    SummaryStream {
+        id: String,
+        name: String,
+        index: usize,
+        kind: BotStreamKind,
+        text: String,
+    },
+    SummaryDone {
+        id: String,
+        name: String,
+        summary: String,
+        thinking: Vec<String>,
+    },
     /// Reply tool use from prompt, with optional offload via bash
     ReplyToolUse {
         id: String,

--- a/crates/coco-tui/src/events.rs
+++ b/crates/coco-tui/src/events.rs
@@ -79,7 +79,7 @@ pub enum AnswerEvent {
         id: String,
         event: SubagentEvent,
     },
-    /// Combo tool event (for run_combo tool).
+    /// Combo tool event (from combo execution).
     ComboToolEvent {
         id: String,
         event: ComboToolEvent,

--- a/crates/coco-tui/src/global.rs
+++ b/crates/coco-tui/src/global.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     actions::Action,
+    combo_run_bridge::ComboRunBridge,
     events::Event,
     theme::{FinalizedTheme, use_builtin_theme},
 };
@@ -20,6 +21,7 @@ static EVENT_TX: OnceLock<UnboundedSender<Event>> = OnceLock::new();
 static ACTION_TX: OnceLock<UnboundedSender<Action>> = OnceLock::new();
 static WORKSPACE_DIR: OnceLock<PathBuf> = OnceLock::new();
 static IGNORE_WORKSPACE_SCRIPTS: AtomicBool = AtomicBool::new(false);
+static COMBO_RUN_BRIDGE: OnceLock<ComboRunBridge> = OnceLock::new();
 /// Initialize the global event and action senders.
 ///
 /// This function can only be called once during the application's lifetime.
@@ -91,6 +93,14 @@ pub fn set_ignore_workspace_scripts(ignore: bool) {
 
 pub fn ignore_workspace_scripts() -> bool {
     IGNORE_WORKSPACE_SCRIPTS.load(Ordering::Relaxed)
+}
+
+pub fn init_combo_run_bridge() -> &'static ComboRunBridge {
+    COMBO_RUN_BRIDGE.get_or_init(ComboRunBridge::default)
+}
+
+pub fn combo_run_bridge() -> Option<&'static ComboRunBridge> {
+    COMBO_RUN_BRIDGE.get()
 }
 
 #[inline]

--- a/crates/coco-tui/src/lib.rs
+++ b/crates/coco-tui/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod actions;
 pub mod app;
+pub mod combo_run_bridge;
+pub mod combo_run_server;
 pub mod error;
 pub mod global;
 pub mod session;

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -141,7 +141,6 @@ async fn main() -> Result<()> {
     let matches = cmd.get_matches();
     let command_name = matches.subcommand_name().unwrap_or("coco").to_string();
     let mut args = Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
-    ensure_tty_or_session()?;
     global::set_ignore_workspace_scripts(args.ignore_workspace_scripts);
     if !args.prompt.is_empty() {
         ensure_whatever!(
@@ -186,6 +185,12 @@ async fn main() -> Result<()> {
             args.command.replace(command);
         }
     }
+
+    // TTY is required for TUI
+    ensure_whatever!(
+        std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
+        "stdin/stdout is not a TTY"
+    );
 
     coco_tui::logging::init()?;
 
@@ -267,14 +272,4 @@ fn has_session_socket() -> bool {
         );
         false
     }
-}
-
-fn ensure_tty_or_session() -> Result<()> {
-    let has_session = has_session_socket();
-    let has_tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
-    ensure_whatever!(
-        has_session || has_tty,
-        "stdin/stdout is not a TTY and COCO_SESSION_SOCK is not available"
-    );
-    Ok(())
 }

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -11,6 +11,7 @@ use snafu::prelude::*;
 use coco_tui::{
     actions::{Action, ComboAction},
     app,
+    combo_run_server::ComboRunSessionServer,
     components::Chat,
     error::Result,
     global, version,
@@ -187,13 +188,22 @@ async fn main() -> Result<()> {
     root_view.apply_runtime_overrides(overrides);
     root_view.setup().await;
     let mut app = app::App::new(Box::new(root_view))?;
+    let bridge = global::init_combo_run_bridge();
+    let combo_run_server = ComboRunSessionServer::start(bridge).await?;
     if let Some(prompt) = startup_prompt {
         app.send_action(Action::SubmitPrompt(prompt));
     }
     match args.command {
         Some(Commands::Combo(combo_cmd)) => match combo_cmd {
             ComboCommands::Run { name, args } => {
-                app.send_action(ComboAction::Execute { name, args }.into());
+                app.send_action(
+                    ComboAction::Execute {
+                        id: None,
+                        name,
+                        args,
+                    }
+                    .into(),
+                );
             }
         },
         Some(
@@ -215,6 +225,10 @@ async fn main() -> Result<()> {
     }
 
     let result = app.run().await;
+
+    if let Some(server) = combo_run_server {
+        server.shutdown().await;
+    }
 
     ratatui::restore();
 

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -107,27 +107,33 @@ impl TryFrom<Commands> for ClientCommand {
     type Error = Commands;
 
     fn try_from(value: Commands) -> std::result::Result<Self, Self::Error> {
-        match value {
-            Commands::Metadata { fields } => Ok(ClientCommand::Metadata { fields }),
-            Commands::Ask { prompt, schemas } => Ok(ClientCommand::Ask { prompt, schemas }),
-            Commands::Tell { prompt } => Ok(ClientCommand::Tell { prompt }),
-            Commands::Reply { fields } => Ok(ClientCommand::Reply { fields }),
+        let command = match value {
+            Commands::Metadata { fields } => ClientCommand::Metadata { fields },
+            Commands::Ask { prompt, schemas } => ClientCommand::Ask { prompt, schemas },
+            Commands::Tell { prompt } => ClientCommand::Tell { prompt },
+            Commands::Reply { fields } => ClientCommand::Reply { fields },
             Commands::Record {
                 wrap_result,
                 command,
-            } => Ok(ClientCommand::Record {
+            } => ClientCommand::Record {
                 wrap_result,
                 command,
-            }),
-            Commands::Mcp { args } => Ok(ClientCommand::Mcp { args }),
-            _ => Err(value),
-        }
+            },
+            Commands::Mcp { args } => ClientCommand::Mcp { args },
+            Commands::Combo(ComboCommands::Run { name, args }) => ClientCommand::ComboRun {
+                name,
+                args,
+                ignore_workspace_scripts: false,
+            },
+        };
+        Ok(command)
     }
 }
 
 #[snafu::report]
 #[tokio::main]
 async fn main() -> Result<()> {
+    ensure_tui_bin_env();
     let cmd = Args::command();
     let program = cmd.get_name().to_string();
     let matches = cmd.get_matches();
@@ -150,7 +156,14 @@ async fn main() -> Result<()> {
     };
     if let Some(command) = args.command.take() {
         match ClientCommand::try_from(command) {
-            Ok(command) => {
+            Ok(mut command) => {
+                if let ClientCommand::ComboRun {
+                    ignore_workspace_scripts,
+                    ..
+                } = &mut command
+                {
+                    *ignore_workspace_scripts = args.ignore_workspace_scripts;
+                }
                 init_client_logging(&program, &command);
                 return handle_client_command(&program, &command_name, command)
                     .await
@@ -233,4 +246,17 @@ async fn main() -> Result<()> {
     ratatui::restore();
 
     result
+}
+
+fn ensure_tui_bin_env() {
+    if std::env::var_os("COCO_TUI_BIN").is_some() {
+        return;
+    }
+    let Ok(path) = std::env::current_exe() else {
+        return;
+    };
+    // Safety: set once during startup before spawning any tasks.
+    unsafe {
+        std::env::set_var("COCO_TUI_BIN", path);
+    }
 }

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -221,14 +221,7 @@ async fn main() -> Result<()> {
     match args.command {
         Some(Commands::Combo(combo_cmd)) => match combo_cmd {
             ComboCommands::Run { name, args } => {
-                app.send_action(
-                    ComboAction::Execute {
-                        id: None,
-                        name,
-                        args,
-                    }
-                    .into(),
-                );
+                app.send_action(ComboAction::ExecuteViaBash { name, args }.into());
             }
         },
         Some(

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -133,7 +133,6 @@ impl TryFrom<Commands> for ClientCommand {
 #[snafu::report]
 #[tokio::main]
 async fn main() -> Result<()> {
-    ensure_tui_bin_env();
     let cmd = Args::command();
     let program = cmd.get_name().to_string();
     let matches = cmd.get_matches();
@@ -155,23 +154,32 @@ async fn main() -> Result<()> {
         Some(prompt)
     };
     if let Some(command) = args.command.take() {
-        match ClientCommand::try_from(command) {
-            Ok(mut command) => {
-                if let ClientCommand::ComboRun {
-                    ignore_workspace_scripts,
-                    ..
-                } = &mut command
-                {
-                    *ignore_workspace_scripts = args.ignore_workspace_scripts;
+        let should_handle_client = match &command {
+            Commands::Combo(ComboCommands::Run { .. }) => should_forward_combo_run_to_client(),
+            _ => true,
+        };
+
+        if should_handle_client {
+            match ClientCommand::try_from(command) {
+                Ok(mut command) => {
+                    if let ClientCommand::ComboRun {
+                        ignore_workspace_scripts,
+                        ..
+                    } = &mut command
+                    {
+                        *ignore_workspace_scripts = args.ignore_workspace_scripts;
+                    }
+                    init_client_logging(&program, &command);
+                    return handle_client_command(&program, &command_name, command)
+                        .await
+                        .whatever_context("failed to handle client command");
                 }
-                init_client_logging(&program, &command);
-                return handle_client_command(&program, &command_name, command)
-                    .await
-                    .whatever_context("failed to handle client command");
+                Err(command) => {
+                    args.command.replace(command);
+                }
             }
-            Err(command) => {
-                args.command.replace(command);
-            }
+        } else {
+            args.command.replace(command);
         }
     }
 
@@ -248,15 +256,18 @@ async fn main() -> Result<()> {
     result
 }
 
-fn ensure_tui_bin_env() {
-    if std::env::var_os("COCO_TUI_BIN").is_some() {
-        return;
-    }
-    let Ok(path) = std::env::current_exe() else {
-        return;
+fn should_forward_combo_run_to_client() -> bool {
+    let Some(path) = std::env::var_os("COCO_SESSION_SOCK") else {
+        return false;
     };
-    // Safety: set once during startup before spawning any tasks.
-    unsafe {
-        std::env::set_var("COCO_TUI_BIN", path);
+    let path = PathBuf::from(path);
+    if path.exists() {
+        true
+    } else {
+        warn!(
+            socket_path = %path.display(),
+            "session socket missing; running combo inside TUI"
+        );
+        false
     }
 }

--- a/crates/coco-tui/src/main.rs
+++ b/crates/coco-tui/src/main.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    io::IsTerminal,
+    path::{Path, PathBuf},
+};
 
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use code_combo::{
@@ -138,6 +141,7 @@ async fn main() -> Result<()> {
     let matches = cmd.get_matches();
     let command_name = matches.subcommand_name().unwrap_or("coco").to_string();
     let mut args = Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
+    ensure_tty_or_session()?;
     global::set_ignore_workspace_scripts(args.ignore_workspace_scripts);
     if !args.prompt.is_empty() {
         ensure_whatever!(
@@ -155,7 +159,7 @@ async fn main() -> Result<()> {
     };
     if let Some(command) = args.command.take() {
         let should_handle_client = match &command {
-            Commands::Combo(ComboCommands::Run { .. }) => should_forward_combo_run_to_client(),
+            Commands::Combo(ComboCommands::Run { .. }) => has_session_socket(),
             _ => true,
         };
 
@@ -256,7 +260,7 @@ async fn main() -> Result<()> {
     result
 }
 
-fn should_forward_combo_run_to_client() -> bool {
+fn has_session_socket() -> bool {
     let Some(path) = std::env::var_os("COCO_SESSION_SOCK") else {
         return false;
     };
@@ -266,8 +270,18 @@ fn should_forward_combo_run_to_client() -> bool {
     } else {
         warn!(
             socket_path = %path.display(),
-            "session socket missing; running combo inside TUI"
+            "session socket missing"
         );
         false
     }
+}
+
+fn ensure_tty_or_session() -> Result<()> {
+    let has_session = has_session_socket();
+    let has_tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+    ensure_whatever!(
+        has_session || has_tty,
+        "stdin/stdout is not a TTY and COCO_SESSION_SOCK is not available"
+    );
+    Ok(())
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -19,7 +19,7 @@ use tracing::warn;
 use crate::{
     Config, Error, PromptSchema, ProviderConfig, RequestOptions, Result, ResultDisplayExt,
     RetryAttempt as CoreRetryAttempt, RetryUpdate, StreamError, ThinkingBlocksMode, ThinkingConfig,
-    tools::{ComboInfo, RunComboContext, RunComboTool, RunTaskContext, RunTaskTool},
+    tools::{ComboEvent, ComboInfo, RunComboContext, RunTaskContext, RunTaskTool, run_combo},
 };
 use executor::PermissionControl;
 use prompt::{build_system_prompt_from_config, build_system_prompt_from_config_async};
@@ -61,7 +61,7 @@ pub struct Agent {
     /// Full agent configuration loaded at initialization
     agent_config: AgentConfig,
 
-    /// Shared context for run_combo tool.
+    /// Shared context for combo execution helpers.
     combo_context: Arc<Mutex<RunComboContext>>,
 
     /// Shared context for run_task tool (if subagents are configured).
@@ -392,8 +392,8 @@ impl Agent {
             None
         };
 
-        // Register run_combo tool with empty combo list initially
-        // Combos will be populated later via set_combos()
+        // Initialize combo context with empty combo list.
+        // Combos can be populated later via set_combos().
         let combo_context = Arc::new(Mutex::new(RunComboContext {
             combos: Vec::new(),
             envs: Vec::new(),
@@ -403,8 +403,6 @@ impl Agent {
             thinking_enabled: false,
             ignore_workspace_scripts: false,
         }));
-        let run_combo_tool = RunComboTool::new_with_shared_context(combo_context.clone());
-        executor.register_tool(std::sync::Arc::new(run_combo_tool));
 
         // Apply agent tools as base
         if let Some(tools) = agent_config.tools.as_deref() {
@@ -459,7 +457,7 @@ impl Agent {
         &self.executor
     }
 
-    /// Update the combo list for run_combo tool.
+    /// Update the combo list for combo execution.
     ///
     /// This should be called after combo discovery to populate the available combos.
     pub async fn set_combos(&self, combos: Vec<ComboInfo>) {
@@ -1205,6 +1203,29 @@ impl Agent {
         self.executor
             .execute_with_output(id, name, input, cancel_token, on_output)
             .await
+    }
+
+    pub async fn execute_combo_with_output<F>(
+        &self,
+        name: String,
+        args: Vec<String>,
+        cancel_token: CancellationToken,
+        on_event: F,
+    ) -> crate::tools::ExecuteResult
+    where
+        F: FnMut(&ComboEvent) + Send + 'static,
+    {
+        let input = json!({
+            "combo_name": name,
+            "args": args,
+        });
+        run_combo(
+            self.combo_context.clone(),
+            crate::tools::Input::Starter(input),
+            cancel_token,
+            on_event,
+        )
+        .await
     }
 
     fn thinking_payload(&self, request_options: &RequestOptions) -> Option<Thinking> {

--- a/src/agent/agent.toml
+++ b/src/agent/agent.toml
@@ -1,6 +1,6 @@
 [agent]
 # Builtin available tools
-tools = ["bash", "read", "list", "str_replace", "run_task", "run_combo"]
+tools = ["bash", "read", "list", "str_replace", "run_task"]
 
 # Builtin system prompt (inline content)
 [agent.system_prompt]

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -13,9 +13,8 @@ use crate::{
     AppliedTextEdit, OutputChunk, TextEdit, error,
     tools::{
         self, BASH_TOOL_NAME, BashInput, BashTool, ComboEvent, Final, LIST_TOOL_NAME, ListTool,
-        READ_TOOL_NAME, RUN_COMBO_TOOL_NAME, RUN_TASK_TOOL_NAME, ReadTool, RunComboTool,
-        RunTaskTool, STR_REPLACE_TOOL_NAME, StrReplaceTool, SubagentEvent, Tool, run_bash_chunked,
-        run_combo, run_task,
+        READ_TOOL_NAME, RUN_TASK_TOOL_NAME, ReadTool, RunTaskTool, STR_REPLACE_TOOL_NAME,
+        StrReplaceTool, SubagentEvent, Tool, run_bash_chunked, run_task,
     },
 };
 
@@ -291,7 +290,6 @@ impl Executor {
                             | READ_TOOL_NAME
                             | LIST_TOOL_NAME
                             | RUN_TASK_TOOL_NAME
-                            | RUN_COMBO_TOOL_NAME
                     )
                 {
                     on_output(Output::AskPermission);
@@ -397,84 +395,6 @@ impl Executor {
                 return Ok(ExecuteStatus::Completed);
             }
         }
-
-        // Special handling for run_combo tool to support streaming ComboEvents
-        if name == RUN_COMBO_TOOL_NAME
-            && let Some(run_combo_tool) = tool
-                .as_any()
-                .and_then(|any| any.downcast_ref::<RunComboTool>())
-        {
-            let input_value = match input {
-                Input::Starter(v) => v,
-                _ => {
-                    on_output(Output::Failure(Final::from(
-                        "run_combo requires Starter input",
-                    )));
-                    return Ok(ExecuteStatus::Completed);
-                }
-            };
-
-            let ctx = run_combo_tool.context();
-
-            let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
-
-            let task_cancel = cancel_token.clone();
-            let task_handle = tokio::spawn(async move {
-                run_combo(
-                    ctx,
-                    Input::Starter(input_value),
-                    task_cancel,
-                    move |event| {
-                        let _ = event_tx.send(event.clone());
-                    },
-                )
-                .await
-            });
-
-            let mut task_handle = std::pin::pin!(task_handle);
-
-            loop {
-                tokio::select! {
-                    event = event_rx.recv() => {
-                        match event {
-                            Some(e) => on_output(Output::ComboOutput(e)),
-                            None => {
-                                match task_handle.await {
-                                    Ok(output) => {
-                                        on_output(output.into());
-                                    }
-                                    Err(e) => {
-                                        on_output(Output::Failure(Final::from(format!("Combo task panicked: {}", e))));
-                                    }
-                                }
-                                break;
-                            }
-                        }
-                    }
-                    result = &mut task_handle => {
-                        while let Ok(e) = event_rx.try_recv() {
-                            on_output(Output::ComboOutput(e));
-                        }
-                        match result {
-                            Ok(output) => {
-                                on_output(output.into());
-                            }
-                            Err(e) => {
-                                on_output(Output::Failure(Final::from(format!("Combo task panicked: {}", e))));
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if cancel_token.is_cancelled() {
-                return Ok(ExecuteStatus::Cancelled);
-            } else {
-                return Ok(ExecuteStatus::Completed);
-            }
-        }
-        // Fall through to generic execution if downcast fails
 
         let output = tokio::select! {
             _ = cancel_token.cancelled() => {

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -14,7 +14,7 @@ use crate::{
     tools::{
         self, BASH_TOOL_NAME, BashInput, BashTool, ComboEvent, Final, LIST_TOOL_NAME, ListTool,
         READ_TOOL_NAME, RUN_TASK_TOOL_NAME, ReadTool, RunTaskTool, STR_REPLACE_TOOL_NAME,
-        StrReplaceTool, SubagentEvent, Tool, run_bash_chunked, run_task,
+        StrReplaceTool, SubagentEvent, Tool, extra_envs_for_bash_input, run_bash_chunked, run_task,
     },
 };
 
@@ -299,7 +299,9 @@ impl Executor {
         }
 
         if name == BASH_TOOL_NAME {
-            let output = run_bash_chunked(input, &self.bash_envs, cancel_token.clone(), |chunk| {
+            let mut envs = self.bash_envs.clone();
+            envs.extend(extra_envs_for_bash_input(&input));
+            let output = run_bash_chunked(input, &envs, cancel_token.clone(), |chunk| {
                 on_output(Output::ToolOutput(chunk.clone()));
             })
             .await;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,11 @@ pub enum ClientCommand {
         /// Reply fields as --field=value format
         fields: Vec<String>,
     },
+    ComboRun {
+        name: String,
+        args: Vec<String>,
+        ignore_workspace_scripts: bool,
+    },
     Record {
         wrap_result: bool,
         command: Vec<String>,
@@ -33,6 +38,7 @@ pub fn init_client_logging(program: &str, command: &ClientCommand) {
         ClientCommand::Ask { .. } => "ask",
         ClientCommand::Tell { .. } => "tell",
         ClientCommand::Reply { .. } => "reply",
+        ClientCommand::ComboRun { .. } => "combo-run",
         ClientCommand::Record { .. } => "record",
         ClientCommand::Mcp { .. } => "mcp",
     };
@@ -58,6 +64,13 @@ pub async fn handle_client_command(
         ClientCommand::Reply { fields } => crate::cmd::handle_reply(fields)
             .await
             .whatever_context("failed to handle reply"),
+        ClientCommand::ComboRun {
+            name,
+            args,
+            ignore_workspace_scripts,
+        } => crate::cmd::handle_combo_run(name, args, ignore_workspace_scripts)
+            .await
+            .whatever_context("failed to handle combo run"),
         ClientCommand::Record {
             wrap_result,
             command,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,8 +1,10 @@
+mod combo;
 mod mcp;
 mod metadata;
 mod prompt;
 mod record;
 
+pub use combo::handle_combo_run;
 pub use mcp::handle_mcp;
 pub use metadata::handle_metadata;
 pub use prompt::{handle_ask, handle_reply, handle_tell};

--- a/src/cmd/combo.rs
+++ b/src/cmd/combo.rs
@@ -155,6 +155,7 @@ fn emit_result(result: &ComboRunResult) -> Result<()> {
         summary: result.summary.clone(),
         tool_calls: result.tool_calls,
         error: result.error.clone(),
+        summary_thinking: Vec::new(),
     };
     let json =
         serde_json::to_string(&output).whatever_context("failed to serialize combo run output")?;

--- a/src/cmd/combo.rs
+++ b/src/cmd/combo.rs
@@ -40,7 +40,6 @@ pub async fn handle_combo_run(
         None => {
             let (result, mut child) = run_with_tui(payload, ignore_workspace_scripts).await?;
             wait_for_tui_exit(&mut child).await?;
-            emit_result(&result)?;
             if !result.success {
                 let error = result
                     .error

--- a/src/cmd/combo.rs
+++ b/src/cmd/combo.rs
@@ -1,0 +1,178 @@
+use std::{path::Path, path::PathBuf, process::Stdio, time::Duration};
+
+use snafu::prelude::*;
+use tokio::{process::Command, time::Instant};
+use tracing::{debug, info, warn};
+
+use crate::{
+    ComboRunPayload, ComboRunResult, SessionEnv, SessionSocketClient, error::Result,
+    tools::RunComboOutput,
+};
+
+pub async fn handle_combo_run(
+    name: String,
+    args: Vec<String>,
+    ignore_workspace_scripts: bool,
+) -> Result<()> {
+    ensure_whatever!(!name.trim().is_empty(), "combo name is required");
+    let payload = ComboRunPayload {
+        run_id: new_run_id(),
+        combo_name: name,
+        args,
+    };
+
+    let client = SessionSocketClient::from_env()
+        .await
+        .whatever_context("failed to read COCO_SESSION_SOCK")?;
+
+    match client {
+        Some(client) => {
+            let result = run_with_client(client, payload).await?;
+            emit_result(&result)?;
+            if !result.success {
+                let error = result
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "combo run failed".to_string());
+                whatever!("{error}");
+            }
+        }
+        None => {
+            let (result, mut child) = run_with_tui(payload, ignore_workspace_scripts).await?;
+            wait_for_tui_exit(&mut child).await?;
+            emit_result(&result)?;
+            if !result.success {
+                let error = result
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "combo run failed".to_string());
+                whatever!("{error}");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_with_client(
+    client: SessionSocketClient,
+    payload: ComboRunPayload,
+) -> Result<ComboRunResult> {
+    let mut session = client
+        .begin_combo_run(payload)
+        .await
+        .whatever_context("failed to start combo run session")?;
+    let result = session
+        .wait_for_result()
+        .await
+        .whatever_context("failed to wait for combo run result")?;
+    Ok(result)
+}
+
+async fn run_with_tui(
+    payload: ComboRunPayload,
+    ignore_workspace_scripts: bool,
+) -> Result<(ComboRunResult, tokio::process::Child)> {
+    let session_env = SessionEnv::builder()
+        .build()
+        .whatever_context("failed to build session env")?;
+    let socket_path = session_env.socket_path().to_path_buf();
+
+    let mut child = spawn_tui(&session_env, ignore_workspace_scripts).await?;
+    let client = wait_for_session(&socket_path, &mut child).await?;
+    info!(?socket_path, "session socket ready for combo run");
+    let result = run_with_client(client, payload).await?;
+    Ok((result, child))
+}
+
+async fn spawn_tui(
+    session_env: &SessionEnv,
+    ignore_workspace_scripts: bool,
+) -> Result<tokio::process::Child> {
+    let tui_bin = resolve_tui_command();
+    let mut cmd = Command::new(&tui_bin);
+    if ignore_workspace_scripts {
+        cmd.arg("--ignore-workspace-scripts");
+    }
+    cmd.env(session_env.socket_env_name(), session_env.socket_path());
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let child = cmd
+        .spawn()
+        .whatever_context("failed to start coco TUI process")?;
+    Ok(child)
+}
+
+async fn wait_for_session(
+    socket_path: &Path,
+    child: &mut tokio::process::Child,
+) -> Result<SessionSocketClient> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match SessionSocketClient::connect(socket_path).await {
+            Ok(client) => return Ok(client),
+            Err(err) => {
+                debug!(?err, "failed to connect to session socket");
+            }
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                whatever!(
+                    "TUI process exited before session socket was ready: {status} (set COCO_TUI_BIN if needed)"
+                );
+            }
+            Ok(None) => {}
+            Err(err) => {
+                warn!(?err, "failed to check TUI process status");
+            }
+        }
+
+        if Instant::now() >= deadline {
+            whatever!(
+                "timed out waiting for session socket at {:?} (set COCO_TUI_BIN if needed)",
+                socket_path
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn wait_for_tui_exit(child: &mut tokio::process::Child) -> Result<()> {
+    let status = child
+        .wait()
+        .await
+        .whatever_context("failed to wait for TUI process")?;
+    if !status.success() {
+        warn!(?status, "TUI exited with non-zero status");
+    }
+    Ok(())
+}
+
+fn emit_result(result: &ComboRunResult) -> Result<()> {
+    let output = RunComboOutput {
+        success: result.success,
+        summary: result.summary.clone(),
+        tool_calls: result.tool_calls,
+        error: result.error.clone(),
+    };
+    let json =
+        serde_json::to_string(&output).whatever_context("failed to serialize combo run output")?;
+    println!("{json}");
+    Ok(())
+}
+
+fn resolve_tui_command() -> PathBuf {
+    std::env::var_os("COCO_TUI_BIN")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("coco"))
+}
+
+fn new_run_id() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("run_{}_{}", std::process::id(), nanos)
+}

--- a/src/combo.rs
+++ b/src/combo.rs
@@ -20,10 +20,12 @@ mod starter;
 
 pub use discovery::*;
 pub use session::{
-    ClientMessage, ControlAction, MetadataPayload, MetadataResponse, PromptPayload, PromptSchema,
-    RecordChunkPayload, RecordControl, RecordEndPayload, RecordSession, RecordStartPayload,
-    ReplyPayload, ReplyValidation, ServerConnection, ServerMessage, SessionClientError,
-    SessionServerError, SessionSocketClient, SessionSocketServer, ThinkingConfig,
+    ClientMessage, ComboRunEvent, ComboRunMessage, ComboRunPayload, ComboRunResult,
+    ComboRunSession, ComboStreamKind, ControlAction, MetadataPayload, MetadataResponse,
+    PromptPayload, PromptSchema, RecordChunkPayload, RecordControl, RecordEndPayload,
+    RecordSession, RecordStartPayload, ReplyPayload, ReplyValidation, ServerConnection,
+    ServerMessage, SessionClientError, SessionServerError, SessionSocketClient,
+    SessionSocketServer, ThinkingConfig,
 };
 pub use session_env::{SessionEnv, SessionEnvBuilder, SessionEnvError};
 pub use starter::PromptResponseSender;

--- a/src/combo/session.rs
+++ b/src/combo/session.rs
@@ -9,7 +9,10 @@ use tokio::{
 };
 use tracing::{debug, warn};
 
-use crate::{MCP_SOCKET_ENV, McpRequest, McpResponse, exec::StreamKind};
+use crate::{
+    MCP_SOCKET_ENV, McpRequest, McpResponse, Message, OutputChunk, Starter, ToolUse,
+    exec::StreamKind, tools::Final,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
@@ -20,6 +23,7 @@ pub enum ClientMessage {
     RecordEnd(RecordEndPayload),
     Prompt(PromptPayload),
     Reply(ReplyPayload),
+    ComboRun(ComboRunPayload),
     Mcp(McpRequest),
 }
 
@@ -30,6 +34,8 @@ pub enum ServerMessage {
     PromptResponse(String),
     ReplyValidation(ReplyValidation),
     Metadata(MetadataResponse),
+    ComboRunEvent(ComboRunEvent),
+    ComboRunResult(ComboRunResult),
     Mcp(McpResponse),
 }
 
@@ -127,6 +133,133 @@ pub struct ReplyValidation {
     pub response: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ComboRunPayload {
+    pub run_id: String,
+    pub combo_name: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComboStreamKind {
+    Plain,
+    Thinking,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ComboRunEvent {
+    Discovering,
+    Discovered {
+        starters: Vec<Starter>,
+    },
+    Executing {
+        id: String,
+        name: String,
+        command_line: String,
+    },
+    RecordStart {
+        id: String,
+        name: String,
+        tool_use: ToolUse,
+    },
+    Output {
+        id: String,
+        name: String,
+        chunk: OutputChunk,
+    },
+    RecordOutput {
+        id: String,
+        name: String,
+        tool_use_id: String,
+        chunk: OutputChunk,
+    },
+    RecordEnd {
+        id: String,
+        name: String,
+        tool_use_id: String,
+        is_error: bool,
+        output: Final,
+    },
+    Prompt {
+        id: String,
+        name: String,
+        prompt: String,
+        thinking: Option<ThinkingConfig>,
+    },
+    PromptStream {
+        id: String,
+        name: String,
+        index: usize,
+        kind: ComboStreamKind,
+        text: String,
+    },
+    PromptStreamReset {
+        id: String,
+        name: String,
+    },
+    ReplyToolUse {
+        id: String,
+        name: String,
+        tool_use: ToolUse,
+        thinking: Vec<String>,
+        offload: bool,
+    },
+    ReplyToolResult {
+        id: String,
+        name: String,
+        tool_use_id: String,
+        is_error: bool,
+        output: Final,
+    },
+    Executed {
+        id: String,
+        name: String,
+        starter: Starter,
+        exit_code: Option<i32>,
+    },
+    ReplyToolError {
+        message: String,
+    },
+    NotFound {
+        id: String,
+        name: String,
+    },
+    Cancelled {
+        id: Option<String>,
+        name: Option<String>,
+    },
+    Transcript {
+        id: String,
+        name: String,
+        messages: Vec<Message>,
+    },
+}
+
+impl PartialEq for ComboRunEvent {
+    fn eq(&self, other: &Self) -> bool {
+        serde_json::to_value(self).ok() == serde_json::to_value(other).ok()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ComboRunResult {
+    pub run_id: String,
+    pub success: bool,
+    pub summary: String,
+    pub tool_calls: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ComboRunMessage {
+    Event(ComboRunEvent),
+    Result(ComboRunResult),
+}
+
 #[derive(Debug, Snafu)]
 #[snafu(module)]
 pub enum SessionClientError {
@@ -159,6 +292,9 @@ pub enum SessionClientError {
 
     #[snafu(display("record execution was interrupted by server"))]
     Interrupted,
+
+    #[snafu(display("combo run finished without a result"))]
+    ComboRunFinished,
 }
 
 pub type ClientResult<T, E = SessionClientError> = std::result::Result<T, E>;
@@ -246,6 +382,14 @@ impl SessionSocketClient {
             ServerMessage::ReplyValidation(validation) => Ok(validation),
             other => Err(SessionClientError::UnexpectedServerMessage { message: other }),
         }
+    }
+
+    pub async fn begin_combo_run(&self, payload: ComboRunPayload) -> ClientResult<ComboRunSession> {
+        self.send_message(&ClientMessage::ComboRun(payload)).await?;
+        Ok(ComboRunSession {
+            client: self.clone(),
+            finished: false,
+        })
     }
 
     pub async fn begin_record(&self, payload: RecordStartPayload) -> ClientResult<RecordSession> {
@@ -368,6 +512,38 @@ impl RecordSession {
                 return Err(SessionClientError::Interrupted);
             }
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComboRunSession {
+    client: SessionSocketClient,
+    finished: bool,
+}
+
+impl ComboRunSession {
+    pub async fn next_message(&mut self) -> ClientResult<Option<ComboRunMessage>> {
+        if self.finished {
+            return Ok(None);
+        }
+        let message = self.client.read_server_message().await?;
+        match message {
+            ServerMessage::ComboRunEvent(event) => Ok(Some(ComboRunMessage::Event(event))),
+            ServerMessage::ComboRunResult(result) => {
+                self.finished = true;
+                Ok(Some(ComboRunMessage::Result(result)))
+            }
+            other => Err(SessionClientError::UnexpectedServerMessage { message: other }),
+        }
+    }
+
+    pub async fn wait_for_result(&mut self) -> ClientResult<ComboRunResult> {
+        while let Some(message) = self.next_message().await? {
+            if let ComboRunMessage::Result(result) = message {
+                return Ok(result);
+            }
+        }
+        Err(SessionClientError::ComboRunFinished)
     }
 }
 
@@ -625,6 +801,93 @@ mod tests {
 
         let received = send_task.await.whatever_context("failed to join")?;
         assert_eq!(received, response);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[snafu::report]
+    async fn combo_run_stream_over_socket() -> Result<()> {
+        let (_dir, socket_path) = unique_socket_path()?;
+        let server = SessionSocketServer::bind(&socket_path)
+            .await
+            .whatever_context("failed to bind socket")?;
+
+        let payload = ComboRunPayload {
+            run_id: "run_1".to_string(),
+            combo_name: "demo".to_string(),
+            args: vec!["a".to_string()],
+        };
+        let client = SessionSocketClient::connect(&socket_path)
+            .await
+            .whatever_context("failed to connect socket path")?;
+
+        let send_payload = payload.clone();
+        let send_task = tokio::spawn(async move {
+            let mut session = client
+                .begin_combo_run(send_payload)
+                .await
+                .expect("begin combo run");
+            let event = session
+                .next_message()
+                .await
+                .expect("read event")
+                .expect("event message");
+            match event {
+                ComboRunMessage::Event(ComboRunEvent::Executing {
+                    id,
+                    name,
+                    command_line,
+                }) => {
+                    assert_eq!(id, "run_1");
+                    assert_eq!(name, "demo");
+                    assert_eq!(command_line, "coco combo run demo a");
+                }
+                other => panic!("unexpected combo event: {other:?}"),
+            }
+            let result = session
+                .next_message()
+                .await
+                .expect("read result")
+                .expect("result message");
+            match result {
+                ComboRunMessage::Result(result) => {
+                    assert!(result.success);
+                    assert_eq!(result.run_id, "run_1");
+                    assert_eq!(result.summary, "ok");
+                    assert_eq!(result.tool_calls, 0);
+                    assert!(result.error.is_none());
+                }
+                other => panic!("unexpected combo result: {other:?}"),
+            }
+        });
+
+        let mut conn = server.accept().await.whatever_context("failed to accept")?;
+        let event = conn
+            .read_client_message()
+            .await
+            .whatever_context("failed to read client message")?;
+        assert_eq!(event, ClientMessage::ComboRun(payload));
+
+        conn.send_server_message(&ServerMessage::ComboRunEvent(ComboRunEvent::Executing {
+            id: "run_1".to_string(),
+            name: "demo".to_string(),
+            command_line: "coco combo run demo a".to_string(),
+        }))
+        .await
+        .whatever_context("failed to send combo event")?;
+
+        conn.send_server_message(&ServerMessage::ComboRunResult(ComboRunResult {
+            run_id: "run_1".to_string(),
+            success: true,
+            summary: "ok".to_string(),
+            tool_calls: 0,
+            error: None,
+        }))
+        .await
+        .whatever_context("failed to send combo result")?;
+
+        send_task.await.whatever_context("failed to join")?;
 
         Ok(())
     }

--- a/src/combo/session.rs
+++ b/src/combo/session.rs
@@ -200,6 +200,24 @@ pub enum ComboRunEvent {
         id: String,
         name: String,
     },
+    SummaryStreamReset {
+        id: String,
+        name: String,
+    },
+    SummaryStream {
+        id: String,
+        name: String,
+        index: usize,
+        kind: ComboStreamKind,
+        text: String,
+    },
+    SummaryDone {
+        id: String,
+        name: String,
+        summary: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        thinking: Vec<String>,
+    },
     ReplyToolUse {
         id: String,
         name: String,

--- a/src/combo/starter.rs
+++ b/src/combo/starter.rs
@@ -10,6 +10,7 @@ use std::{
 
 use futures_core::Stream;
 use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use time::OffsetDateTime;
 use tokio::{
@@ -28,7 +29,8 @@ use crate::{
 };
 use serde_json::json;
 
-#[derive(Debug, Clone, Snafu)]
+#[derive(Debug, Clone, Serialize, Deserialize, Snafu)]
+#[serde(rename_all = "snake_case")]
 pub enum StarterError {
     #[snafu(display("Combo file is not excutable"))]
     NotExcutable,
@@ -38,7 +40,7 @@ pub enum StarterError {
     Cancelled,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Starter {
     pub path: String,
     pub combo: Result<Combo, StarterError>,
@@ -1054,6 +1056,12 @@ async fn handle_session_connection(
                     .build()
                 })?;
                 first_message = false;
+            }
+            ClientMessage::ComboRun(_) => {
+                return Err(InvalidSnafu {
+                    reason: "combo run is not allowed in combo session".to_string(),
+                }
+                .build());
             }
             ClientMessage::Mcp(_) => {
                 return Err(InvalidSnafu {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use snafu::prelude::*;
 #[derive(Debug, Parser)]
 #[command(name = "coco", version, long_version = version::long_version(), about)]
 struct Args {
+    /// Ignore workspace combo scripts under .coco/combos
+    #[arg(long)]
+    ignore_workspace_scripts: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -50,6 +53,18 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    #[command(subcommand)]
+    Combo(ComboCommands),
+}
+
+#[derive(Debug, Subcommand)]
+enum ComboCommands {
+    Run {
+        name: String,
+        /// Arguments passed to the combo starter
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 #[snafu::report]
@@ -70,6 +85,14 @@ async fn main() -> code_combo::Result<()> {
         } => ClientCommand::Record {
             wrap_result,
             command,
+        },
+        Commands::Combo(ComboCommands::Run {
+            name,
+            args: combo_args,
+        }) => ClientCommand::ComboRun {
+            name,
+            args: combo_args,
+            ignore_workspace_scripts: args.ignore_workspace_scripts,
         },
         Commands::Mcp { args } => ClientCommand::Mcp { args },
     };

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -32,7 +32,7 @@ pub use read::{
 };
 pub use run_combo::{
     ComboEvent, ComboInfo, ComboStreamKind, RUN_COMBO_TOOL_NAME, RunComboContext, RunComboInput,
-    RunComboOutput, RunComboTool, run_combo,
+    RunComboOutput, run_combo,
 };
 pub use run_task::{
     RUN_TASK_TOOL_NAME, RunTaskContext, RunTaskInput, RunTaskOutput, RunTaskTool, SubagentEvent,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -24,6 +24,7 @@ mod run_task;
 mod str_replace;
 
 use crate::{AppliedTextEdit, TextEdit};
+pub(crate) use bash::extra_envs_for_bash_input;
 pub(crate) use bash::run_bash_chunked;
 pub use bash::{BASH_TOOL_NAME, BashInput, BashOutput, BashTool, prepare_mcp_envs};
 pub use list::{DEFAULT_ENTRY_LIMIT, LIST_TOOL_NAME, ListInput, ListTool, MAX_ENTRY_LIMIT};

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -51,6 +51,48 @@ fn default_timeout_ms() -> u64 {
     600_000
 }
 
+fn extra_envs_for_bash_input(input: &Input<'_>) -> Vec<(String, String)> {
+    let Input::Starter(input) = input else {
+        return Vec::new();
+    };
+    let Ok(parsed) = serde_json::from_value::<BashInput>(input.clone()) else {
+        return Vec::new();
+    };
+    extra_envs_for_command(&parsed.command)
+}
+
+fn extra_envs_for_command(command: &str) -> Vec<(String, String)> {
+    if !is_coco_combo_run_command(command) {
+        return Vec::new();
+    }
+    let mut envs = Vec::new();
+    if let Ok(value) = std::env::var("COCO_SESSION_SOCK")
+        && !value.is_empty()
+    {
+        envs.push(("COCO_SESSION_SOCK".to_string(), value));
+    }
+    if let Ok(value) = std::env::var("COCO_TUI_BIN")
+        && !value.is_empty()
+    {
+        envs.push(("COCO_TUI_BIN".to_string(), value));
+    }
+    envs
+}
+
+fn is_coco_combo_run_command(command: &str) -> bool {
+    let mut tokens = command.split_whitespace();
+    let Some(first) = tokens.next() else {
+        return false;
+    };
+    let Some(second) = tokens.next() else {
+        return false;
+    };
+    let Some(third) = tokens.next() else {
+        return false;
+    };
+    first == "coco" && second == "combo" && third == "run"
+}
+
 pub const BASH_TOOL_NAME: &str = "bash";
 
 pub async fn run_bash_chunked<'a, F>(
@@ -220,7 +262,8 @@ impl Tool for BashTool {
     }
 
     async fn execute<'a>(&self, input: Input<'a>) -> ExecuteResult {
-        run_bash_chunked(input, &[], CancellationToken::new(), |_| {}).await
+        let extra_envs = extra_envs_for_bash_input(&input);
+        run_bash_chunked(input, &extra_envs, CancellationToken::new(), |_| {}).await
     }
 }
 

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -51,7 +51,7 @@ fn default_timeout_ms() -> u64 {
     600_000
 }
 
-fn extra_envs_for_bash_input(input: &Input<'_>) -> Vec<(String, String)> {
+pub(crate) fn extra_envs_for_bash_input(input: &Input<'_>) -> Vec<(String, String)> {
     let Input::Starter(input) = input else {
         return Vec::new();
     };
@@ -61,10 +61,7 @@ fn extra_envs_for_bash_input(input: &Input<'_>) -> Vec<(String, String)> {
     extra_envs_for_command(&parsed.command)
 }
 
-fn extra_envs_for_command(command: &str) -> Vec<(String, String)> {
-    if !is_coco_combo_run_command(command) {
-        return Vec::new();
-    }
+fn extra_envs_for_command(_command: &str) -> Vec<(String, String)> {
     let mut envs = Vec::new();
     if let Ok(value) = std::env::var("COCO_SESSION_SOCK")
         && !value.is_empty()
@@ -77,20 +74,6 @@ fn extra_envs_for_command(command: &str) -> Vec<(String, String)> {
         envs.push(("COCO_TUI_BIN".to_string(), value));
     }
     envs
-}
-
-fn is_coco_combo_run_command(command: &str) -> bool {
-    let mut tokens = command.split_whitespace();
-    let Some(first) = tokens.next() else {
-        return false;
-    };
-    let Some(second) = tokens.next() else {
-        return false;
-    };
-    let Some(third) = tokens.next() else {
-        return false;
-    };
-    first == "coco" && second == "combo" && third == "run"
 }
 
 pub const BASH_TOOL_NAME: &str = "bash";
@@ -166,10 +149,11 @@ where
             Vec::new()
         }
     };
+    let mut envs = envs;
+    envs.extend(extra_envs.iter().cloned());
     let mut proc = ExecCommand::from_argv(argv)
         .remove_env_prefix("COCO_")
         .envs(envs)
-        .envs(extra_envs.to_vec())
         .spawn_chunked(ChunkConfig {
             interval: Duration::ZERO,
         })

--- a/src/tools/run_combo.rs
+++ b/src/tools/run_combo.rs
@@ -1,12 +1,11 @@
-//! Run Combo Tool - Executes combo scripts within agent context.
+//! Combo runner - executes combo scripts within agent context.
 //!
-//! This tool allows the agent to execute combo scripts that have been
-//! discovered during startup. Combos are executable scripts that can
-//! perform complex operations with recorded tool calls.
+//! This module provides combo execution helpers and shared types.
+//! Combos are executable scripts that can perform complex operations
+//! with recorded tool calls.
 
 use std::{path::PathBuf, sync::Arc};
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
@@ -14,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use super::{
-    BASH_TOOL_NAME, BashInput, ExecuteResult, Final, Input, Output, Tool, prepare_mcp_envs,
+    BASH_TOOL_NAME, BashInput, ExecuteResult, Final, Input, Output, prepare_mcp_envs,
     run_bash_chunked,
 };
 use crate::{
@@ -28,7 +27,7 @@ pub const RUN_COMBO_TOOL_NAME: &str = "run_combo";
 
 type ComboEventCallback = Arc<std::sync::Mutex<Box<dyn FnMut(&ComboEvent) + Send>>>;
 
-/// Input parameters for the run_combo tool.
+/// Input parameters for combo execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunComboInput {
     /// Name of the combo to execute.
@@ -38,7 +37,7 @@ pub struct RunComboInput {
     pub args: Vec<String>,
 }
 
-/// Output from the run_combo tool.
+/// Output from combo execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunComboOutput {
     /// Whether the combo completed successfully.
@@ -210,77 +209,7 @@ pub struct RunComboContext {
     pub ignore_workspace_scripts: bool,
 }
 
-/// Tool for executing combo scripts.
-pub struct RunComboTool {
-    context: Arc<Mutex<RunComboContext>>,
-}
-
-impl RunComboTool {
-    /// Create a new RunComboTool with the given context.
-    pub fn new(context: RunComboContext) -> Self {
-        Self {
-            context: Arc::new(Mutex::new(context)),
-        }
-    }
-
-    /// Create a new RunComboTool with a shared context.
-    /// This allows external code to update the combo list after tool creation.
-    pub fn new_with_shared_context(context: Arc<Mutex<RunComboContext>>) -> Self {
-        Self { context }
-    }
-
-    /// Get the shared context.
-    pub fn context(&self) -> Arc<Mutex<RunComboContext>> {
-        self.context.clone()
-    }
-}
-
-#[async_trait]
-impl Tool for RunComboTool {
-    fn name(&self) -> &'static str {
-        RUN_COMBO_TOOL_NAME
-    }
-
-    fn description(&self) -> &'static str {
-        "Execute a combo script to perform predefined operations."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "combo_name": {
-                    "type": "string",
-                    "description": "Name of the combo to execute"
-                },
-                "args": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Arguments passed to the combo starter"
-                }
-            },
-            "required": ["combo_name"]
-        })
-    }
-
-    async fn execute<'a>(&self, input: Input<'a>) -> ExecuteResult {
-        run_combo(
-            self.context.clone(),
-            input,
-            CancellationToken::new(),
-            |_| {},
-        )
-        .await
-    }
-
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        Some(self)
-    }
-}
-
-/// Execute the run_combo tool with event callback support.
+/// Execute combo logic with event callback support.
 pub async fn run_combo<F>(
     context: Arc<Mutex<RunComboContext>>,
     input: Input<'_>,

--- a/src/tools/run_combo.rs
+++ b/src/tools/run_combo.rs
@@ -49,6 +49,9 @@ pub struct RunComboOutput {
     /// Optional error message if failed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Optional thinking blocks from the summary response.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub summary_thinking: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -130,6 +133,31 @@ pub enum ComboEvent {
     PromptStreamReset {
         /// Combo name.
         name: String,
+    },
+    /// Reset summary stream for combo summary.
+    SummaryStreamReset {
+        /// Combo name.
+        name: String,
+    },
+    /// Summary stream update for combo summary.
+    SummaryStream {
+        /// Combo name.
+        name: String,
+        /// Stream index.
+        index: usize,
+        /// Stream kind.
+        kind: ComboStreamKind,
+        /// Streamed text.
+        text: String,
+    },
+    /// Summary completion for combo summary.
+    SummaryDone {
+        /// Combo name.
+        name: String,
+        /// Summary text.
+        summary: String,
+        /// Thinking blocks.
+        thinking: Vec<String>,
     },
     /// Reply tool use from prompt.
     ReplyToolUse {
@@ -722,6 +750,7 @@ async fn execute_combo(
             summary: "Combo execution was cancelled".to_string(),
             tool_calls,
             error: Some("Cancelled".to_string()),
+            summary_thinking: Vec::new(),
         });
     }
 
@@ -742,6 +771,7 @@ async fn execute_combo(
             summary: summary_parts.join("\n"),
             tool_calls,
             error: Some(format!("Combo error: {}", e)),
+            summary_thinking: Vec::new(),
         });
     }
 
@@ -756,8 +786,8 @@ async fn execute_combo(
         let start = summary_parts.len().saturating_sub(max_lines);
         summary_parts[start..].join("\n")
     };
-    let summary = if cancel_token.is_cancelled() {
-        fallback_summary
+    let (summary, summary_thinking) = if cancel_token.is_cancelled() {
+        (fallback_summary, Vec::new())
     } else {
         match generate_combo_summary(
             &mut reply_agent,
@@ -765,16 +795,27 @@ async fn execute_combo(
             tool_calls,
             exit_code,
             tool_failed,
+            cancel_token.clone(),
+            Some(on_event_for_emit.clone()),
         )
         .await
         {
-            Ok(summary) => summary,
+            Ok(summary) => (summary.summary, summary.thinking),
             Err(err) => {
                 warn!(?err, "Failed to generate combo summary");
-                fallback_summary
+                (fallback_summary, Vec::new())
             }
         }
     };
+
+    emit_combo_event(
+        &on_event_for_emit,
+        ComboEvent::SummaryDone {
+            name: combo_name.clone(),
+            summary: summary.clone(),
+            thinking: summary_thinking.clone(),
+        },
+    );
 
     emit_combo_transcript(&on_event_for_emit, &combo_name, &reply_agent).await;
 
@@ -787,6 +828,7 @@ async fn execute_combo(
         } else {
             None
         },
+        summary_thinking,
     })
 }
 
@@ -1000,13 +1042,20 @@ fn extract_text_response(message: &Message) -> String {
     }
 }
 
+struct SummaryResponse {
+    summary: String,
+    thinking: Vec<String>,
+}
+
 async fn generate_combo_summary(
     agent: &mut Agent,
     combo_name: &str,
     tool_calls: usize,
     exit_code: Option<i32>,
     tool_failed: bool,
-) -> Result<String, String> {
+    cancel_token: CancellationToken,
+    on_event: Option<ComboEventCallback>,
+) -> Result<SummaryResponse, String> {
     let mut summary_agent = agent.clone();
     summary_agent.apply_tool_policies(Some(&[]), None);
     let prompt = format!(
@@ -1026,16 +1075,85 @@ tool_failed: {tool_failed}\n\
             .map(|code| code.to_string())
             .unwrap_or_else(|| "none".to_string()),
     );
-    let response = summary_agent
-        .chat(Message::user(Content::Text(prompt)))
-        .await
-        .map_err(|err| err.to_string())?;
+    let disable_stream = summary_agent.disable_stream_for_current_model();
+    let response = if disable_stream || on_event.is_none() {
+        summary_agent
+            .chat(Message::user(Content::Text(prompt)))
+            .await
+            .map_err(|err| err.to_string())?
+    } else {
+        let stream_name = combo_name.to_string();
+        if let Some(on_event) = on_event.as_ref() {
+            emit_combo_event(
+                on_event,
+                ComboEvent::SummaryStreamReset {
+                    name: stream_name.clone(),
+                },
+            );
+        }
+        let on_event_stream = on_event.clone();
+        summary_agent
+            .chat_stream(
+                Message::user(Content::Text(prompt)),
+                cancel_token,
+                move |update| {
+                    let Some(on_event_stream) = on_event_stream.as_ref() else {
+                        return;
+                    };
+                    match update {
+                        ChatStreamUpdate::Reset => emit_combo_event(
+                            on_event_stream,
+                            ComboEvent::SummaryStreamReset {
+                                name: stream_name.clone(),
+                            },
+                        ),
+                        ChatStreamUpdate::Plain { index, text } => emit_combo_event(
+                            on_event_stream,
+                            ComboEvent::SummaryStream {
+                                name: stream_name.clone(),
+                                index,
+                                kind: ComboStreamKind::Plain,
+                                text,
+                            },
+                        ),
+                        ChatStreamUpdate::Thinking { index, text } => emit_combo_event(
+                            on_event_stream,
+                            ComboEvent::SummaryStream {
+                                name: stream_name.clone(),
+                                index,
+                                kind: ComboStreamKind::Thinking,
+                                text,
+                            },
+                        ),
+                    }
+                },
+            )
+            .await
+            .map_err(|err| err.to_string())?
+    };
     let summary = extract_text_response(&response.message);
     let summary = summary.trim();
     if summary.is_empty() {
         return Err("summary response is empty".to_string());
     }
-    Ok(summary.to_string())
+    let thinking = extract_thinking_blocks(&response.message);
+    Ok(SummaryResponse {
+        summary: summary.to_string(),
+        thinking,
+    })
+}
+
+fn extract_thinking_blocks(message: &Message) -> Vec<String> {
+    match &message.content {
+        Content::Multiple(blocks) => blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Thinking { thinking, .. } if !thinking.is_empty() => Some(thinking.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 fn build_offload_reply_directive(schemas: &[PromptSchema]) -> String {
@@ -1500,6 +1618,7 @@ mod tests {
             summary: "Combo completed".to_string(),
             tool_calls: 3,
             error: None,
+            summary_thinking: Vec::new(),
         };
 
         let json = serde_json::to_value(&output).unwrap();

--- a/src/tools/run_combo.rs
+++ b/src/tools/run_combo.rs
@@ -412,10 +412,11 @@ async fn execute_combo(
     let mut tool_calls = 0;
     let mut summary_parts: Vec<String> = Vec::new();
     let mut exit_code: Option<i32> = None;
-    let mut failed = false;
+    let mut tool_failed = false;
+    let mut starter_failed = false;
     let mut cancelled = false;
 
-    let command_line = format_command_line(&combo_path, &args);
+    let command_line = format_combo_run_command(&combo_name, &args);
     // Emit executing event
     emit_combo_event(
         &on_event_for_emit,
@@ -497,7 +498,7 @@ async fn execute_combo(
                             output: output.clone(),
                         });
                         if is_error {
-                            failed = true;
+                            tool_failed = true;
                         }
                     }
                     StarterEvent::Prompt { prompt } => {
@@ -660,7 +661,7 @@ async fn execute_combo(
                         cancelled = true;
                     }
                     StarterEvent::Failed { reason } => {
-                        failed = true;
+                        starter_failed = true;
                         summary_parts.push(format!("[Failed] {}", reason));
                     }
                 }
@@ -744,7 +745,7 @@ async fn execute_combo(
         });
     }
 
-    let success = !failed && exit_code.map(|c| c == 0).unwrap_or(true);
+    let success = !starter_failed && exit_code.map(|c| c == 0).unwrap_or(true);
     let fallback_summary = if summary_parts.is_empty() {
         format!(
             "Combo '{}' completed with {} tool call(s)",
@@ -758,8 +759,14 @@ async fn execute_combo(
     let summary = if cancel_token.is_cancelled() {
         fallback_summary
     } else {
-        match generate_combo_summary(&mut reply_agent, &combo_name, tool_calls, exit_code, failed)
-            .await
+        match generate_combo_summary(
+            &mut reply_agent,
+            &combo_name,
+            tool_calls,
+            exit_code,
+            tool_failed,
+        )
+        .await
         {
             Ok(summary) => summary,
             Err(err) => {
@@ -775,7 +782,7 @@ async fn execute_combo(
         success,
         summary,
         tool_calls,
-        error: if failed {
+        error: if tool_failed {
             Some("One or more tool calls failed".to_string())
         } else {
             None
@@ -998,7 +1005,7 @@ async fn generate_combo_summary(
     combo_name: &str,
     tool_calls: usize,
     exit_code: Option<i32>,
-    failed: bool,
+    tool_failed: bool,
 ) -> Result<String, String> {
     let mut summary_agent = agent.clone();
     summary_agent.apply_tool_policies(Some(&[]), None);
@@ -1013,7 +1020,7 @@ Context:\n\
 combo_name: {combo_name}\n\
 tool_calls: {tool_calls}\n\
 exit_code: {exit_code}\n\
-failed: {failed}\n\
+tool_failed: {tool_failed}\n\
 ",
         exit_code = exit_code
             .map(|code| code.to_string())
@@ -1450,29 +1457,21 @@ fn flush_buffer(
     }
 }
 
-fn format_command_line(command: &str, args: &[String]) -> String {
-    let command = resolve_command_display(command);
-    let mut parts = Vec::with_capacity(args.len() + 1);
-    parts.push(shell_escape(&command));
+fn format_combo_run_command(name: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 4);
+    parts.push("coco".to_string());
+    parts.push("combo".to_string());
+    parts.push("run".to_string());
+    parts.push(display_combo_arg(name));
     for arg in args {
-        parts.push(shell_escape(arg));
+        parts.push(display_combo_arg(arg));
     }
     parts.join(" ")
 }
 
-fn resolve_command_display(command: &str) -> String {
-    let command_path = std::path::Path::new(command);
-    let workspace_combo_dir = crate::workspace_dir().join(".coco/combos");
-    if let Ok(relative) = command_path.strip_prefix(&workspace_combo_dir) {
-        let display_path = std::path::Path::new(".coco/combos").join(relative);
-        return display_path.to_string_lossy().to_string();
-    }
-    command.to_string()
-}
-
-fn shell_escape(value: &str) -> String {
+fn display_combo_arg(value: &str) -> String {
     if value.is_empty() {
-        return "''".to_string();
+        return "\"\"".to_string();
     }
     if value.bytes().all(|byte| {
         matches!(byte, b'a'..=b'z'
@@ -1482,25 +1481,12 @@ fn shell_escape(value: &str) -> String {
             | b'-'
             | b'.'
             | b'/'
-            | b':'
-            | b'@'
-            | b'+'
-            | b'='
-            | b','
-            | b'%')
+            | b':')
     }) {
         return value.to_string();
     }
-    let mut escaped = String::from("'");
-    for ch in value.chars() {
-        if ch == '\'' {
-            escaped.push_str("'\"'\"'");
-        } else {
-            escaped.push(ch);
-        }
-    }
-    escaped.push('\'');
-    escaped
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #124

## Summary

This PR implements the "RunCombo: move execution into coco combo run" enhancement by migrating combo execution from the `run_combo` tool to a dedicated CLI command `coco combo run` with session socket integration.

## Key Changes

### 1. New CLI Command (`src/cmd/combo.rs`)
- Added `coco combo run <name> [args...]` as the canonical entrypoint for combo execution
- Supports both standalone mode and inline mode when `COCO_SESSION_SOCK` is present
- Streams events and returns JSON summary

### 2. Session Socket Protocol Extensions (`src/combo/session.rs`)
- Extended session socket protocol to support combo run requests
- Added event streaming for real-time UI updates
- Implemented result aggregation and JSON output

### 3. TUI Bridge Components (`crates/coco-tui/src/`)
- **`combo_run_bridge.rs`**: Manages communication between CLI and TUI session
- **`combo_run_server.rs`**: Session socket server handling combo run events
- Updated **`chat.rs`** and **`messages/combo.rs`**: Enhanced to display streaming combo events

### 4. Tool Integration
- Modified `bash` tool to inject `COCO_SESSION_SOCK` when invoking `coco combo run`
- Agent now uses bash tool to execute combos via CLI instead of `run_combo` tool
- Preserved transcript linking for combo runs executed via bash tool

### 5. Permission & Safety
- Added permission handling for combo execution via Bash tool
- Ensures TTY or session socket availability before execution
- Proper error handling and user feedback

## Behavior

- **With running TUI**: `coco combo run demo a b` streams events to the TUI and returns JSON summary
- **Without TUI**: Command starts the TUI and runs the combo
- **Agent usage**: Agent invokes `coco combo run` via bash tool, with proper environment injection