### PR TITLE
fix: improve exit control and subprocess handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "hyper-util",
  "indoc",
  "lazy_static",
+ "nix 0.30.1",
  "openai",
  "rmcp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ futures-core = "0.3.31"
 futures-util = "0.3.31"
 tokio-util = "0.7.16"
 clap = { version = "4.5.54", features = ["derive", "string"] }
+nix = "0.30.1"
 
 # Core dependencies for CLI and application functionality
 [dependencies]
@@ -89,6 +90,7 @@ similar = "2.7.0"
 tempfile.workspace = true
 tree-sitter.workspace = true
 tree-sitter-bash = "0.25.0"
+nix.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -236,6 +236,7 @@ impl CancellationGuard {
         let now = Instant::now();
         if let Some(last) = self.last_hit.get()
             && now.duration_since(last) <= CTRL_C_WINDOW
+            && self.last_shortcut.get() == Some(shortcut)
         {
             // fire
             self.cancel_token();
@@ -253,6 +254,7 @@ impl CancellationGuard {
         let now = Instant::now();
         if let Some(last) = self.last_hit.get()
             && now.duration_since(last) <= CTRL_C_WINDOW
+            && self.last_shortcut.get() == Some(shortcut)
         {
             self.reset();
             return true;
@@ -2247,9 +2249,10 @@ impl Component for Chat<'static> {
                 output,
             }) => {
                 let is_manual_combo = self.manual_combo_runs.contains(id);
-                self.forward_combo_result_to_session(id, output, *is_error);
+                let effective_is_error = if *is_user_cancelled { false } else { *is_error };
+                self.forward_combo_result_to_session(id, output, effective_is_error);
                 if let Some(idx) = self.messages.on_tool_event(event)
-                    && !is_error
+                    && !effective_is_error
                     && self.messages.selected_idx() == Some(idx)
                 {
                     // Move focus back to Input if tool use success.
@@ -2263,7 +2266,7 @@ impl Component for Chat<'static> {
                         .remove(id)
                         .unwrap_or_else(|| format!("combo {id}"));
                     self.ensure_manual_combo_tool_use(id, &command_line);
-                    let result = combo_run_result_from_final(id, output, *is_error);
+                    let result = combo_run_result_from_final(id, output, effective_is_error);
                     let mut summary = result.summary.trim().to_string();
                     if summary.is_empty() {
                         summary = result
@@ -2323,7 +2326,7 @@ impl Component for Chat<'static> {
                     // Collect this result
                     self.collected_tool_results.push(CollectedToolResult {
                         id: id.clone(),
-                        is_error: *is_error,
+                        is_error: effective_is_error,
                         content,
                     });
                     self.pending_tool_ids.remove(id);
@@ -2353,7 +2356,7 @@ impl Component for Chat<'static> {
                     // Single tool execution or not tracked - process immediately
                     let content = ChatContent::Multiple(vec![code_combo::Block::ToolResult {
                         tool_use_id: id.clone(),
-                        is_error: Some(*is_error),
+                        is_error: Some(effective_is_error),
                         content,
                     }]);
                     let content = self.build_user_content(content);
@@ -2429,6 +2432,10 @@ impl Component for Chat<'static> {
             }
         ) {
             if self.view == ViewMode::Chat {
+                if self.messages.has_executing_bash() {
+                    self.handle_ctrl_c();
+                    return;
+                }
                 let has_waiting_permission = self.messages.focused_waiting_permission()
                     || self.messages.focus_latest_waiting_permission();
                 if has_waiting_permission {

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1235,6 +1235,13 @@ impl Chat<'static> {
         }
     }
 
+    fn handle_force_quit_shortcut(&mut self, shortcut: ExitShortcut, action: Action) {
+        if !self.cancellation_guard.try_fire(shortcut) {
+            return;
+        }
+        global::action_tx().send(action).unwrap();
+    }
+
     fn handle_ctrl_c(&mut self) {
         self.handle_exit_shortcut(ExitShortcut::CtrlC, Action::Quit);
     }
@@ -2459,7 +2466,7 @@ impl Component for Chat<'static> {
                 ..
             }
         ) {
-            self.handle_exit_shortcut(
+            self.handle_force_quit_shortcut(
                 ExitShortcut::CtrlQ,
                 Action::CommandPalette(CommandPaletteAction::ForceQuit),
             );

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -249,6 +249,21 @@ impl CancellationGuard {
         false
     }
 
+    pub fn confirm(&mut self, shortcut: ExitShortcut) -> bool {
+        let now = Instant::now();
+        if let Some(last) = self.last_hit.get()
+            && now.duration_since(last) <= CTRL_C_WINDOW
+        {
+            self.reset();
+            return true;
+        }
+
+        *self.last_hit.write() = Some(now);
+        *self.last_shortcut.write() = Some(shortcut);
+
+        false
+    }
+
     pub fn reset(&mut self) {
         *self.last_hit.write() = None;
         *self.last_shortcut.write() = None;
@@ -2413,6 +2428,19 @@ impl Component for Chat<'static> {
                 ..
             }
         ) {
+            if self.view == ViewMode::Chat {
+                let has_waiting_permission = self.messages.focused_waiting_permission()
+                    || self.messages.focus_latest_waiting_permission();
+                if has_waiting_permission {
+                    self.update_focus(Focus::Messages);
+                    if !self.cancellation_guard.confirm(ExitShortcut::CtrlC) {
+                        return;
+                    }
+                    let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+                    self.messages.forward_key_to_selected(&esc);
+                    return;
+                }
+            }
             self.handle_ctrl_c();
             return;
         }

--- a/crates/coco-tui/src/components/chat/state.rs
+++ b/crates/coco-tui/src/components/chat/state.rs
@@ -75,6 +75,7 @@ impl CancellationGuard {
         let now = Instant::now();
         if let Some(last) = self.last_hit.get()
             && now.duration_since(last) <= CTRL_C_WINDOW
+            && self.last_shortcut.get() == Some(shortcut)
         {
             // fire
             self.cancel_token();
@@ -92,6 +93,7 @@ impl CancellationGuard {
         let now = Instant::now();
         if let Some(last) = self.last_hit.get()
             && now.duration_since(last) <= CTRL_C_WINDOW
+            && self.last_shortcut.get() == Some(shortcut)
         {
             self.reset();
             return true;

--- a/crates/coco-tui/src/components/chat/state.rs
+++ b/crates/coco-tui/src/components/chat/state.rs
@@ -88,6 +88,21 @@ impl CancellationGuard {
         false
     }
 
+    pub fn confirm(&mut self, shortcut: ExitShortcut) -> bool {
+        let now = Instant::now();
+        if let Some(last) = self.last_hit.get()
+            && now.duration_since(last) <= CTRL_C_WINDOW
+        {
+            self.reset();
+            return true;
+        }
+
+        *self.last_hit.write() = Some(now);
+        *self.last_shortcut.write() = Some(shortcut);
+
+        false
+    }
+
     pub fn reset(&mut self) {
         *self.last_hit.write() = None;
         *self.last_shortcut.write() = None;

--- a/crates/coco-tui/src/components/message.rs
+++ b/crates/coco-tui/src/components/message.rs
@@ -150,6 +150,16 @@ impl Message {
         false
     }
 
+    pub fn is_waiting_permission(&self) -> bool {
+        if let Some(tool) = self.content.as_any().downcast_ref::<Tool>() {
+            return tool.is_pending_confirmation();
+        }
+        if let Some(combo) = self.content.as_any().downcast_ref::<Combo>() {
+            return combo.is_pending_permission();
+        }
+        false
+    }
+
     pub fn thinking_mut(&mut self) -> Option<&mut Thinking> {
         self.content.as_mut_any().downcast_mut::<Thinking>()
     }

--- a/crates/coco-tui/src/components/message.rs
+++ b/crates/coco-tui/src/components/message.rs
@@ -13,6 +13,7 @@ use crate::{
     global::{self},
     session::{self, Session},
 };
+use code_combo::tools::BASH_TOOL_NAME;
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
@@ -156,6 +157,13 @@ impl Message {
         }
         if let Some(combo) = self.content.as_any().downcast_ref::<Combo>() {
             return combo.is_pending_permission();
+        }
+        false
+    }
+
+    pub fn is_executing_bash(&self) -> bool {
+        if let Some(tool) = self.content.as_any().downcast_ref::<Tool>() {
+            return tool.is_running() && tool.tool_use_name() == BASH_TOOL_NAME;
         }
         false
     }

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -481,6 +481,13 @@ impl Messages {
         message.is_waiting_permission()
     }
 
+    pub fn has_executing_bash(&self) -> bool {
+        self.messages
+            .read()
+            .iter()
+            .any(|message| message.is_executing_bash())
+    }
+
     pub fn focus_latest_waiting_permission(&mut self) -> bool {
         let idx = {
             let messages = self.messages.read();

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -470,6 +470,37 @@ impl Messages {
         }
     }
 
+    pub fn focused_waiting_permission(&self) -> bool {
+        let Some(idx) = self.focus.get() else {
+            return false;
+        };
+        let messages = self.messages.read();
+        let Some(message) = messages.get(idx) else {
+            return false;
+        };
+        message.is_waiting_permission()
+    }
+
+    pub fn focus_latest_waiting_permission(&mut self) -> bool {
+        let idx = {
+            let messages = self.messages.read();
+            let mut found = None;
+            let mut i = messages.len();
+            while i > 0 {
+                i -= 1;
+                if messages[i].is_waiting_permission() {
+                    found = Some(i);
+                    break;
+                }
+            }
+            found
+        };
+        let Some(idx) = idx else {
+            return false;
+        };
+        self.focus(idx)
+    }
+
     pub fn has_actionable(&self) -> bool {
         self.messages
             .read()

--- a/crates/coco-tui/src/components/messages/combo.rs
+++ b/crates/coco-tui/src/components/messages/combo.rs
@@ -192,6 +192,10 @@ impl Combo {
         self.state.tool_use_id == id
     }
 
+    pub fn is_pending_permission(&self) -> bool {
+        self.requiring_permission()
+    }
+
     fn requiring_permission(&self) -> bool {
         matches!(self.state.starter_state, StarterState::AwaitingPermission)
     }

--- a/crates/coco-tui/src/components/messages/tool.rs
+++ b/crates/coco-tui/src/components/messages/tool.rs
@@ -123,8 +123,16 @@ impl Tool {
         &self.inner.tool_use.id
     }
 
+    pub fn tool_use_name(&self) -> &str {
+        &self.inner.tool_use.name
+    }
+
     pub fn is_pending_confirmation(&self) -> bool {
         matches!(self.inner.state, ToolState::PendingConfirmation)
+    }
+
+    pub fn is_running(&self) -> bool {
+        matches!(self.inner.state, ToolState::Initing | ToolState::Executing)
     }
 
     pub fn update_state(&mut self, new_state: ToolState) {
@@ -261,13 +269,21 @@ impl Component for Tool {
                     handle_component_event!(self, event);
                 }
             }
-            Event::Answer(AnswerEvent::ToolResult { id, is_error, .. }) => {
+            Event::Answer(AnswerEvent::ToolResult {
+                id,
+                is_error,
+                is_user_cancelled,
+                ..
+            }) => {
                 if self.tool_use_id() == id {
-                    self.update_state(if *is_error {
+                    let state = if *is_user_cancelled {
+                        ToolState::Cancelled
+                    } else if *is_error {
                         ToolState::Failed
                     } else {
                         ToolState::Completed
-                    });
+                    };
+                    self.update_state(state);
                     handle_component_event!(self, event);
                 }
             }

--- a/crates/coco-tui/src/components/messages/tool.rs
+++ b/crates/coco-tui/src/components/messages/tool.rs
@@ -123,6 +123,10 @@ impl Tool {
         &self.inner.tool_use.id
     }
 
+    pub fn is_pending_confirmation(&self) -> bool {
+        matches!(self.inner.state, ToolState::PendingConfirmation)
+    }
+
     pub fn update_state(&mut self, new_state: ToolState) {
         let state = &self.inner.state;
         if state == &new_state {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -12,11 +12,17 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
-    process::Command,
+    process::{Child, Command},
     sync::{mpsc, oneshot},
     task::JoinHandle,
 };
 use tracing::warn;
+
+#[cfg(unix)]
+use nix::{
+    sys::signal::{Signal, killpg},
+    unistd::{Pid, setpgid},
+};
 
 const HARD_MAX_BUFFERED_BYTES: usize = 2 * 1024 * 1024;
 
@@ -106,6 +112,20 @@ impl RunningProcess {
     }
 }
 
+#[cfg(unix)]
+fn kill_process_group(child: &mut Child) {
+    let Some(pid) = child.id() else {
+        let _ = child.start_kill();
+        return;
+    };
+    let _ = killpg(Pid::from_raw(pid as i32), Signal::SIGKILL);
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(child: &mut Child) {
+    let _ = child.start_kill();
+}
+
 #[derive(Debug)]
 pub struct ExecCommand {
     argv: Vec<String>,
@@ -177,6 +197,13 @@ impl ExecCommand {
         if self.disable_tty {
             cmd.env_remove("GPG_TTY");
             cmd.env_remove("SSH_TTY");
+        }
+        #[cfg(unix)]
+        unsafe {
+            cmd.pre_exec(|| {
+                setpgid(Pid::from_raw(0), Pid::from_raw(0)).map_err(io::Error::other)?;
+                Ok(())
+            });
         }
 
         let mut child = cmd.spawn()?;
@@ -260,7 +287,7 @@ impl ExecCommand {
                 tokio::select! {
                     _ = &mut kill_rx, if !kill_seen => {
                         kill_seen = true;
-                        let _ = child.start_kill();
+                        kill_process_group(&mut child);
                     }
                     line = stdout_reader.read_until(b'\n', &mut stdout_buf), if !stdout_closed => {
                         match line {


### PR DESCRIPTION
This PR improves TUI exit control and subprocess termination:

**Fixes**
- Make Ctrl-Q force quit respect cancellation guard (consistent with other exit shortcuts)
- Properly terminate bash subprocesses on Ctrl-C using process groups and killpg
- Handle Ctrl-C when waiting for permission confirmation (focus first pending message)
- Ensure double Ctrl-C uses consistent shortcut key

**Changes**
- Create process groups for bash commands to ensure all child processes are terminated on cancellation
- Separate user cancellation from error states
- Focus pending permission messages instead of immediate exit on Ctrl-C

These changes ensure more reliable cancellation behavior and complete cleanup of subprocess resources.