### PR TITLE
fix: display dynamic help shortcut hint based on focus

### DIFF
--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1374,7 +1374,9 @@ impl Chat<'static> {
         };
         block = match focus {
             Focus::CommandPalette | Focus::ShortcutHints => block,
-            _ => self.shortcut_hints.decorate_block_top(block, &hints),
+            _ => self
+                .shortcut_hints
+                .decorate_block_top(block, &hints, focus == Focus::Input),
         };
 
         // In compact mode, move context usage and model to top for balanced display

--- a/crates/coco-tui/src/components/input.rs
+++ b/crates/coco-tui/src/components/input.rs
@@ -51,7 +51,6 @@ impl Input<'_> {
         let mut hints = ShortcutHints::default();
         hints.push_visible(&[("Blur", "Esc")]);
         hints.push_visible(&[("Submit", "A-CR")]);
-        hints.push_visible(&[("Help", "Esc+?")]);
         hints.push_hidden(&[("Thinking", "C-r")]);
         hints.push_hidden(&[("Auto Accept Edits", "S-Tab")]);
         hints.push_hidden(&[("Refresh", "C-l")]);

--- a/crates/coco-tui/src/components/shortcut_hints.rs
+++ b/crates/coco-tui/src/components/shortcut_hints.rs
@@ -32,8 +32,13 @@ impl ShortcutHintsPanel {
         self.hints = hints;
     }
 
-    pub fn decorate_block_top<'a>(&self, block: Block<'a>, hints: &ShortcutHints) -> Block<'a> {
-        self.apply_shortcut_hints_top(block, hints)
+    pub fn decorate_block_top<'a>(
+        &self,
+        block: Block<'a>,
+        hints: &ShortcutHints,
+        is_input_focused: bool,
+    ) -> Block<'a> {
+        self.apply_shortcut_hints_top(block, hints, is_input_focused)
     }
 
     pub fn decorate_block_bottom<'a>(&self, block: Block<'a>, hints: &ShortcutHints) -> Block<'a> {
@@ -113,12 +118,15 @@ impl ShortcutHintsPanel {
         &self,
         mut block: Block<'a>,
         hints: &ShortcutHints,
+        is_input_focused: bool,
     ) -> Block<'a> {
         for group in &hints.visible {
             block = block.title_top(shortcuts_desc(group));
         }
         if hints.has_hidden() {
-            block = block.title_top(shortcuts_desc(&[("Help", "?")]));
+            // Input focus requires Esc to blur first before pressing ?
+            let help_key = if is_input_focused { "Esc+?" } else { "?" };
+            block = block.title_top(shortcuts_desc(&[("Help", help_key)]));
         }
         block
     }


### PR DESCRIPTION
## Summary

Fix duplicate help shortcut hints by showing the appropriate key based on current focus state:

- **Input focused**: Display `Esc+?` (require blur first)
- **Other focus**: Display `?` directly

## Changes

- Update `decorate_block_top` signature to accept `is_input_focused` parameter
- Remove hardcoded help hint from input component
- Dynamically render help key in shortcut hints panel based on focus state

## Impact

- `coco-tui` shortcut hints panel

Fixes duplicate hints and makes help guidance more accurate.