### PR TITLE
refactor: reduce code duplication and improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
 name = "coco-macro"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.111",
 ]

--- a/crates/anthropic/src/client.rs
+++ b/crates/anthropic/src/client.rs
@@ -81,16 +81,17 @@ impl Client {
         max_tokens: Option<usize>,
         retry_config: RetryConfig,
     ) -> Result<messages::MessagesResponse, Whatever> {
-        let req = build_request(
-            &self.model,
-            system_prompt,
-            conversations,
-            tools,
-            Some(tool_choice),
-            thinking,
+        let req = messages::MessagesRequest {
+            model: self.model.clone(),
+            messages: conversations,
+            max_tokens: max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+            system: system_prompt.unwrap_or_default().to_string(),
             temperature,
-            max_tokens,
-        );
+            tool_choice: Some(tool_choice),
+            thinking,
+            stream: None,
+            tools,
+        };
         messages::messages(&self.cli, &self.base_url, req, retry_config).await
     }
 
@@ -106,16 +107,17 @@ impl Client {
         max_tokens: Option<usize>,
         retry_config: RetryConfig,
     ) -> Result<messages::MessagesStream, Whatever> {
-        let req = build_request(
-            &self.model,
-            system_prompt,
-            conversations,
-            tools,
-            Some(tool_choice),
-            thinking,
+        let req = messages::MessagesRequest {
+            model: self.model.clone(),
+            messages: conversations,
+            max_tokens: max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+            system: system_prompt.unwrap_or_default().to_string(),
             temperature,
-            max_tokens,
-        );
+            tool_choice: Some(tool_choice),
+            thinking,
+            stream: None,
+            tools,
+        };
         messages::messages_stream(&self.cli, &self.base_url, req, retry_config).await
     }
 }
@@ -166,167 +168,102 @@ impl ClientBuilder {
     }
 }
 
-pub struct MessagesBuilder<'a> {
-    client: &'a Client,
-    system_prompt: Option<String>,
-    conversations: Vec<Message>,
-    tools: Vec<Tool>,
-    thinking: Option<Thinking>,
-    temperature: Option<f64>,
-    max_tokens: Option<usize>,
-    retry_config: RetryConfig,
-}
-
-impl<'a> MessagesBuilder<'a> {
-    fn new(client: &'a Client) -> Self {
-        Self {
-            client,
-            system_prompt: None,
-            conversations: Vec::new(),
-            tools: Vec::new(),
-            thinking: None,
-            temperature: None,
-            max_tokens: None,
-            retry_config: RetryConfig::default(),
+macro_rules! messages_builder {
+    ($name:ident, $call_fn:path, $output:ty) => {
+        pub struct $name<'a> {
+            client: &'a Client,
+            system_prompt: Option<String>,
+            conversations: Vec<Message>,
+            tools: Vec<Tool>,
+            thinking: Option<Thinking>,
+            temperature: Option<f64>,
+            max_tokens: Option<usize>,
+            retry_config: RetryConfig,
         }
-    }
 
-    pub fn maybe_system_prompt(mut self, system_prompt: Option<&str>) -> Self {
-        self.system_prompt = system_prompt.map(str::to_string);
-        self
-    }
+        impl<'a> $name<'a> {
+            fn new(client: &'a Client) -> Self {
+                Self {
+                    client,
+                    system_prompt: None,
+                    conversations: Vec::new(),
+                    tools: Vec::new(),
+                    thinking: None,
+                    temperature: None,
+                    max_tokens: None,
+                    retry_config: RetryConfig::default(),
+                }
+            }
 
-    pub fn conversations(mut self, conversations: Vec<Message>) -> Self {
-        self.conversations = conversations;
-        self
-    }
+            pub fn maybe_system_prompt(mut self, system_prompt: Option<&str>) -> Self {
+                self.system_prompt = system_prompt.map(str::to_string);
+                self
+            }
 
-    pub fn tools(mut self, tools: Vec<Tool>) -> Self {
-        self.tools = tools;
-        self
-    }
+            pub fn conversations(mut self, conversations: Vec<Message>) -> Self {
+                self.conversations = conversations;
+                self
+            }
 
-    pub fn maybe_thinking(mut self, thinking: Option<Thinking>) -> Self {
-        self.thinking = thinking;
-        self
-    }
+            pub fn tools(mut self, tools: Vec<Tool>) -> Self {
+                self.tools = tools;
+                self
+            }
 
-    pub fn maybe_temperature(mut self, temperature: Option<f64>) -> Self {
-        self.temperature = temperature;
-        self
-    }
+            pub fn maybe_thinking(mut self, thinking: Option<Thinking>) -> Self {
+                self.thinking = thinking;
+                self
+            }
 
-    pub fn maybe_max_tokens(mut self, max_tokens: Option<usize>) -> Self {
-        self.max_tokens = max_tokens;
-        self
-    }
+            pub fn maybe_temperature(mut self, temperature: Option<f64>) -> Self {
+                self.temperature = temperature;
+                self
+            }
 
-    pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
-        self.retry_config = retry_config;
-        self
-    }
+            pub fn maybe_max_tokens(mut self, max_tokens: Option<usize>) -> Self {
+                self.max_tokens = max_tokens;
+                self
+            }
 
-    pub async fn call(self) -> Result<messages::MessagesResponse, Whatever> {
-        let req = build_request(
-            &self.client.model,
-            self.system_prompt.as_deref(),
-            self.conversations,
-            self.tools,
-            None,
-            self.thinking,
-            self.temperature,
-            self.max_tokens,
-        );
-        messages::messages(
-            &self.client.cli,
-            &self.client.base_url,
-            req,
-            self.retry_config,
-        )
-        .await
-    }
-}
+            pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
+                self.retry_config = retry_config;
+                self
+            }
 
-pub struct MessagesStreamBuilder<'a> {
-    client: &'a Client,
-    system_prompt: Option<String>,
-    conversations: Vec<Message>,
-    tools: Vec<Tool>,
-    thinking: Option<Thinking>,
-    temperature: Option<f64>,
-    max_tokens: Option<usize>,
-    retry_config: RetryConfig,
-}
-
-impl<'a> MessagesStreamBuilder<'a> {
-    fn new(client: &'a Client) -> Self {
-        Self {
-            client,
-            system_prompt: None,
-            conversations: Vec::new(),
-            tools: Vec::new(),
-            thinking: None,
-            temperature: None,
-            max_tokens: None,
-            retry_config: RetryConfig::default(),
+            pub async fn call(self) -> Result<$output, Whatever> {
+                let req = messages::MessagesRequest {
+                    model: self.client.model.clone(),
+                    messages: self.conversations,
+                    max_tokens: self.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+                    system: self.system_prompt.unwrap_or_default(),
+                    temperature: self.temperature,
+                    tool_choice: None,
+                    thinking: self.thinking,
+                    stream: None,
+                    tools: self.tools,
+                };
+                $call_fn(
+                    &self.client.cli,
+                    &self.client.base_url,
+                    req,
+                    self.retry_config,
+                )
+                .await
+            }
         }
-    }
-
-    pub fn maybe_system_prompt(mut self, system_prompt: Option<&str>) -> Self {
-        self.system_prompt = system_prompt.map(str::to_string);
-        self
-    }
-
-    pub fn conversations(mut self, conversations: Vec<Message>) -> Self {
-        self.conversations = conversations;
-        self
-    }
-
-    pub fn tools(mut self, tools: Vec<Tool>) -> Self {
-        self.tools = tools;
-        self
-    }
-
-    pub fn maybe_thinking(mut self, thinking: Option<Thinking>) -> Self {
-        self.thinking = thinking;
-        self
-    }
-
-    pub fn maybe_temperature(mut self, temperature: Option<f64>) -> Self {
-        self.temperature = temperature;
-        self
-    }
-
-    pub fn maybe_max_tokens(mut self, max_tokens: Option<usize>) -> Self {
-        self.max_tokens = max_tokens;
-        self
-    }
-
-    pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
-        self.retry_config = retry_config;
-        self
-    }
-
-    pub async fn call(self) -> Result<messages::MessagesStream, Whatever> {
-        let req = build_request(
-            &self.client.model,
-            self.system_prompt.as_deref(),
-            self.conversations,
-            self.tools,
-            None,
-            self.thinking,
-            self.temperature,
-            self.max_tokens,
-        );
-        messages::messages_stream(
-            &self.client.cli,
-            &self.client.base_url,
-            req,
-            self.retry_config,
-        )
-        .await
-    }
+    };
 }
+
+messages_builder!(
+    MessagesBuilder,
+    messages::messages,
+    messages::MessagesResponse
+);
+messages_builder!(
+    MessagesStreamBuilder,
+    messages::messages_stream,
+    messages::MessagesStream
+);
 
 fn build_headers(token: &str) -> Result<HeaderMap, Whatever> {
     let mut headers = HeaderMap::new();
@@ -345,30 +282,6 @@ fn build_headers(token: &str) -> Result<HeaderMap, Whatever> {
 
 fn missing_field(field: &str) -> Whatever {
     <Whatever as snafu::FromString>::without_source(format!("missing anthropic {field}"))
-}
-
-#[allow(clippy::too_many_arguments)]
-fn build_request(
-    model: &str,
-    system_prompt: Option<&str>,
-    conversations: Vec<Message>,
-    tools: Vec<Tool>,
-    tool_choice: Option<messages::ToolChoice>,
-    thinking: Option<messages::Thinking>,
-    temperature: Option<f64>,
-    max_tokens: Option<usize>,
-) -> messages::MessagesRequest {
-    messages::MessagesRequest {
-        model: model.to_string(),
-        messages: conversations,
-        max_tokens: max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-        system: system_prompt.unwrap_or_default().to_string(),
-        temperature,
-        tool_choice,
-        thinking,
-        stream: None,
-        tools,
-    }
 }
 
 #[cfg(test)]

--- a/crates/coco-highlight/src/lang.rs
+++ b/crates/coco-highlight/src/lang.rs
@@ -70,56 +70,38 @@ impl std::fmt::Display for Lang {
 pub fn new_config(lang: &Lang, names: &[&str]) -> Result<HighlightConfiguration> {
     use Lang::*;
     match lang {
-        Bash => bash_config(names),
-        Diff => diff_config(names),
-        Json => json_config(names),
+        Bash => simple_config(
+            tree_sitter_bash::LANGUAGE.into(),
+            "bash",
+            tree_sitter_bash::HIGHLIGHT_QUERY,
+            names,
+        ),
+        Diff => simple_config(
+            tree_sitter_diff::LANGUAGE.into(),
+            "diff",
+            tree_sitter_diff::HIGHLIGHTS_QUERY,
+            names,
+        ),
+        Json => simple_config(
+            tree_sitter_json::LANGUAGE.into(),
+            "json",
+            tree_sitter_json::HIGHLIGHTS_QUERY,
+            names,
+        ),
         Markdown => markdown_config(names),
         MarkdownInline => markdown_inline_config(names),
     }
 }
 
-fn bash_config(names: &[&str]) -> Result<HighlightConfiguration> {
-    let mut config = HighlightConfiguration::new(
-        tree_sitter_bash::LANGUAGE.into(),
-        "bash",
-        tree_sitter_bash::HIGHLIGHT_QUERY,
-        "",
-        "",
-    )
-    .whatever_context("failed to create bash highlight configuration")?;
-
+fn simple_config(
+    language: tree_sitter::Language,
+    name: &str,
+    highlights_query: &str,
+    names: &[&str],
+) -> Result<HighlightConfiguration> {
+    let mut config = HighlightConfiguration::new(language, name, highlights_query, "", "")
+        .whatever_context(format!("failed to create {name} highlight configuration"))?;
     config.configure(names);
-
-    Ok(config)
-}
-
-fn diff_config(names: &[&str]) -> Result<HighlightConfiguration> {
-    let mut config = HighlightConfiguration::new(
-        tree_sitter_diff::LANGUAGE.into(),
-        "diff",
-        tree_sitter_diff::HIGHLIGHTS_QUERY,
-        "",
-        "",
-    )
-    .whatever_context("failed to create diff highlight configuration")?;
-
-    config.configure(names);
-
-    Ok(config)
-}
-
-fn json_config(names: &[&str]) -> Result<HighlightConfiguration> {
-    let mut config = HighlightConfiguration::new(
-        tree_sitter_json::LANGUAGE.into(),
-        "json",
-        tree_sitter_json::HIGHLIGHTS_QUERY,
-        "",
-        "",
-    )
-    .whatever_context("failed to create json highlight configuration")?;
-
-    config.configure(names);
-
     Ok(config)
 }
 

--- a/crates/coco-macro/Cargo.toml
+++ b/crates/coco-macro/Cargo.toml
@@ -7,5 +7,6 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0"
 quote = "1.0.42"
 syn = "2.0.111"

--- a/crates/coco-macro/src/lib.rs
+++ b/crates/coco-macro/src/lib.rs
@@ -1,28 +1,52 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Attribute, DeriveInput, LitStr, parse_macro_input};
+use syn::{Attribute, DeriveInput, LitStr, parse_macro_input, spanned::Spanned};
 
 /// Extracts the `type_id` value from a `#[component(type_id = "...")]` attribute.
-fn parse_type_id(attrs: &[Attribute]) -> LitStr {
+///
+/// Returns a compile-time error with proper span information if:
+/// - The `#[component]` attribute is missing
+/// - The `type_id` key is missing or malformed
+/// - The `type_id` value is not a string literal
+fn parse_type_id(attrs: &[Attribute]) -> syn::Result<LitStr> {
     let attr = attrs
         .iter()
         .find(|a| a.path().is_ident("component"))
-        .expect("`component` attribute is required");
+        .ok_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "missing `#[component(type_id = \"...\")]` attribute",
+            )
+        })?;
 
     let mut type_id: Option<LitStr> = None;
-    attr.parse_nested_meta(|m| {
+    let mut parse_error: Option<syn::Error> = None;
+
+    let result = attr.parse_nested_meta(|m| {
         if m.path.is_ident("type_id") {
-            let value = m.value().expect("`type_id` assignment is required");
-            let value = value
-                .parse::<LitStr>()
-                .expect("`type_id` value must be a literal string");
-            type_id.replace(value);
+            let value = m.value().map_err(|_| {
+                syn::Error::new(
+                    m.path.span(),
+                    "`type_id` requires a value: type_id = \"...\"",
+                )
+            })?;
+            let lit = value.parse::<LitStr>().map_err(|_| {
+                syn::Error::new(value.span(), "`type_id` value must be a string literal")
+            })?;
+            type_id = Some(lit);
         }
         Ok(())
-    })
-    .ok();
+    });
 
-    type_id.expect("`type_id` assignment not found")
+    if let Err(e) = result {
+        parse_error = Some(e);
+    }
+
+    if let Some(err) = parse_error {
+        return Err(err);
+    }
+
+    type_id.ok_or_else(|| syn::Error::new(attr.span(), "`type_id` key not found in attribute"))
 }
 
 /// Derive macro for implementing the `Identity` trait and registering a component.
@@ -54,7 +78,10 @@ pub fn component(input: TokenStream) -> TokenStream {
         ..
     } = parse_macro_input!(input);
 
-    let type_id = parse_type_id(&attrs);
+    let type_id = match parse_type_id(&attrs) {
+        Ok(id) => id,
+        Err(err) => return err.into_compile_error().into(),
+    };
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let handler_mod = quote::format_ident!("__COMPONENT_REGISTER_{}", ident);
 
@@ -113,7 +140,10 @@ pub fn component(input: TokenStream) -> TokenStream {
 pub fn content_component(input: TokenStream) -> TokenStream {
     let DeriveInput { ident, attrs, .. } = parse_macro_input!(input);
 
-    let type_id = parse_type_id(&attrs);
+    let type_id = match parse_type_id(&attrs) {
+        Ok(id) => id,
+        Err(err) => return err.into_compile_error().into(),
+    };
     let handler_mod = quote::format_ident!("__CONTENT_COMPONENT_REGISTER_{}", ident);
 
     let expanded = quote! {

--- a/crates/coco-macro/src/lib.rs
+++ b/crates/coco-macro/src/lib.rs
@@ -1,6 +1,29 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{DeriveInput, LitStr, parse_macro_input};
+use syn::{Attribute, DeriveInput, LitStr, parse_macro_input};
+
+/// Extracts the `type_id` value from a `#[component(type_id = "...")]` attribute.
+fn parse_type_id(attrs: &[Attribute]) -> LitStr {
+    let attr = attrs
+        .iter()
+        .find(|a| a.path().is_ident("component"))
+        .expect("`component` attribute is required");
+
+    let mut type_id: Option<LitStr> = None;
+    attr.parse_nested_meta(|m| {
+        if m.path.is_ident("type_id") {
+            let value = m.value().expect("`type_id` assignment is required");
+            let value = value
+                .parse::<LitStr>()
+                .expect("`type_id` value must be a literal string");
+            type_id.replace(value);
+        }
+        Ok(())
+    })
+    .ok();
+
+    type_id.expect("`type_id` assignment not found")
+}
 
 /// Derive macro for implementing the `Identity` trait and registering a component.
 ///
@@ -24,33 +47,17 @@ use syn::{DeriveInput, LitStr, parse_macro_input};
 /// - A hidden module that registers the component during static initialization
 #[proc_macro_derive(ComponentExt, attributes(component))]
 pub fn component(input: TokenStream) -> TokenStream {
-    let mut type_id: Option<LitStr> = None;
-
     let DeriveInput {
         ident,
         attrs,
         generics,
         ..
     } = parse_macro_input!(input);
-    let attr = attrs
-        .iter()
-        .find(|a| a.path().is_ident("component"))
-        .expect("`component` attribute is required");
-    attr.parse_nested_meta(|m| {
-        if m.path.is_ident("type_id") {
-            let value = m.value().expect("`type_id` assignment is required");
-            let value = value
-                .parse::<LitStr>()
-                .expect("`type_id` value must be a literal string");
-            type_id.replace(value);
-        }
-        Ok(())
-    })
-    .ok();
 
-    let type_id = type_id.expect("`type_id` assignment not found");
+    let type_id = parse_type_id(&attrs);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let handler_mod = quote::format_ident!("__COMPONENT_REGISTER_{}", ident);
+
     let expanded = quote! {
         impl #impl_generics crate::components::Identity for #ident #ty_generics #where_clause {
             fn id(&self) -> &'static str {
@@ -104,27 +111,11 @@ pub fn component(input: TokenStream) -> TokenStream {
 /// during static initialization using the `ctor` crate.
 #[proc_macro_derive(ContentComponentExt)]
 pub fn content_component(input: TokenStream) -> TokenStream {
-    let mut type_id: Option<LitStr> = None;
-
     let DeriveInput { ident, attrs, .. } = parse_macro_input!(input);
-    let attr = attrs
-        .iter()
-        .find(|a| a.path().is_ident("component"))
-        .expect("`component` attribute is required");
-    attr.parse_nested_meta(|m| {
-        if m.path.is_ident("type_id") {
-            let value = m.value().expect("`type_id` assignment is required");
-            let value = value
-                .parse::<LitStr>()
-                .expect("`type_id` value must be a literal string");
-            type_id.replace(value);
-        }
-        Ok(())
-    })
-    .ok();
 
-    let type_id = type_id.expect("`type_id` assignment not found");
+    let type_id = parse_type_id(&attrs);
     let handler_mod = quote::format_ident!("__CONTENT_COMPONENT_REGISTER_{}", ident);
+
     let expanded = quote! {
         #[allow(non_snake_case)]
         mod #handler_mod {

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -10,7 +10,6 @@ use ratatui::{
     Frame,
     layout::{Constraint, Layout},
     prelude::Rect,
-    style::Style,
     text::{Line, Span},
     widgets::Wrap,
 };
@@ -30,7 +29,7 @@ use crate::{
     events::{AnswerEvent, AskEvent, Event},
     global::{self, State},
     session::{self, Session},
-    widgets::{Paragraph, tab_panel_width},
+    widgets::{Paragraph, render_tabs_panel, tab_panel_width},
 };
 
 #[derive(Serialize, Deserialize)]
@@ -107,28 +106,6 @@ fn output_marker_width(view: BashOutputView) -> u16 {
         BashOutputView::Mixed => 1,
         _ => 0,
     }
-}
-
-fn render_tabs_panel(view: BashOutputView) -> Paragraph<'static> {
-    let theme = global::theme();
-    let highlight = theme.ui.bash_tab_active;
-    let items = [
-        (BashOutputView::Stdout, " 1 ", theme.ui.bash_tab_stdout),
-        (BashOutputView::Stderr, " 2 ", theme.ui.bash_tab_stderr),
-        (BashOutputView::Mixed, " 3 ", theme.ui.bash_tab_mixed),
-    ];
-    let lines = items
-        .into_iter()
-        .map(|(v, digit, base_style)| {
-            let style = if v.index() == view.index() {
-                highlight
-            } else {
-                Style::default()
-            };
-            Line::from(Span::styled(digit, base_style.patch(style)))
-        })
-        .collect::<Vec<_>>();
-    Paragraph::new(lines)
 }
 
 const OUTPUT_MARKER: &str = "▐";
@@ -745,7 +722,16 @@ impl Component for Bash<'static> {
         }
 
         if let Some(area_tabs) = area_output_tabs {
-            let tabs_panel = render_tabs_panel(self.exec_view());
+            let theme = global::theme();
+            let tabs_panel = render_tabs_panel(
+                self.exec_view().index(),
+                &[
+                    (" 1 ", theme.ui.bash_tab_stdout),
+                    (" 2 ", theme.ui.bash_tab_stderr),
+                    (" 3 ", theme.ui.bash_tab_mixed),
+                ],
+                theme.ui.bash_tab_active,
+            );
             frame.render_widget(tabs_panel, area_tabs);
         }
         Ok(())

--- a/crates/coco-tui/src/components/messages/tool/bash.rs
+++ b/crates/coco-tui/src/components/messages/tool/bash.rs
@@ -30,7 +30,7 @@ use crate::{
     events::{AnswerEvent, AskEvent, Event},
     global::{self, State},
     session::{self, Session},
-    widgets::Paragraph,
+    widgets::{Paragraph, tab_panel_width},
 };
 
 #[derive(Serialize, Deserialize)]
@@ -101,14 +101,6 @@ impl Default for ExecState {
 
 const OUTPUT_PREVIEW_LINES: usize = 6;
 const TAB_PANEL_HEIGHT: usize = 3;
-
-fn tab_panel_width(total_width: u16) -> u16 {
-    let min_total_width = 24u16;
-    if total_width < min_total_width {
-        return 0;
-    }
-    3
-}
 
 fn output_marker_width(view: BashOutputView) -> u16 {
     match view {

--- a/crates/coco-tui/src/components/messages/tool/str_replace.rs
+++ b/crates/coco-tui/src/components/messages/tool/str_replace.rs
@@ -24,7 +24,7 @@ use crate::{
     events::{AnswerEvent, AskEvent, Event},
     global::{self, State},
     session::{self, Session},
-    widgets::Paragraph,
+    widgets::{Paragraph, tab_panel_width},
 };
 
 const DEFAULT_CONTEXT_RADIUS: usize = 3;
@@ -167,14 +167,6 @@ fn build_diff_widget(diff_text: String) -> StrReplaceWidget<'static> {
         Ok(highlight) => StrReplaceWidget::CodeHighlight(highlight),
         Err(_) => StrReplaceWidget::Paragraph(Paragraph::new(diff_text)),
     }
-}
-
-fn tab_panel_width(total_width: u16) -> u16 {
-    let min_total_width = 24u16;
-    if total_width < min_total_width {
-        return 0;
-    }
-    3
 }
 
 fn render_tabs_panel(view: ResultView) -> Paragraph<'static> {

--- a/crates/coco-tui/src/components/messages/tool/str_replace.rs
+++ b/crates/coco-tui/src/components/messages/tool/str_replace.rs
@@ -24,7 +24,7 @@ use crate::{
     events::{AnswerEvent, AskEvent, Event},
     global::{self, State},
     session::{self, Session},
-    widgets::{Paragraph, tab_panel_width},
+    widgets::{Paragraph, render_tabs_panel, tab_panel_width},
 };
 
 const DEFAULT_CONTEXT_RADIUS: usize = 3;
@@ -167,27 +167,6 @@ fn build_diff_widget(diff_text: String) -> StrReplaceWidget<'static> {
         Ok(highlight) => StrReplaceWidget::CodeHighlight(highlight),
         Err(_) => StrReplaceWidget::Paragraph(Paragraph::new(diff_text)),
     }
-}
-
-fn render_tabs_panel(view: ResultView) -> Paragraph<'static> {
-    let theme = global::theme();
-    let highlight = Style::default().reversed();
-    let items = [
-        (ResultView::Applied, " 1 ", theme.ui.result_success),
-        (ResultView::Unapplied, " 2 ", theme.ui.result_error),
-    ];
-    let lines = items
-        .into_iter()
-        .map(|(v, digit, base_style)| {
-            let style = if v == view {
-                highlight
-            } else {
-                Style::default()
-            };
-            Line::from(Span::styled(digit, base_style.patch(style)))
-        })
-        .collect::<Vec<_>>();
-    Paragraph::new(lines)
 }
 
 fn has_result_tabs(state: &Inner) -> bool {
@@ -750,7 +729,15 @@ impl Component for StrReplace<'static> {
                 StrReplaceWidget::Empty => {}
             }
             if let Some(tabs_area) = area_tabs {
-                let tabs_panel = render_tabs_panel(state.result_view);
+                let theme = global::theme();
+                let tabs_panel = render_tabs_panel(
+                    state.result_view as usize,
+                    &[
+                        (" 1 ", theme.ui.result_success),
+                        (" 2 ", theme.ui.result_error),
+                    ],
+                    Style::default().reversed(),
+                );
                 frame.render_widget(tabs_panel, tabs_area);
             }
             return Ok(());

--- a/crates/coco-tui/src/widgets.rs
+++ b/crates/coco-tui/src/widgets.rs
@@ -1,5 +1,7 @@
 mod paragraph;
+mod tabs;
 mod throbber;
 
 pub use paragraph::*;
+pub use tabs::*;
 pub use throbber::*;

--- a/crates/coco-tui/src/widgets/tabs.rs
+++ b/crates/coco-tui/src/widgets/tabs.rs
@@ -1,0 +1,20 @@
+//! Shared tab panel utilities for tool widgets.
+
+/// Calculate the width for a vertical tab panel.
+///
+/// Returns 0 if total width is too narrow, otherwise returns the fixed panel width.
+pub fn tab_panel_width(total_width: u16) -> u16 {
+    const MIN_TOTAL_WIDTH: u16 = 24;
+    const PANEL_WIDTH: u16 = 3;
+
+    if total_width < MIN_TOTAL_WIDTH {
+        0
+    } else {
+        PANEL_WIDTH
+    }
+}
+
+/// Height of a tab panel with the given number of items.
+pub const fn tab_panel_height(item_count: usize) -> usize {
+    item_count
+}

--- a/crates/coco-tui/src/widgets/tabs.rs
+++ b/crates/coco-tui/src/widgets/tabs.rs
@@ -1,5 +1,12 @@
 //! Shared tab panel utilities for tool widgets.
 
+use ratatui::{
+    style::Style,
+    text::{Line, Span},
+};
+
+use crate::widgets::Paragraph;
+
 /// Calculate the width for a vertical tab panel.
 ///
 /// Returns 0 if total width is too narrow, otherwise returns the fixed panel width.
@@ -17,4 +24,30 @@ pub fn tab_panel_width(total_width: u16) -> u16 {
 /// Height of a tab panel with the given number of items.
 pub const fn tab_panel_height(item_count: usize) -> usize {
     item_count
+}
+
+/// Renders a vertical tab panel with the given items.
+///
+/// # Arguments
+/// * `current_index` - The index of the currently selected tab
+/// * `items` - Array of (label, base_style) pairs
+/// * `highlight` - Style to apply to the selected tab
+pub fn render_tabs_panel(
+    current_index: usize,
+    items: &[(&str, Style)],
+    highlight: Style,
+) -> Paragraph<'static> {
+    let lines = items
+        .iter()
+        .enumerate()
+        .map(|(idx, (label, base_style))| {
+            let style = if idx == current_index {
+                highlight
+            } else {
+                Style::default()
+            };
+            Line::from(Span::styled((*label).to_string(), base_style.patch(style)))
+        })
+        .collect::<Vec<_>>();
+    Paragraph::new(lines)
 }

--- a/src/combo/session.rs
+++ b/src/combo/session.rs
@@ -364,11 +364,11 @@ impl SessionSocketClient {
         &self,
         payload: MetadataPayload,
     ) -> ClientResult<MetadataResponse> {
-        self.send_message(&ClientMessage::Metadata(payload)).await?;
-        match self.read_server_message().await? {
+        self.send_and_expect(ClientMessage::Metadata(payload), |msg| match msg {
             ServerMessage::Metadata(response) => Ok(response),
-            other => Err(SessionClientError::UnexpectedServerMessage { message: other }),
-        }
+            other => Err(other),
+        })
+        .await
     }
 
     pub async fn send_prompt(&self, payload: PromptPayload) -> ClientResult<()> {
@@ -376,30 +376,30 @@ impl SessionSocketClient {
     }
 
     pub async fn send_mcp_request(&self, payload: McpRequest) -> ClientResult<McpResponse> {
-        self.send_message(&ClientMessage::Mcp(payload)).await?;
-        match self.read_server_message().await? {
+        self.send_and_expect(ClientMessage::Mcp(payload), |msg| match msg {
             ServerMessage::Mcp(response) => Ok(response),
-            other => Err(SessionClientError::UnexpectedServerMessage { message: other }),
-        }
+            other => Err(other),
+        })
+        .await
     }
 
     pub async fn send_prompt_wait_response(&self, payload: PromptPayload) -> ClientResult<String> {
-        self.send_message(&ClientMessage::Prompt(payload)).await?;
-        match self.read_server_message().await? {
+        self.send_and_expect(ClientMessage::Prompt(payload), |msg| match msg {
             ServerMessage::PromptResponse(response) => Ok(response),
-            other => Err(SessionClientError::UnexpectedServerMessage { message: other }),
-        }
+            other => Err(other),
+        })
+        .await
     }
 
     pub async fn send_reply_wait_validation(
         &self,
         payload: ReplyPayload,
     ) -> ClientResult<ReplyValidation> {
-        self.send_message(&ClientMessage::Reply(payload)).await?;
-        match self.read_server_message().await? {
+        self.send_and_expect(ClientMessage::Reply(payload), |msg| match msg {
             ServerMessage::ReplyValidation(validation) => Ok(validation),
-            other => Err(SessionClientError::UnexpectedServerMessage { message: other }),
-        }
+            other => Err(other),
+        })
+        .await
     }
 
     pub async fn begin_combo_run(&self, payload: ComboRunPayload) -> ClientResult<ComboRunSession> {
@@ -472,6 +472,20 @@ impl SessionSocketClient {
                 socket_path: self.socket_path.clone(),
             })?;
         serde_json::from_slice(&buf).context(session_client_error::DeserializeSnafu)
+    }
+
+    /// Send a message and expect a specific response type.
+    ///
+    /// The `extract` function should return `Ok(T)` if the response matches,
+    /// or `Err(ServerMessage)` to indicate an unexpected message type.
+    async fn send_and_expect<T, F>(&self, message: ClientMessage, extract: F) -> ClientResult<T>
+    where
+        F: FnOnce(ServerMessage) -> Result<T, ServerMessage>,
+    {
+        self.send_message(&message).await?;
+        let response = self.read_server_message().await?;
+        extract(response)
+            .map_err(|msg| SessionClientError::UnexpectedServerMessage { message: msg })
     }
 }
 


### PR DESCRIPTION
## Summary

This PR focuses on reducing code duplication and improving error handling across multiple modules:

### Changes

**1. Anthropic client (crates/anthropic/src/client.rs)**
- Introduced messages_builder! macro to eliminate duplication between MessagesBuilder and MessagesStreamBuilder
- Reduced ~120 lines of repetitive builder code
- Both builders now share a single implementation via macro

**2. Code highlighting (crates/coco-highlight/src/lang.rs)**
- Created simple_config() helper function to reduce duplication in language configuration
- Consolidated bash, diff, and JSON config creation into a single reusable function

**3. Component macros (crates/coco-macro/src/lib.rs)**
- Extracted parse_type_id() function with improved error handling
- Added proper span information for compile-time errors
- Better error messages when component attribute is missing or malformed
- Both ComponentExt and ContentComponentExt macros now share the same parsing logic

**4. TUI widgets (crates/coco-tui/src/widgets/)**
- Created new shared tabs module with reusable tab panel utilities
- Extracted tab_panel_width(), tab_panel_height(), and render_tabs_panel() functions
- Both bash and str_replace tools now use the shared tab rendering code

**5. Session socket client (src/combo/session.rs)**
- Introduced send_and_expect() helper method to reduce duplication in request-response patterns
- All metadata, MCP, prompt, and reply methods now use the same underlying implementation

### Benefits

- Reduced code duplication: ~200+ lines of repetitive code eliminated
- Improved maintainability: Changes to builder/response patterns now only need to be made in one place
- Better error messages: Compile-time errors in macros now include proper span information
- Clearer code organization: Shared utilities are properly abstracted into reusable functions