### PR TITLE
refactor: restructure combo module and add streaming line buffering

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -58,6 +58,7 @@ pub use config::{
     load_agent_config_with_layers,
 };
 pub use executor::{ExecuteStatus, Executor, Input, Output};
+pub use streaming::{BufferSet, EmitChunkCallback, LineBuffer};
 
 // Internal submodules
 mod bash_executor;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -24,9 +24,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::{
-    Config, Error, PromptSchema, RequestOptions, Result, ResultDisplayExt, StreamError,
-    ThinkingBlocksMode, ThinkingConfig,
-    tools::{ComboEvent, ComboInfo, RunComboContext, RunTaskContext, RunTaskTool, run_combo},
+    ComboEvent, ComboInfo, Config, Error, PromptSchema, RequestOptions, Result, ResultDisplayExt,
+    RunComboContext, StreamError, ThinkingBlocksMode, ThinkingConfig,
+    tools::{RunTaskContext, RunTaskTool, run_combo},
 };
 use executor::PermissionControl;
 use message::{

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -23,10 +23,11 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
+use crate::combo::run_combo;
 use crate::{
     ComboEvent, ComboInfo, Config, Error, PromptSchema, RequestOptions, Result, ResultDisplayExt,
     RunComboContext, StreamError, ThinkingBlocksMode, ThinkingConfig,
-    tools::{RunTaskContext, RunTaskTool, run_combo},
+    tools::{RunTaskContext, RunTaskTool},
 };
 use executor::PermissionControl;
 use message::{

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -10,11 +10,11 @@ use tokio_util::sync::CancellationToken;
 
 use super::bash_executor;
 use crate::{
-    AppliedTextEdit, OutputChunk, TextEdit, error,
+    AppliedTextEdit, ComboEvent, OutputChunk, TextEdit, error,
     tools::{
-        self, BASH_TOOL_NAME, BashInput, BashTool, ComboEvent, Final, LIST_TOOL_NAME, ListTool,
-        READ_TOOL_NAME, RUN_TASK_TOOL_NAME, ReadTool, RunTaskTool, STR_REPLACE_TOOL_NAME,
-        StrReplaceTool, SubagentEvent, Tool, extra_envs_for_bash_input, run_bash_chunked, run_task,
+        self, BASH_TOOL_NAME, BashInput, BashTool, Final, LIST_TOOL_NAME, ListTool, READ_TOOL_NAME,
+        RUN_TASK_TOOL_NAME, ReadTool, RunTaskTool, STR_REPLACE_TOOL_NAME, StrReplaceTool,
+        SubagentEvent, Tool, extra_envs_for_bash_input, run_bash_chunked, run_task,
     },
 };
 

--- a/src/agent/streaming.rs
+++ b/src/agent/streaming.rs
@@ -4,10 +4,12 @@
 //! from AI providers, including event accumulation, retry logic, and progress updates.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
+use crate::exec::StreamKind;
 use crate::provider::{Block, ContentBlockDelta, MessagesStreamEvent, StopReason, UsageStats};
-use crate::{RetryAttempt as CoreRetryAttempt, RetryUpdate, StreamError};
+use crate::{OutputChunk, RetryAttempt as CoreRetryAttempt, RetryUpdate, StreamError};
 use snafu::ResultExt;
 use tokio_util::sync::CancellationToken;
 
@@ -272,6 +274,157 @@ pub async fn wait_for_retry(delay: Duration, cancel_token: &CancellationToken) -
     }
 }
 
+/// Callback type for emitting stream chunks.
+pub type EmitChunkCallback = Arc<dyn Fn(OutputChunk) + Send + Sync>;
+
+/// Buffer for aggregating streaming text into lines.
+pub struct LineBuffer {
+    buffer: Arc<std::sync::Mutex<String>>,
+    stream: StreamKind,
+    prefix: String,
+}
+
+impl LineBuffer {
+    /// Create a new line buffer for the given stream type.
+    pub fn new(stream: StreamKind) -> Self {
+        Self {
+            buffer: Arc::new(std::sync::Mutex::new(String::new())),
+            stream,
+            prefix: String::new(),
+        }
+    }
+
+    /// Create a new line buffer with a prefix for each line.
+    pub fn with_prefix(stream: StreamKind, prefix: impl Into<String>) -> Self {
+        Self {
+            buffer: Arc::new(std::sync::Mutex::new(String::new())),
+            stream,
+            prefix: prefix.into(),
+        }
+    }
+
+    /// Add text to the buffer and emit complete lines via callback.
+    pub fn append(&self, text: &str, emit: &EmitChunkCallback) {
+        let mut buf = self.buffer.lock().unwrap();
+        buf.push_str(text);
+
+        let now_ms = || {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        };
+
+        let mut lines_to_emit = Vec::new();
+        while let Some(newline_pos) = buf.find('\n') {
+            let line = buf.drain(..=newline_pos).collect::<String>();
+            let line = line.trim_end_matches('\n');
+            if !line.is_empty() || self.prefix.is_empty() {
+                lines_to_emit.push(format!("{}{}", self.prefix, line));
+            }
+        }
+
+        if !lines_to_emit.is_empty() {
+            let chunk = OutputChunk {
+                timestamp: now_ms(),
+                stream: self.stream,
+                lines: lines_to_emit,
+            };
+            emit(chunk);
+        }
+    }
+
+    /// Clear the buffer.
+    pub fn clear(&self) {
+        let mut buf = self.buffer.lock().unwrap();
+        buf.clear();
+    }
+
+    /// Flush remaining content as a single line.
+    pub fn flush(&self, emit: &EmitChunkCallback) {
+        let mut buf = self.buffer.lock().unwrap();
+        if buf.is_empty() {
+            return;
+        }
+
+        let now_ms = || {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        };
+
+        let content = std::mem::take(&mut *buf);
+        let line = if self.prefix.is_empty() {
+            content
+        } else {
+            format!("{}{}", self.prefix, content)
+        };
+
+        let chunk = OutputChunk {
+            timestamp: now_ms(),
+            stream: self.stream,
+            lines: vec![line],
+        };
+        emit(chunk);
+    }
+
+    /// Get a reference to the internal buffer for cloning.
+    pub fn clone_buffer(&self) -> Arc<std::sync::Mutex<String>> {
+        self.buffer.clone()
+    }
+}
+
+/// Manages multiple line buffers for different stream types.
+pub struct BufferSet {
+    pub plain: LineBuffer,
+    pub thinking: LineBuffer,
+}
+
+impl BufferSet {
+    /// Create a new buffer set.
+    pub fn new() -> Self {
+        Self {
+            plain: LineBuffer::new(StreamKind::Stdout),
+            thinking: LineBuffer::with_prefix(StreamKind::Stderr, "[thinking] "),
+        }
+    }
+
+    /// Handle a chat stream update, buffering and emitting lines as appropriate.
+    pub fn handle_update(&self, update: &ChatStreamUpdate, emit: &EmitChunkCallback) {
+        match update {
+            ChatStreamUpdate::Reset => {
+                self.plain.clear();
+                self.thinking.clear();
+            }
+            ChatStreamUpdate::Plain { text, .. } => {
+                self.plain.append(text, emit);
+            }
+            ChatStreamUpdate::Thinking { text, .. } => {
+                self.thinking.append(text, emit);
+            }
+        }
+    }
+
+    /// Flush all remaining buffered content.
+    pub fn flush_all(&self, emit: &EmitChunkCallback) {
+        self.plain.flush(emit);
+        self.thinking.flush(emit);
+    }
+
+    /// Clear all buffers.
+    pub fn clear_all(&self) {
+        self.plain.clear();
+        self.thinking.clear();
+    }
+}
+
+impl Default for BufferSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -382,5 +535,90 @@ mod tests {
 
         let err = StreamError::decode("chat stream cancelled".to_string());
         assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn line_buffer_emits_complete_lines() {
+        let buffer = LineBuffer::new(StreamKind::Stdout);
+        let emitted: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let emitted_clone = emitted.clone();
+        let emit: EmitChunkCallback = Arc::new(move |chunk| {
+            emitted_clone.lock().unwrap().extend(chunk.lines);
+        });
+
+        buffer.append("hello", &emit);
+        assert!(emitted.lock().unwrap().is_empty());
+
+        buffer.append(" world\n", &emit);
+        assert_eq!(emitted.lock().unwrap().len(), 1);
+        assert_eq!(emitted.lock().unwrap()[0], "hello world");
+    }
+
+    #[test]
+    fn line_buffer_with_prefix() {
+        let buffer = LineBuffer::with_prefix(StreamKind::Stderr, "[test] ");
+        let emitted: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let emitted_clone = emitted.clone();
+        let emit: EmitChunkCallback = Arc::new(move |chunk| {
+            emitted_clone.lock().unwrap().extend(chunk.lines);
+        });
+
+        buffer.append("line1\nline2\n", &emit);
+        let lines = emitted.lock().unwrap();
+        assert_eq!(lines[0], "[test] line1");
+        assert_eq!(lines[1], "[test] line2");
+    }
+
+    #[test]
+    fn buffer_set_reset_clears_all() {
+        let buffers = BufferSet::new();
+        let emit: EmitChunkCallback = Arc::new(|_| {});
+
+        buffers.plain.append("partial", &emit);
+        buffers.thinking.append("thinking", &emit);
+
+        buffers.clear_all();
+
+        buffers.flush_all(&emit);
+        // Flush should emit nothing after clear (verified by no panic)
+    }
+
+    #[test]
+    fn buffer_set_handles_chat_stream_updates() {
+        let buffers = BufferSet::new();
+        let emitted: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let emitted_clone = emitted.clone();
+        let emit: EmitChunkCallback = Arc::new(move |chunk| {
+            emitted_clone.lock().unwrap().extend(chunk.lines);
+        });
+
+        // Handle plain stream update
+        buffers.handle_update(
+            &ChatStreamUpdate::Plain {
+                index: 0,
+                text: "Hello\n".to_string(),
+            },
+            &emit,
+        );
+
+        // Handle thinking stream update
+        buffers.handle_update(
+            &ChatStreamUpdate::Thinking {
+                index: 0,
+                text: "Thinking\n".to_string(),
+            },
+            &emit,
+        );
+
+        let lines = emitted.lock().unwrap();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "Hello");
+        assert_eq!(lines[1], "[thinking] Thinking");
     }
 }

--- a/src/cmd/combo.rs
+++ b/src/cmd/combo.rs
@@ -5,8 +5,7 @@ use tokio::{process::Command, time::Instant};
 use tracing::{debug, info, warn};
 
 use crate::{
-    ComboRunPayload, ComboRunResult, SessionEnv, SessionSocketClient, error::Result,
-    tools::RunComboOutput,
+    ComboRunPayload, ComboRunResult, RunComboOutput, SessionEnv, SessionSocketClient, error::Result,
 };
 
 pub async fn handle_combo_run(

--- a/src/combo.rs
+++ b/src/combo.rs
@@ -14,12 +14,14 @@ pub struct Combo {
 }
 
 mod discovery;
+pub mod runner;
 mod session;
 mod session_env;
 mod starter;
 mod types;
 
 pub use discovery::*;
+pub use runner::{RUN_COMBO_TOOL_NAME, run_combo};
 pub use session::{
     ClientMessage, ComboRunEvent, ComboRunMessage, ComboRunPayload, ComboRunResult,
     ComboRunSession, ComboStreamKind, ControlAction, MetadataPayload, MetadataResponse,

--- a/src/combo.rs
+++ b/src/combo.rs
@@ -17,6 +17,7 @@ mod discovery;
 mod session;
 mod session_env;
 mod starter;
+mod types;
 
 pub use discovery::*;
 pub use session::{
@@ -30,3 +31,6 @@ pub use session::{
 pub use session_env::{SessionEnv, SessionEnvBuilder, SessionEnvError};
 pub use starter::PromptResponseSender;
 pub use starter::{Starter, StarterCommand, StarterError, StarterEvent, StarterExecution};
+pub use types::{
+    ComboEvent, ComboEventStreamKind, ComboInfo, RunComboContext, RunComboInput, RunComboOutput,
+};

--- a/src/combo/runner.rs
+++ b/src/combo/runner.rs
@@ -11,10 +11,24 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use super::{
-    BASH_TOOL_NAME, BashInput, ExecuteResult, Final, Input, Output, prepare_mcp_envs,
-    run_bash_chunked,
+macro_rules! err_msg {
+    ($template:literal) => {
+        crate::tools::Final::from(format!($template)).err()
+    };
+    ($template:literal, $expression:expr) => {
+        crate::tools::Final::from(format!($template, $expression)).err()
+    };
+    ($template:literal, $($expression:expr),* ) => {
+        crate::tools::Final::from(format!($template, $($expression),*)).err()
+    };
+}
+
+use crate::tools::{
+    BASH_TOOL_NAME, BashInput, Final, Input, Output, prepare_mcp_envs, run_bash_chunked,
 };
+
+pub type ExecuteResult = Result<Output, Final>;
+
 use crate::{
     Agent, Block, ChatStreamUpdate, Config, Content, Message, OutputChunk, PromptSchema,
     SessionEnv, Starter, StarterCommand, StarterError, StarterEvent, ToolUse, bash_unsafe_ranges,

--- a/src/combo/types.rs
+++ b/src/combo/types.rs
@@ -1,0 +1,222 @@
+//! Shared types for combo execution.
+//!
+//! This module contains types shared between combo tools and combo execution.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Combo, Message, OutputChunk, ThinkingConfig, ToolUse};
+
+// Import Final from tools module for use in combo events
+pub use crate::tools::Final;
+
+/// Stream kind for combo event output.
+/// Note: This is different from session::ComboStreamKind which is for socket communication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComboEventStreamKind {
+    Plain,
+    Thinking,
+}
+
+/// Event emitted during combo execution.
+#[derive(Debug, Clone)]
+pub enum ComboEvent {
+    /// Combo not found.
+    NotFound {
+        /// Combo name.
+        name: String,
+    },
+    /// Combo is executing.
+    Executing {
+        /// Combo name.
+        name: String,
+        /// Command line with args.
+        command_line: String,
+    },
+    /// Regular output chunk (stdout/stderr).
+    Output {
+        /// Combo name.
+        name: String,
+        /// Output chunk.
+        chunk: OutputChunk,
+    },
+    /// Tool record started.
+    RecordStart {
+        /// Combo name.
+        name: String,
+        /// Tool use info.
+        tool_use: ToolUse,
+    },
+    /// Tool record output.
+    RecordOutput {
+        /// Combo name.
+        name: String,
+        /// Tool use ID.
+        tool_use_id: String,
+        /// Output chunk.
+        chunk: OutputChunk,
+    },
+    /// Tool record ended.
+    RecordEnd {
+        /// Combo name.
+        name: String,
+        /// Tool use ID.
+        tool_use_id: String,
+        /// Whether the tool failed.
+        is_error: bool,
+        /// Tool output.
+        output: Final,
+    },
+    /// Prompt message from combo.
+    Prompt {
+        /// Combo name.
+        name: String,
+        /// Prompt text.
+        prompt: String,
+        /// Optional thinking config.
+        thinking: Option<ThinkingConfig>,
+    },
+    /// Prompt stream update for combo reply.
+    PromptStream {
+        /// Combo name.
+        name: String,
+        /// Stream index.
+        index: usize,
+        /// Stream kind.
+        kind: ComboEventStreamKind,
+        /// Streamed text.
+        text: String,
+    },
+    /// Reset prompt stream for combo reply.
+    PromptStreamReset {
+        /// Combo name.
+        name: String,
+    },
+    /// Reset summary stream for combo summary.
+    SummaryStreamReset {
+        /// Combo name.
+        name: String,
+    },
+    /// Summary stream update for combo summary.
+    SummaryStream {
+        /// Combo name.
+        name: String,
+        /// Stream index.
+        index: usize,
+        /// Stream kind.
+        kind: ComboEventStreamKind,
+        /// Streamed text.
+        text: String,
+    },
+    /// Summary completion for combo summary.
+    SummaryDone {
+        /// Combo name.
+        name: String,
+        /// Summary text.
+        summary: String,
+        /// Thinking blocks.
+        thinking: Vec<String>,
+    },
+    /// Reply tool use from prompt.
+    ReplyToolUse {
+        /// Combo name.
+        name: String,
+        /// Tool use info.
+        tool_use: ToolUse,
+        /// Thinking blocks.
+        thinking: Vec<String>,
+        /// Whether this is an offload reply (executed via bash).
+        offload: bool,
+    },
+    /// Reply tool result for offload.
+    ReplyToolResult {
+        /// Combo name.
+        name: String,
+        /// Tool use ID.
+        tool_use_id: String,
+        /// Whether the tool failed.
+        is_error: bool,
+        /// Tool output.
+        output: Final,
+    },
+    /// Reply tool error.
+    ReplyToolError {
+        /// Error message.
+        message: String,
+    },
+    /// Combo execution finished.
+    Executed {
+        /// Combo name.
+        name: String,
+        /// Starter summary.
+        starter: crate::Starter,
+        /// Exit code.
+        exit_code: Option<i32>,
+    },
+    /// Combo execution was cancelled.
+    Cancelled {
+        /// Combo name if available.
+        name: Option<String>,
+    },
+    /// Transcript messages collected during combo execution.
+    Transcript {
+        /// Combo name.
+        name: String,
+        /// Transcript messages for the combo reply agent.
+        messages: Vec<Message>,
+    },
+}
+
+/// Information about a discovered combo.
+#[derive(Debug, Clone)]
+pub struct ComboInfo {
+    /// Path to the combo executable.
+    pub path: String,
+    /// Combo metadata.
+    pub combo: Combo,
+}
+
+/// Context needed to create and run combo instances.
+#[derive(Clone)]
+pub struct RunComboContext {
+    /// Available combos discovered at startup.
+    pub combos: Vec<ComboInfo>,
+    /// Environment variables for combo execution.
+    pub envs: Vec<(String, String)>,
+    /// Config for combo reply agent.
+    pub config: crate::Config,
+    /// System prompt used for combo reply.
+    pub system_prompt: String,
+    /// Optional model override for combo reply.
+    pub model_override: Option<String>,
+    /// Whether thinking is enabled for combo reply.
+    pub thinking_enabled: bool,
+    /// Whether to ignore workspace combo scripts.
+    pub ignore_workspace_scripts: bool,
+}
+
+/// Output from combo execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunComboOutput {
+    /// Whether the combo completed successfully.
+    pub success: bool,
+    /// Summary of the combo execution.
+    pub summary: String,
+    /// Number of tool calls made during execution.
+    pub tool_calls: usize,
+    /// Optional error message if failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Optional thinking blocks from the summary response.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub summary_thinking: Vec<String>,
+}
+
+/// Input parameters for combo execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunComboInput {
+    /// Name of the combo to execute.
+    pub combo_name: String,
+    /// Arguments passed to the combo starter.
+    #[serde(default)]
+    pub args: Vec<String>,
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -31,9 +31,12 @@ pub use list::{DEFAULT_ENTRY_LIMIT, LIST_TOOL_NAME, ListInput, ListTool, MAX_ENT
 pub use read::{
     DEFAULT_LINE_LIMIT, DEFAULT_LINE_OFFSET, MAX_LINE_LIMIT, READ_TOOL_NAME, ReadInput, ReadTool,
 };
-pub use run_combo::{
-    ComboEvent, ComboInfo, ComboStreamKind, RUN_COMBO_TOOL_NAME, RunComboContext, RunComboInput,
-    RunComboOutput, run_combo,
+pub use run_combo::{RUN_COMBO_TOOL_NAME, run_combo};
+
+// Re-export combo types from combo module
+pub use crate::combo::{
+    ComboEvent, ComboEventStreamKind as ComboStreamKind, ComboInfo, RunComboContext, RunComboInput,
+    RunComboOutput,
 };
 pub use run_task::{
     RUN_TASK_TOOL_NAME, RunTaskContext, RunTaskInput, RunTaskOutput, RunTaskTool, SubagentEvent,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -19,7 +19,6 @@ macro_rules! err_msg {
 mod bash;
 mod list;
 mod read;
-mod run_combo;
 mod run_task;
 mod str_replace;
 
@@ -31,7 +30,9 @@ pub use list::{DEFAULT_ENTRY_LIMIT, LIST_TOOL_NAME, ListInput, ListTool, MAX_ENT
 pub use read::{
     DEFAULT_LINE_LIMIT, DEFAULT_LINE_OFFSET, MAX_LINE_LIMIT, READ_TOOL_NAME, ReadInput, ReadTool,
 };
-pub use run_combo::{RUN_COMBO_TOOL_NAME, run_combo};
+
+// Re-export run_combo from combo module
+pub use crate::combo::runner::{RUN_COMBO_TOOL_NAME, run_combo};
 
 // Re-export combo types from combo module
 pub use crate::combo::{
@@ -132,11 +133,11 @@ impl From<Value> for Final {
 }
 
 impl Final {
-    fn ok(self) -> ExecuteResult {
+    pub fn ok(self) -> ExecuteResult {
         Ok(self.into())
     }
 
-    fn err(self) -> ExecuteResult {
+    pub fn err(self) -> ExecuteResult {
         Err(self)
     }
 }

--- a/src/tools/run_combo.rs
+++ b/src/tools/run_combo.rs
@@ -1,12 +1,11 @@
 //! Combo runner - executes combo scripts within agent context.
 //!
-//! This module provides combo execution helpers and shared types.
+//! This module provides combo execution helpers.
 //! Combos are executable scripts that can perform complex operations
 //! with recorded tool calls.
 
 use std::{path::PathBuf, sync::Arc};
 
-use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -17,225 +16,19 @@ use super::{
     run_bash_chunked,
 };
 use crate::{
-    Agent, Block, ChatStreamUpdate, Combo, Config, Content, Message, OutputChunk, PromptSchema,
-    SessionEnv, Starter, StarterCommand, StarterError, StarterEvent, ThinkingConfig, ToolUse,
-    bash_unsafe_ranges, bash_unsafe_reason, discover_starters, exec::StreamKind,
-    parse_primary_command, workspace_dir,
+    Agent, Block, ChatStreamUpdate, Config, Content, Message, OutputChunk, PromptSchema,
+    SessionEnv, Starter, StarterCommand, StarterError, StarterEvent, ToolUse, bash_unsafe_ranges,
+    bash_unsafe_reason, discover_starters, exec::StreamKind, parse_primary_command, workspace_dir,
+};
+
+// Import types from combo module
+use crate::combo::{
+    ComboEvent, ComboEventStreamKind, ComboInfo, RunComboContext, RunComboInput, RunComboOutput,
 };
 
 pub const RUN_COMBO_TOOL_NAME: &str = "run_combo";
 
 type ComboEventCallback = Arc<std::sync::Mutex<Box<dyn FnMut(&ComboEvent) + Send>>>;
-
-/// Input parameters for combo execution.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RunComboInput {
-    /// Name of the combo to execute.
-    pub combo_name: String,
-    /// Arguments passed to the combo starter.
-    #[serde(default)]
-    pub args: Vec<String>,
-}
-
-/// Output from combo execution.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RunComboOutput {
-    /// Whether the combo completed successfully.
-    pub success: bool,
-    /// Summary of the combo execution.
-    pub summary: String,
-    /// Number of tool calls made during execution.
-    pub tool_calls: usize,
-    /// Optional error message if failed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-    /// Optional thinking blocks from the summary response.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub summary_thinking: Vec<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ComboStreamKind {
-    Plain,
-    Thinking,
-}
-
-/// Event emitted during combo execution.
-#[derive(Debug, Clone)]
-pub enum ComboEvent {
-    /// Combo not found.
-    NotFound {
-        /// Combo name.
-        name: String,
-    },
-    /// Combo is executing.
-    Executing {
-        /// Combo name.
-        name: String,
-        /// Command line with args.
-        command_line: String,
-    },
-    /// Regular output chunk (stdout/stderr).
-    Output {
-        /// Combo name.
-        name: String,
-        /// Output chunk.
-        chunk: OutputChunk,
-    },
-    /// Tool record started.
-    RecordStart {
-        /// Combo name.
-        name: String,
-        /// Tool use info.
-        tool_use: crate::ToolUse,
-    },
-    /// Tool record output.
-    RecordOutput {
-        /// Combo name.
-        name: String,
-        /// Tool use ID.
-        tool_use_id: String,
-        /// Output chunk.
-        chunk: OutputChunk,
-    },
-    /// Tool record ended.
-    RecordEnd {
-        /// Combo name.
-        name: String,
-        /// Tool use ID.
-        tool_use_id: String,
-        /// Whether the tool failed.
-        is_error: bool,
-        /// Tool output.
-        output: Final,
-    },
-    /// Prompt message from combo.
-    Prompt {
-        /// Combo name.
-        name: String,
-        /// Prompt text.
-        prompt: String,
-        /// Optional thinking config.
-        thinking: Option<ThinkingConfig>,
-    },
-    /// Prompt stream update for combo reply.
-    PromptStream {
-        /// Combo name.
-        name: String,
-        /// Stream index.
-        index: usize,
-        /// Stream kind.
-        kind: ComboStreamKind,
-        /// Streamed text.
-        text: String,
-    },
-    /// Reset prompt stream for combo reply.
-    PromptStreamReset {
-        /// Combo name.
-        name: String,
-    },
-    /// Reset summary stream for combo summary.
-    SummaryStreamReset {
-        /// Combo name.
-        name: String,
-    },
-    /// Summary stream update for combo summary.
-    SummaryStream {
-        /// Combo name.
-        name: String,
-        /// Stream index.
-        index: usize,
-        /// Stream kind.
-        kind: ComboStreamKind,
-        /// Streamed text.
-        text: String,
-    },
-    /// Summary completion for combo summary.
-    SummaryDone {
-        /// Combo name.
-        name: String,
-        /// Summary text.
-        summary: String,
-        /// Thinking blocks.
-        thinking: Vec<String>,
-    },
-    /// Reply tool use from prompt.
-    ReplyToolUse {
-        /// Combo name.
-        name: String,
-        /// Tool use info.
-        tool_use: ToolUse,
-        /// Thinking blocks.
-        thinking: Vec<String>,
-        /// Whether this is an offload reply (executed via bash).
-        offload: bool,
-    },
-    /// Reply tool result for offload.
-    ReplyToolResult {
-        /// Combo name.
-        name: String,
-        /// Tool use ID.
-        tool_use_id: String,
-        /// Whether the tool failed.
-        is_error: bool,
-        /// Tool output.
-        output: Final,
-    },
-    /// Reply tool error.
-    ReplyToolError {
-        /// Error message.
-        message: String,
-    },
-    /// Combo execution finished.
-    Executed {
-        /// Combo name.
-        name: String,
-        /// Starter summary.
-        starter: Starter,
-        /// Exit code.
-        exit_code: Option<i32>,
-    },
-    /// Combo execution was cancelled.
-    Cancelled {
-        /// Combo name if available.
-        name: Option<String>,
-    },
-    /// Transcript messages collected during combo execution.
-    Transcript {
-        /// Combo name.
-        name: String,
-        /// Transcript messages for the combo reply agent.
-        messages: Vec<Message>,
-    },
-}
-
-/// Information about a discovered combo.
-#[derive(Debug, Clone)]
-pub struct ComboInfo {
-    /// Path to the combo executable.
-    pub path: String,
-    /// Combo metadata.
-    pub combo: Combo,
-}
-
-/// Context needed to create and run combo instances.
-#[derive(Clone)]
-pub struct RunComboContext {
-    /// Available combos discovered at startup.
-    pub combos: Vec<ComboInfo>,
-    /// Environment variables for combo execution.
-    pub envs: Vec<(String, String)>,
-    /// Config for combo reply agent.
-    pub config: Config,
-    /// System prompt used for combo reply.
-    pub system_prompt: String,
-    /// Optional model override for combo reply.
-    pub model_override: Option<String>,
-    /// Whether thinking is enabled for combo reply.
-    pub thinking_enabled: bool,
-    /// Whether to ignore workspace combo scripts.
-    pub ignore_workspace_scripts: bool,
-}
 
 /// Execute combo logic with event callback support.
 pub async fn run_combo<F>(
@@ -620,7 +413,7 @@ async fn execute_combo(
                                                         ComboEvent::PromptStream {
                                                             name: stream_name.clone(),
                                                             index,
-                                                            kind: ComboStreamKind::Plain,
+                                                            kind: ComboEventStreamKind::Plain,
                                                             text,
                                                         },
                                                     );
@@ -635,7 +428,7 @@ async fn execute_combo(
                                                         ComboEvent::PromptStream {
                                                             name: stream_name.clone(),
                                                             index,
-                                                            kind: ComboStreamKind::Thinking,
+                                                            kind: ComboEventStreamKind::Thinking,
                                                             text,
                                                         },
                                                     );
@@ -1112,7 +905,7 @@ tool_failed: {tool_failed}\n\
                             ComboEvent::SummaryStream {
                                 name: stream_name.clone(),
                                 index,
-                                kind: ComboStreamKind::Plain,
+                                kind: ComboEventStreamKind::Plain,
                                 text,
                             },
                         ),
@@ -1121,7 +914,7 @@ tool_failed: {tool_failed}\n\
                             ComboEvent::SummaryStream {
                                 name: stream_name.clone(),
                                 index,
-                                kind: ComboStreamKind::Thinking,
+                                kind: ComboEventStreamKind::Thinking,
                                 text,
                             },
                         ),
@@ -1363,7 +1156,7 @@ async fn handle_offload_combo_reply(
                     ComboEvent::PromptStream {
                         name: stream_name.clone(),
                         index,
-                        kind: ComboStreamKind::Plain,
+                        kind: ComboEventStreamKind::Plain,
                         text,
                     },
                 );
@@ -1374,7 +1167,7 @@ async fn handle_offload_combo_reply(
                     ComboEvent::PromptStream {
                         name: stream_name.clone(),
                         index,
-                        kind: ComboStreamKind::Thinking,
+                        kind: ComboEventStreamKind::Thinking,
                         text,
                     },
                 );


### PR DESCRIPTION
## Changes

- **Extract combo types**: Move combo-related types to dedicated `combo/types.rs` module for better organization
- **Restructure combo runner**: Move `run_combo` from `tools/` to `combo/runner.rs` for clearer module boundaries
- **Add streaming line buffering**: Introduce `LineBuffer` and `BufferSet` types to manage streaming text aggregation with support for line prefixes and multi-stream handling

## Summary

This PR improves code organization by consolidating combo-related functionality into a dedicated module and enhances streaming output capabilities with line buffering support.