### PR TITLE
fix: disable TTY for subprocess execution

### DIFF
--- a/src/cmd/record.rs
+++ b/src/cmd/record.rs
@@ -53,6 +53,7 @@ pub async fn handle_record(wrap_result: bool, command: Vec<String>) -> Result<()
     let started_at = OffsetDateTime::now_utc().unix_timestamp();
     let mut proc = ExecCommand::from_argv(exec_command.clone())
         .stdin(Stdio::inherit())
+        .disable_tty()
         .spawn_chunked(ChunkConfig {
             interval: Duration::from_millis(500),
         })

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -153,6 +153,7 @@ where
     envs.extend(extra_envs.iter().cloned());
     let mut proc = ExecCommand::from_argv(argv)
         .remove_env_prefix("COCO_")
+        .disable_tty()
         .envs(envs)
         .spawn_chunked(ChunkConfig {
             interval: Duration::ZERO,


### PR DESCRIPTION
## Summary
Disable TTY for subprocess execution to avoid TTY-related issues.

## Changes
- Add `.disable_tty()` call in `record` command
- Add `.disable_tty()` call in `bash` tool

Both locations spawn subprocesses via `ExecCommand` and need TTY disabled to ensure proper interaction behavior.