### PR TITLE
feat: improve TUI layout for small screen sizes

### DIFF
--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1334,7 +1334,15 @@ impl Chat<'static> {
         }
     }
 
-    fn input_block_with_dynamic_titles<'a>(&'a self, mut block: Block<'a>) -> Block<'a> {
+    fn input_block_with_dynamic_titles<'a>(
+        &'a self,
+        mut block: Block<'a>,
+        width: u16,
+    ) -> Block<'a> {
+        // Threshold for compact mode: move some indicators from bottom to top
+        const COMPACT_WIDTH: u16 = 100;
+        let compact = width < COMPACT_WIDTH;
+
         block = block.title_top(Line::from(""));
         let focus = self.focus_for_shortcut_hints();
         let hints = match focus {
@@ -1347,20 +1355,33 @@ impl Chat<'static> {
             Focus::CommandPalette | Focus::ShortcutHints => block,
             _ => self.shortcut_hints.decorate_block_top(block, &hints),
         };
+
+        // In compact mode, move context usage and model to top for balanced display
+        if compact {
+            if let Some(line) = self.context_usage_indicator() {
+                block = block.title_top(line);
+            }
+            block = block.title_top(self.model_indicator());
+        }
+
         block = block
             .title_bottom(Line::from(""))
             .title_bottom(self.widget_state_indicator());
         if let Some(line) = self.retry_indicator_line() {
             block = block.title_bottom(line);
         }
+
+        // In normal mode, model and context stay at bottom
+        if !compact {
+            block = block.title_bottom(self.model_indicator());
+        }
         block = block
-            .title_bottom(self.model_indicator())
             .title_bottom(self.auto_accept_indicator())
             .title_bottom(self.thinking_indicator());
         if let Some(line) = self.ctrl_c_reminder_line() {
             block = block.title_bottom(line);
         }
-        if let Some(line) = self.context_usage_indicator() {
+        if !compact && let Some(line) = self.context_usage_indicator() {
             block = block.title_bottom(line);
         }
         block
@@ -1379,7 +1400,7 @@ impl Chat<'static> {
                 .border_style(theme.ui.block_border_inactive)
         };
 
-        block = self.input_block_with_dynamic_titles(block);
+        block = self.input_block_with_dynamic_titles(block, area.width);
         frame.render_widget(&block, area);
         self.input.draw(frame, block.inner(area))?;
 

--- a/crates/coco-tui/src/components/shortcut_hints.rs
+++ b/crates/coco-tui/src/components/shortcut_hints.rs
@@ -55,7 +55,9 @@ impl ShortcutHintsPanel {
             horizontal: 3,
             vertical: 1,
         };
-        let width = 120 + (margin_background.horizontal + margin_content.horizontal) * 2;
+        // Adaptive width: prefer 132 but shrink to fit screen with minimal margins
+        let preferred_width = 120 + (margin_background.horizontal + margin_content.horizontal) * 2;
+        let width = preferred_width.min(area.width.saturating_sub(4));
         let height = (self.hints.hidden.len() as u16)
             .saturating_add(4 + margin_background.vertical * 2 + margin_content.vertical * 2)
             .min(area.height.saturating_sub(2))


### PR DESCRIPTION
## Summary

This PR improves the TUI experience for small terminal sizes by making the UI more responsive and space-efficient.

## Changes

### Compact Mode for Input Block (chat.rs)
- Added a compact mode that activates when terminal width < 100 characters
- In compact mode, moves context usage indicator and model indicator from bottom to top of the input block
- This balances the visual layout and prevents bottom indicators from overwhelming small screens
- Normal mode (wider screens) keeps the original layout with indicators at the bottom

### Adaptive Shortcut Hints Panel (shortcut_hints.rs)
- Made the shortcut hints panel width adaptive to fit available screen space
- Previously fixed at 120+ characters, now shrinks to fit with minimal margins (4 chars reserved)
- Ensures the popup remains usable on smaller screens without horizontal overflow

## Related Issue

Fixes #125 - The TUI now adapts layouts to fit available space and ensures essential controls remain accessible on small screen sizes.