### PR TITLE
feat(tui): add Ctrl-L for manual full-screen refresh

### DIFF
--- a/crates/coco-tui/src/app.rs
+++ b/crates/coco-tui/src/app.rs
@@ -48,7 +48,6 @@ pub struct App {
     // Config
     frame_rate: f64,
     tick_rate: f64,
-    full_refresh_rate: f64,
 }
 
 impl App {
@@ -74,7 +73,6 @@ impl App {
             root,
             frame_rate: 60.0,
             tick_rate: 4.0,
-            full_refresh_rate: 1.0 / 30.0, // every 30 seconds
         })
     }
 
@@ -104,7 +102,6 @@ impl App {
             self.cancellation_token.clone(),
             self.frame_rate,
             self.tick_rate,
-            self.full_refresh_rate,
         );
         self.send_event(Event::Init);
         self.task = tokio::spawn(async {
@@ -181,12 +178,10 @@ impl App {
         cancellation_token: CancellationToken,
         frame_rate: f64,
         tick_rate: f64,
-        full_refresh_rate: f64,
     ) {
         let mut event_stream = EventStream::new();
         let mut tick_interval = interval(Duration::from_secs_f64(1.0 / tick_rate));
         let mut render_interval = interval(Duration::from_secs_f64(1.0 / frame_rate));
-        let mut full_refresh_interval = interval(Duration::from_secs_f64(1.0 / full_refresh_rate));
 
         loop {
             let event = tokio::select! {
@@ -195,7 +190,6 @@ impl App {
                 },
                 _ = tick_interval.tick() => Event::Tick,
                 _ = render_interval.tick() => Event::Render,
-                _ = full_refresh_interval.tick() => Event::FullRefresh,
                 crossterm_event = event_stream.next().fuse() => match crossterm_event {
                     Some(Ok(event)) => match event {
                         CrosstermEvent::Key(key) => Event::Key(key),
@@ -281,16 +275,19 @@ impl App {
     }
 
     fn render(&mut self) -> Result<()> {
+        // If a full refresh is requested, first do a blank draw to reset
+        // ratatui's internal buffer state, then do the actual render.
+        // This ensures the diff algorithm starts from a clean slate.
+        if self.force_full_refresh {
+            self.terminal
+                .draw(|frame| {
+                    frame.render_widget(ratatui::widgets::Clear, frame.area());
+                })
+                .whatever_context("failed to clear terminal for full refresh")?;
+        }
+
         self.terminal
             .draw(|frame| {
-                // If a full refresh is requested, first render a blank block
-                // to clear any ratatui diff artifacts. Then render the actual content.
-                // This clears any leftover characters from the diff algorithm.
-                if self.force_full_refresh {
-                    let blank = ratatui::widgets::Clear;
-                    frame.render_widget(blank, frame.area());
-                }
-
                 if let Err(err) = self.root.draw(frame, frame.area()) {
                     error!(?err, "terminal draw error");
                 }

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1288,6 +1288,7 @@ impl Chat<'static> {
         hints.push_visible(&[("Up", "k"), ("Down", "j")]);
         hints.push_hidden(&[("Thinking", "C-r")]);
         hints.push_hidden(&[("Auto Accept Edits", "S-Tab")]);
+        hints.push_hidden(&[("Refresh", "C-l")]);
         hints
     }
 
@@ -1304,6 +1305,7 @@ impl Chat<'static> {
         hints.push_hidden(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]);
         hints.push_hidden(&[("Thinking", "C-r")]);
         hints.push_hidden(&[("Auto Accept Edits", "S-Tab")]);
+        hints.push_hidden(&[("Refresh", "C-l")]);
         hints
     }
 
@@ -1318,6 +1320,7 @@ impl Chat<'static> {
         hints.push_visible(&[("Up", "k"), ("Down", "j")]);
         hints.push_hidden(&[("Scroll Up", "C-y"), ("Down", "C-e")]);
         hints.push_hidden(&[("Scroll+ Up", "C-u"), ("Down", "C-d")]);
+        hints.push_hidden(&[("Refresh", "C-l")]);
         hints
     }
 
@@ -2399,6 +2402,18 @@ impl Component for Chat<'static> {
             )
         {
             self.toggle_thinking();
+            return;
+        }
+        // Ctrl-L: Force full screen refresh to clear residual artifacts
+        if matches!(
+            key,
+            KeyEvent {
+                code: Char('l') | Char('L'),
+                modifiers: KM::CONTROL,
+                ..
+            }
+        ) {
+            global::signal_full_refresh();
             return;
         }
         if self.view == ViewMode::Transcript {

--- a/crates/coco-tui/src/components/input.rs
+++ b/crates/coco-tui/src/components/input.rs
@@ -51,6 +51,7 @@ impl Input<'_> {
         let mut hints = ShortcutHints::default();
         hints.push_visible(&[("Blur", "Esc")]);
         hints.push_visible(&[("Submit", "A-CR")]);
+        hints.push_visible(&[("Help", "Esc+?")]);
         hints.push_hidden(&[("Thinking", "C-r")]);
         hints.push_hidden(&[("Auto Accept Edits", "S-Tab")]);
         hints.push_hidden(&[("Refresh", "C-l")]);

--- a/crates/coco-tui/src/components/input.rs
+++ b/crates/coco-tui/src/components/input.rs
@@ -53,6 +53,7 @@ impl Input<'_> {
         hints.push_visible(&[("Submit", "A-CR")]);
         hints.push_hidden(&[("Thinking", "C-r")]);
         hints.push_hidden(&[("Auto Accept Edits", "S-Tab")]);
+        hints.push_hidden(&[("Refresh", "C-l")]);
         hints
     }
 }

--- a/crates/coco-tui/src/global.rs
+++ b/crates/coco-tui/src/global.rs
@@ -117,6 +117,16 @@ pub fn signal_dirty() {
     event_tx().send(Event::Dirty).ok();
 }
 
+/// Signal full refresh to clear screen artifacts.
+///
+/// This function sends a `FullRefresh` event to trigger a complete redraw of the UI,
+/// clearing any residual character artifacts left by the ratatui diff algorithm.
+/// Users can trigger this manually via Ctrl-L when visual artifacts appear.
+#[inline]
+pub fn signal_full_refresh() {
+    event_tx().send(Event::FullRefresh).ok();
+}
+
 /// `State` is modify-aware to signal the Dirty event for re-rendering.
 ///
 /// This struct wraps any type `T` and provides a mechanism to automatically


### PR DESCRIPTION
Implements manual full-screen refresh via Ctrl-L to fix ratatui residual character artifacts. Removes automatic 30s refresh timer. Closes #136