### PR TITLE
refactor: reduce code duplication with macros and convenience helpers

### DIFF
--- a/crates/anthropic/src/client/messages.rs
+++ b/crates/anthropic/src/client/messages.rs
@@ -639,6 +639,36 @@ struct StreamErrorEvent {
     error: StreamErrorDetail,
 }
 
+/// Execute an operation with retry logic, notification, and error conversion.
+///
+/// This macro reduces boilerplate for setting up retry configuration,
+/// notification callbacks, and final error transformation.
+macro_rules! with_retry {
+    ($retry_config:expr, $log_context:literal, $operation:expr) => {{
+        let notify = $retry_config.notifier.clone();
+        let max_attempts = $retry_config.max_attempts;
+        let mut attempts = 0usize;
+        let backoff = build_backoff($retry_config);
+        let result = $operation
+            .retry(backoff)
+            .when(AnthropicRequestError::is_retryable)
+            .notify(move |err, dur| {
+                attempts = attempts.saturating_add(1);
+                if let Some(notify) = notify.as_ref() {
+                    notify(RetryAttempt {
+                        attempt: attempts,
+                        max_attempts,
+                        delay: dur,
+                        error: err.to_string(),
+                    });
+                }
+                warn!(error = %err, delay = ?dur, concat!("retrying anthropic ", $log_context, " request"));
+            })
+            .await;
+        result.map_err(AnthropicRequestError::into_whatever)
+    }};
+}
+
 pub async fn messages_stream(
     client: &reqwest::Client,
     base_url: &Url,
@@ -652,11 +682,8 @@ pub async fn messages_stream(
     let body = serde_json::to_string(&req).whatever_context("encode request error")?;
     let client = client.clone();
     let url_clone = url.clone();
-    let notify = retry_config.notifier.clone();
-    let max_attempts = retry_config.max_attempts;
-    let mut attempts = 0usize;
-    let backoff = build_backoff(retry_config);
-    let result = (|| {
+
+    with_retry!(retry_config, "messages stream", || {
         let body = body.clone();
         let url = url_clone.clone();
         let client = client.clone();
@@ -685,26 +712,6 @@ pub async fn messages_stream(
             Ok(MessagesStream::new(resp))
         }
     })
-    .retry(backoff)
-    .when(AnthropicRequestError::is_retryable)
-    .notify(move |err, dur| {
-        attempts = attempts.saturating_add(1);
-        if let Some(notify) = notify.as_ref() {
-            notify(RetryAttempt {
-                attempt: attempts,
-                max_attempts,
-                delay: dur,
-                error: err.to_string(),
-            });
-        }
-        warn!(
-            error = %err,
-            delay = ?dur,
-            "retrying anthropic messages stream request"
-        );
-    })
-    .await;
-    result.map_err(AnthropicRequestError::into_whatever)
 }
 
 pub async fn messages(
@@ -719,11 +726,8 @@ pub async fn messages(
     let body = serde_json::to_string(&req).whatever_context("encode request error")?;
     let client = client.clone();
     let url_clone = url.clone();
-    let notify = retry_config.notifier.clone();
-    let max_attempts = retry_config.max_attempts;
-    let mut attempts = 0usize;
-    let backoff = build_backoff(retry_config);
-    let result = (|| {
+
+    with_retry!(retry_config, "messages", || {
         let body = body.clone();
         let url = url_clone.clone();
         let client = client.clone();
@@ -752,22 +756,6 @@ pub async fn messages(
                 .map_err(|err| AnthropicRequestError::decode("messages", err))
         }
     })
-    .retry(backoff)
-    .when(AnthropicRequestError::is_retryable)
-    .notify(move |err, dur| {
-        attempts = attempts.saturating_add(1);
-        if let Some(notify) = notify.as_ref() {
-            notify(RetryAttempt {
-                attempt: attempts,
-                max_attempts,
-                delay: dur,
-                error: err.to_string(),
-            });
-        }
-        warn!(error = %err, delay = ?dur, "retrying anthropic messages request");
-    })
-    .await;
-    result.map_err(AnthropicRequestError::into_whatever)
 }
 
 fn format_error_message(status: StatusCode, body: &str) -> String {

--- a/crates/openai/src/client.rs
+++ b/crates/openai/src/client.rs
@@ -90,6 +90,34 @@ impl Default for RetryConfig {
 
 type Result<T> = std::result::Result<T, Whatever>;
 
+/// Helper macro that wraps an async operation with retry logic, including backoff setup,
+/// notification callbacks, and final error transformation.
+macro_rules! with_retry {
+    ($retry_config:expr, $log_context:literal, $operation:expr) => {{
+        let notify = $retry_config.notifier.clone();
+        let max_attempts = $retry_config.max_attempts;
+        let mut attempts = 0usize;
+        let backoff = build_backoff($retry_config);
+        let result = $operation
+            .retry(backoff)
+            .when(OpenAIRequestError::is_retryable)
+            .notify(move |err, dur| {
+                attempts = attempts.saturating_add(1);
+                if let Some(notify) = notify.as_ref() {
+                    notify(RetryAttempt {
+                        attempt: attempts,
+                        max_attempts,
+                        delay: dur,
+                        error: err.to_string(),
+                    });
+                }
+                warn!(error = %err, delay = ?dur, concat!("retrying openai ", $log_context, " request"));
+            })
+            .await;
+        result.map_err(OpenAIRequestError::into_whatever)
+    }};
+}
+
 impl Client {
     pub fn new(
         base_url: &str,
@@ -155,51 +183,30 @@ impl Client {
             .join(self.api_path("chat/completions"))
             .whatever_context("build chat completions url")?;
         let cli = self.cli.clone();
-        let request = request;
-        let url_clone = url.clone();
-        let notify = retry.notifier.clone();
-        let max_attempts = retry.max_attempts;
-        let mut attempts = 0usize;
-        let backoff = build_backoff(retry);
-        let result =
-            (|| {
-                let request = request.clone();
-                let url = url_clone.clone();
-                let cli = cli.clone();
-                async move {
-                    let resp =
-                        cli.post(url).json(&request).send().await.map_err(|err| {
-                            OpenAIRequestError::transport("chat completions", err)
-                        })?;
-                    let status = resp.status();
-                    if !status.is_success() {
-                        let body = resp
-                            .text()
-                            .await
-                            .unwrap_or_else(|err| format!("failed to read error response: {err}"));
-                        return Err(OpenAIRequestError::http_status(status, body));
-                    }
-                    resp.json::<ChatCompletionResponse>()
+        with_retry!(retry, "chat completions", || {
+            let request = request.clone();
+            let url = url.clone();
+            let cli = cli.clone();
+            async move {
+                let resp = cli
+                    .post(url)
+                    .json(&request)
+                    .send()
+                    .await
+                    .map_err(|err| OpenAIRequestError::transport("chat completions", err))?;
+                let status = resp.status();
+                if !status.is_success() {
+                    let body = resp
+                        .text()
                         .await
-                        .map_err(|err| OpenAIRequestError::decode("chat completions", err))
+                        .unwrap_or_else(|err| format!("failed to read error response: {err}"));
+                    return Err(OpenAIRequestError::http_status(status, body));
                 }
-            })
-            .retry(backoff)
-            .when(OpenAIRequestError::is_retryable)
-            .notify(move |err, dur| {
-                attempts = attempts.saturating_add(1);
-                if let Some(notify) = notify.as_ref() {
-                    notify(RetryAttempt {
-                        attempt: attempts,
-                        max_attempts,
-                        delay: dur,
-                        error: err.to_string(),
-                    });
-                }
-                warn!(error = %err, delay = ?dur, "retrying openai chat completions request");
-            })
-            .await;
-        result.map_err(OpenAIRequestError::into_whatever)
+                resp.json::<ChatCompletionResponse>()
+                    .await
+                    .map_err(|err| OpenAIRequestError::decode("chat completions", err))
+            }
+        })
     }
 
     pub async fn chat_completions_stream(
@@ -217,15 +224,9 @@ impl Client {
             .join(self.api_path("chat/completions"))
             .whatever_context("build chat completions stream url")?;
         let cli = self.cli.clone();
-        let request = request;
-        let url_clone = url.clone();
-        let notify = retry.notifier.clone();
-        let max_attempts = retry.max_attempts;
-        let mut attempts = 0usize;
-        let backoff = build_backoff(retry);
-        let result = (|| {
+        with_retry!(retry, "chat completions stream", || {
             let request = request.clone();
-            let url = url_clone.clone();
+            let url = url.clone();
             let cli = cli.clone();
             async move {
                 let resp =
@@ -243,22 +244,6 @@ impl Client {
                 Ok(ChatCompletionStream::new(resp))
             }
         })
-        .retry(backoff)
-        .when(OpenAIRequestError::is_retryable)
-        .notify(move |err, dur| {
-            attempts = attempts.saturating_add(1);
-            if let Some(notify) = notify.as_ref() {
-                notify(RetryAttempt {
-                    attempt: attempts,
-                    max_attempts,
-                    delay: dur,
-                    error: err.to_string(),
-                });
-            }
-            warn!(error = %err, delay = ?dur, "retrying openai chat completions stream request");
-        })
-        .await;
-        result.map_err(OpenAIRequestError::into_whatever)
     }
 }
 

--- a/crates/openai/src/types.rs
+++ b/crates/openai/src/types.rs
@@ -25,6 +25,56 @@ pub struct ChatMessage {
     pub name: Option<String>,
 }
 
+impl ChatMessage {
+    /// Create a system message
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::System,
+            content: Some(content.into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// Create a user message
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: Some(content.into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// Create an assistant message
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: Some(content.into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    /// Create a tool result message
+    pub fn tool_result(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Tool,
+            content: Some(content.into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            name: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tool {
     #[serde(rename = "type")]

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -7,12 +7,7 @@ pub async fn handle_metadata(fields: Vec<String>) -> Result<()> {
     let payload = parse_metadata_fields(&fields)?;
     let name = payload.name.clone();
 
-    let Some(client) = SessionSocketClient::from_env()
-        .await
-        .whatever_context("failed to new from env COCO_SESSION_SOCK")?
-    else {
-        whatever!("env COCO_SESSION_SOCK is not set");
-    };
+    let client = SessionSocketClient::require_from_env().await?;
 
     let MetadataResponse { discovery } = client
         .send_metadata_wait_response(payload)

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -13,12 +13,7 @@ pub async fn handle_ask(prompt: String, schemas: Vec<String>) -> Result<()> {
         schemas.push(default_prompt_schema());
     }
 
-    let Some(client) = SessionSocketClient::from_env()
-        .await
-        .whatever_context("failed to new from env COCO_SESSION_SOCK")?
-    else {
-        whatever!("env COCO_SESSION_SOCK is not set");
-    };
+    let client = SessionSocketClient::require_from_env().await?;
 
     let payload = PromptPayload {
         prompt,
@@ -43,12 +38,7 @@ pub async fn handle_ask(prompt: String, schemas: Vec<String>) -> Result<()> {
 
 pub async fn handle_tell(prompt: String) -> Result<()> {
     let prompt = resolve_prompt(prompt).await?;
-    let Some(client) = SessionSocketClient::from_env()
-        .await
-        .whatever_context("failed to new from env COCO_SESSION_SOCK")?
-    else {
-        whatever!("env COCO_SESSION_SOCK is not set");
-    };
+    let client = SessionSocketClient::require_from_env().await?;
     let payload = PromptPayload {
         prompt,
         thinking: None,
@@ -66,12 +56,7 @@ pub async fn handle_tell(prompt: String) -> Result<()> {
 /// Fields are provided as --field=value format.
 /// Validation is done by the parent process (TUI) which knows the required schemas.
 pub async fn handle_reply(fields: Vec<String>) -> Result<()> {
-    let Some(client) = SessionSocketClient::from_env()
-        .await
-        .whatever_context("failed to new from env COCO_SESSION_SOCK")?
-    else {
-        whatever!("env COCO_SESSION_SOCK is not set");
-    };
+    let client = SessionSocketClient::require_from_env().await?;
 
     let validation = client
         .send_reply_wait_validation(ReplyPayload { fields })

--- a/src/cmd/record.rs
+++ b/src/cmd/record.rs
@@ -27,12 +27,7 @@ pub async fn handle_record(wrap_result: bool, command: Vec<String>) -> Result<()
     ensure_whatever!(!command.is_empty(), "command is required");
     let exec_command = normalize_command(&command);
 
-    let client = SessionSocketClient::from_env()
-        .await
-        .whatever_context("failed to new from env COCO_SESSION_SOCK")?;
-    let Some(client) = client else {
-        whatever!("env COCO_SESSION_SOCK is not set");
-    };
+    let client = SessionSocketClient::require_from_env().await?;
     let started_at = OffsetDateTime::now_utc().unix_timestamp();
     let mut session = Some(
         client

--- a/src/combo/session.rs
+++ b/src/combo/session.rs
@@ -349,6 +349,21 @@ impl SessionSocketClient {
         Self::from_env_key(MCP_SOCKET_ENV).await
     }
 
+    /// Get the session socket client from environment, returning an error if not set.
+    ///
+    /// This is a convenience method that combines `from_env()` with an error
+    /// for the missing environment variable case.
+    pub async fn require_from_env() -> crate::error::Result<Self> {
+        use snafu::prelude::*;
+        let Some(client) = Self::from_env()
+            .await
+            .whatever_context("failed to connect to COCO_SESSION_SOCK")?
+        else {
+            whatever!("env COCO_SESSION_SOCK is not set");
+        };
+        Ok(client)
+    }
+
     async fn from_env_key(key: &str) -> ClientResult<Option<Self>> {
         match std::env::var_os(key) {
             Some(path) => Ok(Some(Self::connect(path).await?)),

--- a/src/combo/starter.rs
+++ b/src/combo/starter.rs
@@ -388,6 +388,23 @@ fn build_combo_from_session(
     Ok(parse_combo(command))
 }
 
+/// Helper macro to send a failed event and return early with the error.
+/// Used within the execute_command async block where `event_tx` and `command` are in scope.
+macro_rules! fail_early {
+    ($event_tx:expr, $command:expr, $error:expr) => {{
+        $event_tx
+            .send(StarterEvent::Failed {
+                reason: $error.to_string(),
+            })
+            .await
+            .ok();
+        return Starter {
+            path: $command,
+            combo: Err($error),
+        };
+    }};
+}
+
 fn execute_command(
     command: String,
     args: Vec<String>,
@@ -416,34 +433,14 @@ fn execute_command(
         let mut session_server = match _session_env_guard.as_ref() {
             Some(env) => match spawn_session_server(env, discovery, event_tx.clone()).await {
                 Ok(task) => Some(task),
-                Err(error) => {
-                    event_tx
-                        .send(StarterEvent::Failed {
-                            reason: error.to_string(),
-                        })
-                        .await
-                        .ok();
-                    return Starter {
-                        path: command,
-                        combo: Err(error),
-                    };
-                }
+                Err(error) => fail_early!(event_tx, command, error),
             },
             None => {
                 let error = InvalidSnafu {
                     reason: "session env is required for starter execution".to_string(),
                 }
                 .build();
-                event_tx
-                    .send(StarterEvent::Failed {
-                        reason: error.to_string(),
-                    })
-                    .await
-                    .ok();
-                return Starter {
-                    path: command,
-                    combo: Err(error),
-                };
+                fail_early!(event_tx, command, error);
             }
         };
         let event_tx = event_tx;
@@ -467,16 +464,7 @@ fn execute_command(
                     }
                     .build(),
                 };
-                event_tx
-                    .send(StarterEvent::Failed {
-                        reason: error.to_string(),
-                    })
-                    .await
-                    .ok();
-                return Starter {
-                    path: command,
-                    combo: Err(error),
-                };
+                fail_early!(event_tx, command, error);
             }
         };
 
@@ -564,33 +552,13 @@ fn execute_command(
                         task.shutdown();
                         match task.handle.await {
                             Ok(Ok(state)) => Some(state),
-                            Ok(Err(err)) => {
-                                event_tx
-                                    .send(StarterEvent::Failed {
-                                        reason: err.to_string(),
-                                    })
-                                    .await
-                                    .ok();
-                                return Starter {
-                                    path: command,
-                                    combo: Err(err),
-                                };
-                            }
+                            Ok(Err(err)) => fail_early!(event_tx, command, err),
                             Err(err) => {
                                 let error = InvalidSnafu {
                                     reason: format!("session server join error: {err}"),
                                 }
                                 .build();
-                                event_tx
-                                    .send(StarterEvent::Failed {
-                                        reason: error.to_string(),
-                                    })
-                                    .await
-                                    .ok();
-                                return Starter {
-                                    path: command,
-                                    combo: Err(error),
-                                };
+                                fail_early!(event_tx, command, error);
                             }
                         }
                     } else {

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -112,14 +112,7 @@ fn build_request(
     if let Some(system_prompt) = system_prompt
         && !system_prompt.trim().is_empty()
     {
-        messages.push(openai_api::ChatMessage {
-            role: openai_api::Role::System,
-            content: Some(system_prompt.to_string()),
-            reasoning_content: None,
-            tool_calls: None,
-            tool_call_id: None,
-            name: None,
-        });
+        messages.push(openai_api::ChatMessage::system(system_prompt));
     }
     messages.extend(convert_messages(conversations)?);
     let tools = tools
@@ -190,14 +183,7 @@ fn convert_user_message(
     match content {
         Content::Text(value) => {
             if !value.is_empty() {
-                output.push(openai_api::ChatMessage {
-                    role: openai_api::Role::User,
-                    content: Some(value),
-                    reasoning_content: None,
-                    tool_calls: None,
-                    tool_call_id: None,
-                    name: None,
-                });
+                output.push(openai_api::ChatMessage::user(value));
             }
             return Ok(());
         }
@@ -217,25 +203,11 @@ fn convert_user_message(
         }
     }
     if !text.is_empty() {
-        output.push(openai_api::ChatMessage {
-            role: openai_api::Role::User,
-            content: Some(text),
-            reasoning_content: None,
-            tool_calls: None,
-            tool_call_id: None,
-            name: None,
-        });
+        output.push(openai_api::ChatMessage::user(text));
     }
     for (tool_use_id, result_content) in tool_results {
         let content = content_to_text(&result_content);
-        output.push(openai_api::ChatMessage {
-            role: openai_api::Role::Tool,
-            content: Some(content),
-            reasoning_content: None,
-            tool_calls: None,
-            tool_call_id: Some(tool_use_id),
-            name: None,
-        });
+        output.push(openai_api::ChatMessage::tool_result(tool_use_id, content));
     }
     Ok(())
 }
@@ -250,14 +222,7 @@ fn convert_assistant_message(
     match content {
         Content::Text(value) => {
             if !value.is_empty() {
-                output.push(openai_api::ChatMessage {
-                    role: openai_api::Role::Assistant,
-                    content: Some(value),
-                    reasoning_content: None,
-                    tool_calls: None,
-                    tool_call_id: None,
-                    name: None,
-                });
+                output.push(openai_api::ChatMessage::assistant(value));
             }
             return Ok(());
         }


### PR DESCRIPTION
## Summary

This PR refactors error handling and request retry logic to reduce code duplication across the codebase.

### Changes

- **Extract `fail_early!` macro** in `src/combo/starter.rs`: Reduces repetitive error handling code that sends failed events and returns early
- **Extract `with_retry!` macro** in both `crates/anthropic` and `crates/openai`: Consolidates retry logic with backoff, notification, and error transformation
- **Add convenience helper `require_from_env()`** in `src/combo/session.rs`: Simplifies session socket client initialization with proper error handling
- **Add `ChatMessage` constructor methods** in `crates/openai/src/types.rs`: Provides `system()`, `user()`, `assistant()`, and `tool_result()` static methods for cleaner message creation