### PR TITLE
feat: add git fetch to safe commands

### DIFF
--- a/src/agent/bash_executor.rs
+++ b/src/agent/bash_executor.rs
@@ -2111,4 +2111,15 @@ mod tests {
         assert_safe_cmd_with_rules!("agent_cmd", &rules);
         assert_safe_cmd_with_rules!("ls", &rules); // builtin should still exist
     }
+
+    #[test]
+    fn git_fetch_is_safe_command() {
+        // Test that git fetch is recognized as a safe command
+        assert_safe_cmd!("git fetch");
+        assert_safe_cmd!("git fetch origin");
+        assert_safe_cmd!("git fetch origin main");
+        assert_safe_cmd!("git fetch --all");
+        assert_safe_cmd!("git fetch --prune");
+        assert_safe_cmd!("git fetch --multiple origin upstream");
+    }
 }

--- a/src/agent/safe_commands.toml
+++ b/src/agent/safe_commands.toml
@@ -208,6 +208,10 @@ command = ["git", "commit"]
 flags = [{ name = "--dry-run", arg = "none" }]
 
 [[commands]]
+command = ["git", "fetch"]
+allow_any = true
+
+[[commands]]
 command = ["cargo", "check"]
 allow_any = true
 


### PR DESCRIPTION
Add git fetch to safe commands list with allow_any flag since it's a read-only operation.

**Changes:**
- Add `git fetch` to `safe_commands.toml` with `allow_any = true`
- Add comprehensive tests for various git fetch patterns (with/without remote, branch, flags)

This allows agents to fetch updates from remotes without requiring approval.