### PR TITLE
feat: auto focus next pending user action after tool approval/cancellation

### DIFF
--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -2079,6 +2079,13 @@ impl Chat<'static> {
         false
     }
 
+    fn focus_next_pending_user_action_or_input(&mut self) {
+        if !self.focus_next_pending_user_action() {
+            self.update_focus(Focus::Input);
+            self.messages.blur();
+        }
+    }
+
     fn try_submit_combo_feedback(&mut self, feedback: &str) -> bool {
         let pending_feedback_combo_ids = self
             .pending_user_actions
@@ -2671,11 +2678,8 @@ impl Component for Chat<'static> {
                 if let Some(idx) = self.messages.on_tool_event(event)
                     && !effective_is_error
                     && self.messages.selected_idx() == Some(idx)
-                    && !self.focus_next_pending_user_action()
                 {
-                    // Move focus back to Input if no more pending actions.
-                    self.update_focus(Focus::Input);
-                    self.messages.blur();
+                    self.focus_next_pending_user_action_or_input();
                 }
 
                 if is_manual_combo {
@@ -3116,13 +3120,13 @@ impl Component for Chat<'static> {
                     self.remove_pending_tool_use_action(&tool_use.id);
                     self.agent.grant_once(&tool_use.id, &tool_use.name);
                     self.spawn_tool_use(tool_use);
-                    self.focus_next_pending_user_action();
+                    self.focus_next_pending_user_action_or_input();
                 }
                 ToolAction::GrantSession(tool_use) => {
                     self.remove_pending_tool_use_action(&tool_use.id);
                     self.agent.grant_session(tool_use);
                     self.spawn_tool_use(tool_use);
-                    self.focus_next_pending_user_action();
+                    self.focus_next_pending_user_action_or_input();
                 }
                 ToolAction::Cancel(tool_use) => {
                     let pending_combo_id =
@@ -4211,6 +4215,56 @@ mod tests {
         assert!(chat.focus_next_pending_user_action());
         assert_eq!(chat.state.focus, Focus::Messages);
         assert_eq!(chat.messages.selected_idx(), Some(idx));
+    }
+
+    #[test]
+    fn focus_next_pending_user_action_or_input_returns_to_input_when_no_next_action() {
+        let mut chat = Chat::new(Config::default());
+        let tool = mock_tool_use("tool_a");
+        chat.messages
+            .push(Message::bot(Tool::new(tool.clone()).into()));
+
+        let event = Event::Ask(AskEvent::ToolUsePermission(tool.id.clone()));
+        let idx = chat
+            .messages
+            .on_tool_event(&event)
+            .expect("tool should be found");
+        chat.pending_user_actions.clear();
+        chat.update_focus(Focus::Messages);
+        assert!(chat.messages.focus(idx));
+
+        chat.focus_next_pending_user_action_or_input();
+        assert_eq!(chat.state.focus, Focus::Input);
+        assert_eq!(chat.messages.selected_idx(), None);
+    }
+
+    #[test]
+    fn focus_next_pending_user_action_or_input_keeps_messages_when_next_action_exists() {
+        let mut chat = Chat::new(Config::default());
+        let tool_a = mock_tool_use("tool_a");
+        let tool_b = mock_tool_use("tool_b");
+        chat.messages
+            .push(Message::bot(Tool::new(tool_a.clone()).into()));
+        chat.messages
+            .push(Message::bot(Tool::new(tool_b.clone()).into()));
+
+        let event_a = Event::Ask(AskEvent::ToolUsePermission(tool_a.id.clone()));
+        let event_b = Event::Ask(AskEvent::ToolUsePermission(tool_b.id.clone()));
+        let idx_a = chat
+            .messages
+            .on_tool_event(&event_a)
+            .expect("first tool should be found");
+        let idx_b = chat
+            .messages
+            .on_tool_event(&event_b)
+            .expect("second tool should be found");
+        chat.pending_user_actions.clear();
+        chat.update_focus(Focus::Messages);
+        assert!(chat.messages.focus(idx_a));
+
+        chat.focus_next_pending_user_action_or_input();
+        assert_eq!(chat.state.focus, Focus::Messages);
+        assert_eq!(chat.messages.selected_idx(), Some(idx_b));
     }
 
     #[test]

--- a/crates/coco-tui/src/components/chat.rs
+++ b/crates/coco-tui/src/components/chat.rs
@@ -1751,6 +1751,7 @@ impl Chat<'static> {
             )
             .unwrap();
         } else {
+            self.remove_pending_tool_use_action(&id);
             // Move focus back to Input when the tool interaction ends.
             if let Some(idx) = self.messages.locate_tool_message(&id)
                 && self.messages.selected_idx() == Some(idx)
@@ -1775,6 +1776,7 @@ impl Chat<'static> {
                 });
             // Set chat status to Ready after all hunks rejected
             self.set_ready();
+            self.focus_next_pending_user_action();
         }
     }
 
@@ -2069,6 +2071,10 @@ impl Chat<'static> {
                     return true;
                 }
             }
+        }
+        if self.messages.focus_next_waiting_permission() {
+            self.update_focus(Focus::Messages);
+            return true;
         }
         false
     }
@@ -2611,6 +2617,7 @@ impl Component for Chat<'static> {
                     global::trigger_schedule_session_save();
                     return;
                 }
+                self.add_pending_tool_use_action(id.clone(), None);
                 if let Some(idx) = self.messages.on_tool_event(event) {
                     // Move focus to tool use message when permission is required
                     self.update_focus(Focus::Messages);
@@ -2620,7 +2627,12 @@ impl Component for Chat<'static> {
                 // Trigger session save after ask event
                 global::trigger_schedule_session_save();
             }
-            Event::Ask(AskEvent::TextEdit { auto_accept, .. }) => {
+            Event::Ask(AskEvent::TextEdit {
+                id, auto_accept, ..
+            }) => {
+                if !*auto_accept {
+                    self.add_pending_tool_use_action(id.clone(), None);
+                }
                 if let Some(idx) = self.messages.on_tool_event(event)
                     && !*auto_accept
                 {
@@ -2655,11 +2667,13 @@ impl Component for Chat<'static> {
                     global::trigger_schedule_session_save();
                     return;
                 }
+                self.remove_pending_tool_use_action(id);
                 if let Some(idx) = self.messages.on_tool_event(event)
                     && !effective_is_error
                     && self.messages.selected_idx() == Some(idx)
+                    && !self.focus_next_pending_user_action()
                 {
-                    // Move focus back to Input if tool use success.
+                    // Move focus back to Input if no more pending actions.
                     self.update_focus(Focus::Input);
                     self.messages.blur();
                 }
@@ -4140,6 +4154,64 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    fn mock_tool_use(id: &str) -> ToolUse {
+        ToolUse {
+            id: id.to_string(),
+            name: "mock_tool".to_string(),
+            input: json!({}),
+        }
+    }
+
+    #[test]
+    fn focus_next_pending_user_action_falls_back_to_waiting_permission_messages() {
+        let mut chat = Chat::new(Config::default());
+        let tool_a = mock_tool_use("tool_a");
+        let tool_b = mock_tool_use("tool_b");
+        chat.messages
+            .push(Message::bot(Tool::new(tool_a.clone()).into()));
+        chat.messages
+            .push(Message::bot(Tool::new(tool_b.clone()).into()));
+
+        let event_a = Event::Ask(AskEvent::ToolUsePermission(tool_a.id.clone()));
+        let event_b = Event::Ask(AskEvent::ToolUsePermission(tool_b.id.clone()));
+        let idx_a = chat
+            .messages
+            .on_tool_event(&event_a)
+            .expect("first tool should be found");
+        let idx_b = chat
+            .messages
+            .on_tool_event(&event_b)
+            .expect("second tool should be found");
+        chat.pending_user_actions.clear();
+        chat.update_focus(Focus::Messages);
+        assert!(chat.messages.focus(idx_a));
+
+        assert!(chat.focus_next_pending_user_action());
+        assert_eq!(chat.state.focus, Focus::Messages);
+        assert_eq!(chat.messages.selected_idx(), Some(idx_b));
+    }
+
+    #[test]
+    fn focus_next_pending_user_action_selects_first_waiting_permission_without_message_focus() {
+        let mut chat = Chat::new(Config::default());
+        let tool = mock_tool_use("tool_a");
+        chat.messages
+            .push(Message::bot(Tool::new(tool.clone()).into()));
+
+        let event = Event::Ask(AskEvent::ToolUsePermission(tool.id.clone()));
+        let idx = chat
+            .messages
+            .on_tool_event(&event)
+            .expect("tool should be found");
+        chat.pending_user_actions.clear();
+        chat.update_focus(Focus::Input);
+        chat.messages.blur();
+
+        assert!(chat.focus_next_pending_user_action());
+        assert_eq!(chat.state.focus, Focus::Messages);
+        assert_eq!(chat.messages.selected_idx(), Some(idx));
+    }
 
     #[test]
     fn truncate_with_suffix_appends_marker() {

--- a/crates/coco-tui/src/components/messages.rs
+++ b/crates/coco-tui/src/components/messages.rs
@@ -512,6 +512,33 @@ impl Messages {
         self.focus(idx)
     }
 
+    pub fn focus_next_waiting_permission(&mut self) -> bool {
+        let current = self.focus.get();
+        let start = current.map_or(0, |idx| idx.saturating_add(1));
+        let idx = {
+            let messages = self.messages.read();
+            messages
+                .iter()
+                .enumerate()
+                .skip(start)
+                .find(|(_, message)| message.is_waiting_permission())
+                .map(|(idx, _)| idx)
+                .or_else(|| {
+                    let wrap_end = current.unwrap_or(0);
+                    messages
+                        .iter()
+                        .enumerate()
+                        .take(wrap_end)
+                        .find(|(_, message)| message.is_waiting_permission())
+                        .map(|(idx, _)| idx)
+                })
+        };
+        let Some(idx) = idx else {
+            return false;
+        };
+        self.focus(idx)
+    }
+
     pub fn has_actionable(&self) -> bool {
         self.messages
             .read()

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -453,7 +453,7 @@ mod tests {
         guard.clear_env();
 
         let input = Input::Starter(json!({
-            "command": "printf \"%s\" \"$COCO_SESSION_SOCK\"",
+            "command": "printf \"%s\\n\" \"$COCO_SESSION_SOCK\"",
             "timeout": 60_000,
         }));
         let extra_envs = vec![(


### PR DESCRIPTION
## Summary
Automatically focus the next pending user action after tool approval/cancellation, improving workflow efficiency.

## Details
- Extract `focus_next_pending_user_action_or_input` helper for unified focus handling
- Auto-focus next pending action after tool operations; fall back to input if none
- Fix pending action tracking (add/remove `tool_use_action`)
- Add `focus_next_waiting_permission` in messages module to search next permission request
- Add 4 test cases for focus behavior verification